### PR TITLE
fix: config miss

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -108,11 +108,6 @@ func setupConfiguration(baseDir string) *v1alpha1.Config {
 	}
 	viper.AddConfigPath(pwd)
 
-	// handle deprecated ksonnet spec
-	for old, new := range deprecated {
-		viper.RegisterAlias(new, old)
-	}
-
 	// read it
 	if err := viper.ReadInConfig(); err != nil {
 		// just run fine without config. Provider features won't work (apply, show, diff)
@@ -122,7 +117,16 @@ func setupConfiguration(baseDir string) *v1alpha1.Config {
 
 		log.Fatalln(err)
 	}
-	checkDeprecated()
+
+	// handle deprecated ksonnet spec
+	for old, new := range deprecated {
+		if viper.IsSet(old) && !viper.IsSet(new) {
+			viper.Set(new, viper.Get(old))
+		}
+	}
+
+	// disabled for now
+	// checkDeprecated()
 
 	var config v1alpha1.Config
 	if err := viper.Unmarshal(&config); err != nil {


### PR DESCRIPTION
Due to some quirks of cobra, the new config format didn't actually work.
This fixes that.

Furthermore mutes the warnings about the deprecated config
Fixes #14