### PR TITLE
feat(cli): limit output to specific objects only

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -19,7 +19,7 @@ type workflowFlagVars struct {
 
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
-	fs.StringSliceVarP(&v.targets, "target", "t", nil, "only use the specified objects")
+	fs.StringSliceVarP(&v.targets, "target", "t", nil, "only use the specified objects (Format: <type>/<name>)")
 	return &v
 }
 


### PR DESCRIPTION
Use `-t=objectspec` to limit to an object.

Examples: 
```
-t=namespace/name
-t=deployment/asdf
```