### PR TITLE
fix(cli): diff UX enhancements

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"path/filepath"
 
@@ -27,7 +26,7 @@ func evalCmd() *cobra.Command {
 		if err != nil {
 			log.Fatalln("evaluating:", err)
 		}
-		fmt.Print(json)
+		pageln(json)
 	}
 
 	return cmd

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/posener/complete"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/grafana/tanka/pkg/cmp"
 	"github.com/grafana/tanka/pkg/config/v1alpha1"
@@ -18,9 +20,16 @@ import (
 // To be overwritten at build time
 var Version = "dev"
 
+// primary handlers
 var (
 	config = &v1alpha1.Config{}
 	kube   *kubernetes.Kubernetes
+)
+
+// describing variables
+var (
+	verbose     = false
+	interactive = terminal.IsTerminal(int(os.Stdout.Fd()))
 )
 
 // list of deprecated config keys and their alternatives
@@ -53,7 +62,7 @@ func main() {
 
 		},
 	}
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "")
 
 	// Subcommands
 	cobra.EnableCommandSorting = false

--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/alecthomas/chroma/quick"
+)
+
+// pageln invokes the systems pager with the supplied data
+// falls back to fmt.Println() when paging fails or non-interactive
+func pageln(i ...interface{}) {
+	// no paging in non-interactive mode
+	if !interactive {
+		fmt.Println(i...)
+		return
+	}
+
+	// get system pager, fallback to `more`
+	pager := os.Getenv("PAGER")
+	if pager == "" {
+		pager = "more"
+	}
+
+	// invoke pager
+	cmd := exec.Command(pager)
+	cmd.Stdin = strings.NewReader(fmt.Sprintln(i...))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// if this fails, just print it
+	if err := cmd.Run(); err != nil {
+		fmt.Println(i...)
+	}
+}
+
+func highlight(lang, s string) string {
+	var buf bytes.Buffer
+	if err := quick.Highlight(&buf, s, lang, "terminal", "vim"); err != nil {
+		log.Fatalln("Highlighting:", err)
+	}
+	return buf.String()
+}

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -5,10 +5,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/grafana/tanka/pkg/cmp"
 	"github.com/posener/complete"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/grafana/tanka/pkg/cmp"
+	"github.com/grafana/tanka/pkg/kubernetes"
 )
 
 type workflowFlagVars struct {
@@ -40,6 +42,10 @@ func applyCmd() *cobra.Command {
 		desired, err := kube.Reconcile(raw, vars.targets...)
 		if err != nil {
 			log.Fatalln("Reconciling:", err)
+		}
+
+		if !diff(desired, false) {
+			log.Println("Warning: There are no differences. Your apply may not do anything at all.")
 		}
 
 		if err := kube.Apply(desired); err != nil {
@@ -78,28 +84,41 @@ func diffCmd() *cobra.Command {
 			log.Fatalln("Reconciling:", err)
 		}
 
-		changes, err := kube.Diff(desired)
-		if err != nil {
-			log.Fatalln("Diffing:", err)
-		}
-
-		if changes == nil {
-			return
-		}
-
-		if interactive {
-			pageln(highlight("diff", *changes))
-		} else {
-			fmt.Println(*changes)
-		}
-
-		if changes != nil {
+		if diff(desired, interactive) {
 			os.Exit(16)
 		}
+		log.Println("No differences.")
 	}
 
 	cmd.Flags().String("diff-strategy", "", "force the diff-strategy to use. Automatically chosen if not set.")
 	return cmd
+}
+
+// computes the diff, prints to screen.
+// set `pager` to false to disable the pager.
+// When non-interactive, no paging happens anyways.
+func diff(state []kubernetes.Manifest, pager bool) (changed bool) {
+	changes, err := kube.Diff(state)
+	if err != nil {
+		log.Fatalln("Diffing:", err)
+	}
+
+	if changes == nil {
+		return false
+	}
+
+	if interactive {
+		h := highlight("diff", *changes)
+		if pager {
+			pageln(h)
+		} else {
+			fmt.Println(h)
+		}
+	} else {
+		fmt.Println(*changes)
+	}
+
+	return true
 }
 
 func showCmd() *cobra.Command {

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -3,14 +3,11 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 
-	"github.com/alecthomas/chroma/quick"
 	"github.com/grafana/tanka/pkg/cmp"
 	"github.com/posener/complete"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 type workflowFlagVars struct {
@@ -85,14 +82,13 @@ func diffCmd() *cobra.Command {
 			log.Fatalln("Diffing:", err)
 		}
 
-		if terminal.IsTerminal(int(os.Stdout.Fd())) {
-			if err := quick.Highlight(os.Stdout, changes, "diff", "terminal", "vim"); err != nil {
-				log.Fatalln("Highlighting:", err)
-			}
-		} else {
-			fmt.Println(changes)
+		if interactive {
+			pageln(highlight("diff", changes))
+			return
 		}
+		fmt.Println(changes)
 	}
+
 	cmd.Flags().String("diff-strategy", "", "force the diff-strategy to use. Automatically chosen if not set.")
 	return cmd
 }
@@ -122,7 +118,8 @@ func showCmd() *cobra.Command {
 		if err != nil {
 			log.Fatalln("Pretty printing state:", err)
 		}
-		fmt.Println(pretty)
+
+		pageln(pretty)
 	}
 	return cmd
 }

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/grafana/tanka/pkg/cmp"
 	"github.com/posener/complete"
@@ -82,11 +83,19 @@ func diffCmd() *cobra.Command {
 			log.Fatalln("Diffing:", err)
 		}
 
-		if interactive {
-			pageln(highlight("diff", changes))
+		if changes == nil {
 			return
 		}
-		fmt.Println(changes)
+
+		if interactive {
+			pageln(highlight("diff", *changes))
+		} else {
+			fmt.Println(*changes)
+		}
+
+		if changes != nil {
+			os.Exit(16)
+		}
 	}
 
 	cmd.Flags().String("diff-strategy", "", "force the diff-strategy to use. Automatically chosen if not set.")

--- a/pkg/kubernetes/kubectl.go
+++ b/pkg/kubernetes/kubectl.go
@@ -172,9 +172,9 @@ Please type 'yes' to perform: `,
 
 // Diff takes a desired state as yaml and returns the differences
 // to the system in common diff format
-func (k Kubectl) Diff(yaml string) (string, error) {
+func (k Kubectl) Diff(yaml string) (*string, error) {
 	if err := k.setupContext(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	argv := []string{"diff",
@@ -187,7 +187,7 @@ func (k Kubectl) Diff(yaml string) (string, error) {
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	go func() {
@@ -199,11 +199,13 @@ func (k Kubectl) Diff(yaml string) (string, error) {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			// kubectl uses this to tell us that there is a diff
 			if exitError.ExitCode() == 1 {
-				return raw.String(), nil
+				s := raw.String()
+				return &s, nil
 			}
 		}
-		return "", err
+		return nil, err
 	}
 
-	return raw.String(), nil
+	// no diff -> nil
+	return nil, nil
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -23,7 +23,7 @@ type Kubernetes struct {
 	differs map[string]Differ // List of diff strategies
 }
 
-type Differ func(yaml string) (string, error)
+type Differ func(yaml string) (*string, error)
 
 // New creates a new Kubernetes
 func New(s v1alpha1.Spec) *Kubernetes {
@@ -94,10 +94,10 @@ func (k *Kubernetes) Apply(state []Manifest) error {
 }
 
 // Diff takes the desired state and returns the differences from the cluster
-func (k *Kubernetes) Diff(state []Manifest) (string, error) {
+func (k *Kubernetes) Diff(state []Manifest) (*string, error) {
 	yaml, err := k.Fmt(state)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if k.Spec.DiffStrategy == "" {


### PR DESCRIPTION
improves the UX of especially the `diff` subcommand:

- uses systems pager for long outputs (`$PAGER`, fallback is `more`). Fixes #20 
- exits with `exit-code 16` in case of differences. Fixes #27 
- shows `diff` before `apply` (without pagination). Fixes #17 