### PR TITLE
feat(cli): autoApprove, forceApply

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -33,6 +33,8 @@ func applyCmd() *cobra.Command {
 		},
 	}
 	vars := workflowFlags(cmd.Flags())
+	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
+	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		raw, err := evalDict(args[0])
 		if err != nil {
@@ -48,7 +50,10 @@ func applyCmd() *cobra.Command {
 			log.Println("Warning: There are no differences. Your apply may not do anything at all.")
 		}
 
-		if err := kube.Apply(desired); err != nil {
+		if err := kube.Apply(desired, kubernetes.ApplyOpts{
+			Force:       *force,
+			AutoApprove: *autoApprove,
+		}); err != nil {
 			log.Fatalln("Applying:", err)
 		}
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -105,12 +105,12 @@ func (k *Kubernetes) Fmt(state []Manifest) (string, error) {
 }
 
 // Apply receives a state object generated using `Reconcile()` and may apply it to the target system
-func (k *Kubernetes) Apply(state []Manifest) error {
+func (k *Kubernetes) Apply(state []Manifest, opts ApplyOpts) error {
 	yaml, err := k.Fmt(state)
 	if err != nil {
 		return err
 	}
-	return k.client.Apply(yaml, k.Spec.Namespace)
+	return k.client.Apply(yaml, k.Spec.Namespace, opts)
 }
 
 // Diff takes the desired state and returns the differences from the cluster


### PR DESCRIPTION
`--dangerous-auto-approve`: Skip interactive change approval before apply, useful for
automation

`--force`: Force kubectl to apply, ignoring resource ownership

Fixes #32 