### PR TITLE
Nil pointer deference in subset diff.

### DIFF
--- a/pkg/kubernetes/subsetdiff.go
+++ b/pkg/kubernetes/subsetdiff.go
@@ -58,7 +58,7 @@ func (k Kubectl) SubsetDiff(y string) (*string, error) {
 		return nil, errors.Wrap(lastErr, "calculating subset")
 	}
 
-	var diffs *string
+	var diffs string
 	for _, d := range docs {
 		diffStr, err := diff(d.name, d.live, d.merged)
 		if err != nil {
@@ -67,13 +67,10 @@ func (k Kubectl) SubsetDiff(y string) (*string, error) {
 		if diffStr != "" {
 			diffStr += "\n"
 		}
-		if diffs == nil {
-			*diffs = ""
-		}
-		*diffs += diffStr
+		diffs += diffStr
 	}
 
-	return diffs, nil
+	return &diffs, nil
 }
 
 func subsetDiff(k Kubectl, rawShould map[interface{}]interface{}, r chan difference, e chan error) {


### PR DESCRIPTION
```
$ tk diff environments/cortex/eu-west2.dev/
Warning: `namespace` is deprecated, use `spec.namespace` instead.
Warning: `server` is deprecated, use `spec.apiServer` instead.
Warning: `team` is deprecated, use `metadata.labels.team` instead.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x148b9d6]

goroutine 1 [running]:
github.com/grafana/tanka/pkg/kubernetes.Kubectl.SubsetDiff(0x0, 0x0, 0xc0000f6240, 0x15, 0xc00062c000, 0x918f, 0x9, 0xc0002e5e18, 0x8)
    /Users/twilkie/Documents/src/github.com/sh0rez/tanka/pkg/kubernetes/subsetdiff.go:71 +0x7a6
github.com/grafana/tanka/pkg/kubernetes.(*Kubernetes).Diff(0xc0000b3380, 0xc000523000, 0x20, 0x20, 0x0, 0x0, 0x20)
    /Users/twilkie/Documents/src/github.com/sh0rez/tanka/pkg/kubernetes/kubernetes.go:132 +0x1af
main.diff(0xc000523000, 0x20, 0x20, 0x1, 0x0)
    /Users/twilkie/Documents/src/github.com/sh0rez/tanka/cmd/tk/workflow.go:101 +0x66
main.diffCmd.func1(0xc0000eec80, 0xc0004e62f0, 0x1, 0x1)
    /Users/twilkie/Documents/src/github.com/sh0rez/tanka/cmd/tk/workflow.go:87 +0x1f8
github.com/spf13/cobra.(*Command).execute(0xc0000eec80, 0xc0000b4020, 0x1, 0x1, 0xc0000eec80, 0xc0000b4020)
    /Users/twilkie/Documents/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000ee000, 0xc0004e62c0, 0xc00026d8c0, 0x0)
    /Users/twilkie/Documents/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fc
github.com/spf13/cobra.(*Command).Execute(...)
    /Users/twilkie/Documents/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
```

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>