### PR TITLE
Improve PAGER usage.

### DIFF
--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -22,12 +22,17 @@ func pageln(i ...interface{}) {
 
 	// get system pager, fallback to `more`
 	pager := os.Getenv("PAGER")
+	var args []string
 	if pager == "" {
-		pager = "more"
+		// --raw-control-chars	Honors colors from diff.
+		// --quit-if-one-screen Closer to the git experience.
+		// --no-init 			Don't clear the screen when exiting.
+		pager = "less"
+		args = []string{"--raw-control-chars", "--quit-if-one-screen", "--no-init"}
 	}
 
 	// invoke pager
-	cmd := exec.Command(pager)
+	cmd := exec.Command(pager, args...)
 	cmd.Stdin = strings.NewReader(fmt.Sprintln(i...))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -24,9 +24,9 @@ func pageln(i ...interface{}) {
 	pager := os.Getenv("PAGER")
 	var args []string
 	if pager == "" {
-		// --raw-control-chars	Honors colors from diff.
+		// --raw-control-chars  Honors colors from diff.
 		// --quit-if-one-screen Closer to the git experience.
-		// --no-init 			Don't clear the screen when exiting.
+		// --no-init            Don't clear the screen when exiting.
 		pager = "less"
 		args = []string{"--raw-control-chars", "--quit-if-one-screen", "--no-init"}
 	}


### PR DESCRIPTION
- Don't paginate if content fits on one screen.
- Honor colors from less.

Stops output looking like:

```
ESC[1mESC[34mESC[40mdiff -u -N /var/folders/g5/3pb5_td927l61zm9xfmmtcp80000gn/T/diff017840273/LIVE-v1.ConfigMap.dev.consul /var/folders/g5/3pb5_td927l61zm9xfmmtcp80000gn/T/diff017840273/MERGED-v1.ConfigMap.dev.consul
ESC[0mESC[91mESC[40m--- /var/folders/g5/3pb5_td927l61zm9xfmmtcp80000gn/T/diff017840273/LIVE-v1.ConfigMap.dev.consul     2019-08-12 13:43:01.000000000 +0100
ESC[0mESC[92mESC[40m+++ /var/folders/g5/3pb5_td927l61zm9xfmmtcp80000gn/T/diff017840273/MERGED-v1.ConfigMap.dev.consul   2019-08-12 13:43:01.000000000 +0100
ESC[0mESC[1mESC[35mESC[40m@@ -1,7 +1,7 @@
ESC[0m apiVersion: v1
 data:
```

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>