### PR TITLE
fix(cli): command executed twice on error

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -104,7 +104,7 @@ func main() {
 
 	// Run!
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatalln("Ouch:", rootCmd.Execute())
+		log.Fatalln("Ouch:", err)
 	}
 }
 


### PR DESCRIPTION
Running `tk show` with no arguments would print the help text twice, like so:

```
Error: accepts 1 arg(s), received 0
Usage:
  tk show [directory] [flags]

Flags:
  -h, --help             help for show
  -t, --target strings   only use the specified objects (Format: <type>/<name>)

Global Flags:
  -v, --verbose

Error: accepts 1 arg(s), received 0
Usage:
  tk show [directory] [flags]

Flags:
  -h, --help             help for show
  -t, --target strings   only use the specified objects (Format: <type>/<name>)

Global Flags:
  -v, --verbose

Ouch: accepts 1 arg(s), received 0
```

This PR fixes the repeated output. 