### PR TITLE
Add --check-files parameter

### DIFF
--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -50,18 +50,21 @@ func jpathCmd() *cobra.Command {
 }
 
 func importsCmd() *cobra.Command {
+	var modFiles []string
+
 	cmd := &cobra.Command{
 		Use:   "imports [file]",
 		Short: "list all transitive imports of a file",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var modFiles []string
+			var newModFiles []string
 			if cmd.Flag("check").Changed {
 				var err error
-				modFiles, err = gitChangedFiles(cmd.Flag("check").Value.String())
+				newModFiles, err = gitChangedFiles(cmd.Flag("check").Value.String())
 				if err != nil {
 					log.Fatalln("invoking git:", err)
 				}
+				modFiles = append(modFiles, newModFiles...)
 			}
 
 			f, err := filepath.Abs(args[0])
@@ -108,6 +111,7 @@ func importsCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("check", "c", "", "git commit hash to check against")
+	cmd.Flags().StringSliceVarP(&modFiles, "check-files", "f", []string{}, "files to check for inclusion in imports")
 
 	return cmd
 }


### PR DESCRIPTION
This adds a `--check-files` argument along the lines of the `--check` arg.

The `--check` arg uses Git to look at the diffs caused by a specific commit. However, we need to compare all the changes caused by a branch attached to a PR.

I could have updated this to invoke Git to get that list of files, however that would get clunky, and very use-case specific. It made more sense to just pass in a comma-separated list of files to check for inclusion.

I would also recommend removing the `--check` arg in preference to this one (and possibly renaming `--check-files` to `--check`), as it only serves a small range of functionality.
