### PR TITLE
fix(kubernetes): do not fail on nil receiver

### DIFF
--- a/pkg/jpath/jpath.go
+++ b/pkg/jpath/jpath.go
@@ -9,10 +9,10 @@ import (
 
 var (
 	// ErrorNoRoot means no rootDir was found in the parents
-	ErrorNoRoot = errors.New("could not locate a jsonnetfile.json in the parent directories, which is required to identify the project root")
+	ErrorNoRoot = errors.New("could not locate a jsonnetfile.json in the parent directories, which is required to identify the project root. Refer to https://tanka.dev/directory-structure for more information")
 
 	// ErrorNoBase means no baseDir was found in the parents
-	ErrorNoBase = errors.New("could not locate a main.jsonnet in the parent directories, which is required as the entrypoint for the evaluation")
+	ErrorNoBase = errors.New("could not locate a main.jsonnet in the parent directories, which is required as the entrypoint for the evaluation. Refer to https://tanka.dev/directory-structure for more information")
 )
 
 // ErrorFileNotFound means that the searched file was not found

--- a/pkg/kubernetes/errors.go
+++ b/pkg/kubernetes/errors.go
@@ -9,3 +9,11 @@ type ErrorNotFound struct {
 func (e ErrorNotFound) Error() string {
 	return fmt.Sprintf(`error from server (NotFound): secrets "%s" not found`, e.resource)
 }
+
+type ErrorMissingConfig struct {
+	verb string
+}
+
+func (e ErrorMissingConfig) Error() string {
+	return fmt.Sprintf("%s requires additional configuration. Refer to https://tanka.dev/environments for that.", e.verb)
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -64,7 +64,9 @@ func (k *Kubernetes) Reconcile(raw map[string]interface{}, objectspecs ...string
 	}
 	for _, d := range docs {
 		m := objx.New(d)
-		m.Set("metadata.namespace", k.Spec.Namespace)
+		if k != nil {
+			m.Set("metadata.namespace", k.Spec.Namespace)
+		}
 		out = append(out, Manifest(m))
 	}
 
@@ -106,6 +108,10 @@ func (k *Kubernetes) Fmt(state []Manifest) (string, error) {
 
 // Apply receives a state object generated using `Reconcile()` and may apply it to the target system
 func (k *Kubernetes) Apply(state []Manifest, opts ApplyOpts) error {
+	if k == nil {
+		return ErrorMissingConfig{"apply"}
+	}
+
 	yaml, err := k.Fmt(state)
 	if err != nil {
 		return err
@@ -115,6 +121,9 @@ func (k *Kubernetes) Apply(state []Manifest, opts ApplyOpts) error {
 
 // Diff takes the desired state and returns the differences from the cluster
 func (k *Kubernetes) Diff(state []Manifest) (*string, error) {
+	if k == nil {
+		return nil, ErrorMissingConfig{"diff"}
+	}
 	yaml, err := k.Fmt(state)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Although Tanka can `show` totally fine without a `spec.json`, however it panicked because of
the namespace override.

Now leaves the namespace untouched if it is not known.

Furthermore also fails on apply and diff without a `spec.json` with a clean error
message.

Fixes #55 