### PR TITLE
chore(packaging): manual changelog + release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,3 @@ container: static
 # CI
 drone:
 	jsonnet .drone/drone.jsonnet  | jq .drone -r | yq -y . > .drone/drone.yml
-
-changelog:
-	standard-version --skip.commit --skip.tag --preMajor
-
-release:
-	standard-version --skip.changelog --preMajor


### PR DESCRIPTION
drops `standard-version` for determining the next version number, because it did
not work anyways.
Changelogs need to written by hand now as well, what we did before anyways.