### PR TITLE
fix(kubernetes): correct handling of kubectl stderr

### DIFF
--- a/pkg/kubernetes/errors.go
+++ b/pkg/kubernetes/errors.go
@@ -3,11 +3,12 @@ package kubernetes
 import "fmt"
 
 type ErrorNotFound struct {
-	resource string
+	name string
+	kind string
 }
 
 func (e ErrorNotFound) Error() string {
-	return fmt.Sprintf(`error from server (NotFound): secrets "%s" not found`, e.resource)
+	return fmt.Sprintf(`error from server (NotFound): %s "%s" not found`, e.kind, e.name)
 }
 
 type ErrorMissingConfig struct {

--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 )
 
 func diff(name, is, should string) (string, error) {
@@ -43,4 +44,17 @@ func diff(name, is, should string) (string, error) {
 	}
 
 	return out, nil
+}
+
+// FilteredErr is a filtered Stderr. If one of the regular expressions match, the current input is discarded.
+type FilteredErr []*regexp.Regexp
+
+func (r FilteredErr) Write(p []byte) (n int, err error) {
+	for _, re := range r {
+		if re.Match(p) {
+			// silently discard
+			return len(p), nil
+		}
+	}
+	return os.Stderr.Write(p)
 }


### PR DESCRIPTION
A more sophisticated approach on #59 than #60 took.

Uses a custom regex middleware for the stderr stream to mute all `exit status NUMBER` outputs from kubectl in diff mode, but retains all other outputs.

Furthermore fixes a minor bug in error handling where a missing object was always reported as a `secret`.

Fixes #59 
Closes #60 
