### PR TITLE
fix(cli): remove empty lines on diff

### DIFF
--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -16,14 +16,14 @@ import (
 func pageln(i ...interface{}) {
 	// no paging in non-interactive mode
 	if !interactive {
-		fmt.Println(i...)
+		fmt.Print(i...)
 		return
 	}
 
-	// get system pager, fallback to `more`
+	// get system pager, fallback to `less`
 	pager := os.Getenv("PAGER")
 	var args []string
-	if pager == "" {
+	if pager == "" || pager == "less" {
 		// --raw-control-chars  Honors colors from diff.
 		// --quit-if-one-screen Closer to the git experience.
 		// --no-init            Don't clear the screen when exiting.
@@ -33,13 +33,13 @@ func pageln(i ...interface{}) {
 
 	// invoke pager
 	cmd := exec.Command(pager, args...)
-	cmd.Stdin = strings.NewReader(fmt.Sprintln(i...))
+	cmd.Stdin = strings.NewReader(fmt.Sprint(i...))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	// if this fails, just print it
 	if err := cmd.Run(); err != nil {
-		fmt.Println(i...)
+		fmt.Print(i...)
 	}
 }
 

--- a/pkg/kubernetes/subsetdiff.go
+++ b/pkg/kubernetes/subsetdiff.go
@@ -69,6 +69,7 @@ func (k Kubectl) SubsetDiff(y string) (*string, error) {
 		}
 		diffs += diffStr
 	}
+	diffs = strings.TrimSuffix(diffs, "\n")
 
 	return &diffs, nil
 }


### PR DESCRIPTION
Diff used to output empty lines after the differences. Removes that.