### PR TITLE
fix(cli): error on missing config

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -37,7 +37,7 @@ func applyCmd() *cobra.Command {
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if kube == nil {
-			log.Fatalln(kubernetes.ErrorMissingConfig{"apply"})
+			log.Fatalln(kubernetes.ErrorMissingConfig{Verb: "apply"})
 		}
 
 		raw, err := evalDict(args[0])
@@ -80,7 +80,7 @@ func diffCmd() *cobra.Command {
 	vars := workflowFlags(cmd.Flags())
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if kube == nil {
-			log.Fatalln(kubernetes.ErrorMissingConfig{"diff"})
+			log.Fatalln(kubernetes.ErrorMissingConfig{Verb: "diff"})
 		}
 
 		raw, err := evalDict(args[0])

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -36,6 +36,10 @@ func applyCmd() *cobra.Command {
 	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if kube == nil {
+			log.Fatalln(kubernetes.ErrorMissingConfig{"apply"})
+		}
+
 		raw, err := evalDict(args[0])
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)
@@ -75,6 +79,10 @@ func diffCmd() *cobra.Command {
 	}
 	vars := workflowFlags(cmd.Flags())
 	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if kube == nil {
+			log.Fatalln(kubernetes.ErrorMissingConfig{"diff"})
+		}
+
 		raw, err := evalDict(args[0])
 		if err != nil {
 			log.Fatalln("Evaluating jsonnet:", err)

--- a/pkg/kubernetes/errors.go
+++ b/pkg/kubernetes/errors.go
@@ -11,9 +11,9 @@ func (e ErrorNotFound) Error() string {
 }
 
 type ErrorMissingConfig struct {
-	verb string
+	Verb string
 }
 
 func (e ErrorMissingConfig) Error() string {
-	return fmt.Sprintf("%s requires additional configuration. Refer to https://tanka.dev/environments for that.", e.verb)
+	return fmt.Sprintf("%s requires additional configuration. Refer to https://tanka.dev/environments for that.", e.Verb)
 }


### PR DESCRIPTION
Prints an error when the config is missing for an action that requires it
instead of just panicking.