### PR TITLE
feat(kubernetes): regexp targets

### DIFF
--- a/docs/targets.md
+++ b/docs/targets.md
@@ -24,3 +24,47 @@ multiple objects match this pattern, all of them are used.
 
 The `--target` / `-t` flag can be specified multiple times, to work with
 multiple objects.
+
+
+## Regular Expressions
+The argument passed to the `--target` flag is interpreted as a
+[RE2](https://golang.org/s/re2syntax) regular expression.
+
+This allows you to use all sorts of wildcards and other advanced matching
+functionality to select Kubernetes objects:
+
+```bash
+# show all deployments
+$ tk show . -t 'deployment/.*'
+
+# show all objects named "loki"
+$ tk show . -t '.*/loki'
+```
+
+### Gotchas
+When using regular expressions, there are some things to watch out for:
+
+#### Line Anchors
+Tanka automatically surrounds your regular expression with line anchors:
+```text
+^<your expression>$
+```
+For example, `--target 'deployment/.*'` becomes `^deployment/.*$`.
+
+#### Quoting
+Regular expressions may consist of characters that have special meanings in
+shell. Always make sure to properly quote your regular expression using **single
+quotes**.
+
+```zsh
+# shell attempts to match the wildcard itself:
+zsh-5.4.2$ tk show . -t deployment/.*
+zsh: no matches found: deployment/.*
+
+# properly quoted:
+zsh-5.4.2$ tk show . -t 'deployment/.*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+# ...
+```

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -56,7 +57,7 @@ func (m Manifest) Namespace() string {
 
 // Reconcile receives the raw evaluated jsonnet as a marshaled json dict and
 // shall return it reconciled as a state object of the target system
-func (k *Kubernetes) Reconcile(raw map[string]interface{}, objectspecs ...string) (state []Manifest, err error) {
+func (k *Kubernetes) Reconcile(raw map[string]interface{}, objectspecs ...*regexp.Regexp) (state []Manifest, err error) {
 	docs, err := walkJSON(raw, "")
 	out := make([]Manifest, 0, len(docs))
 	if err != nil {
@@ -74,7 +75,7 @@ func (k *Kubernetes) Reconcile(raw map[string]interface{}, objectspecs ...string
 		out = funk.Filter(out, func(i interface{}) bool {
 			p := objectspec(i.(Manifest))
 			for _, o := range objectspecs {
-				if strings.EqualFold(p, o) {
+				if o.MatchString(strings.ToLower(p)) {
 					return true
 				}
 			}


### PR DESCRIPTION
Switches target matching from literal string match to regexp.Match.

The `--target` / `-t` flag now takes a regular expression that is matched
against the literal string `<kind>/<name>`. If none of the expressions match,
the object is discarded.

To prevent substrings to match, the expressions is surrounded by
line anchors (`^%s$)`.

Fixes #53 