### PR TITLE
feat(kubernetes): diff histogram

### DIFF
--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -8,8 +8,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
+// diff computes the differences between the strings `is` and `should` using the
+// UNIX `diff(1)` utility.
 func diff(name, is, should string) (string, error) {
 	dir, err := ioutil.TempDir("", "diff")
 	if err != nil {
@@ -44,6 +47,22 @@ func diff(name, is, should string) (string, error) {
 	}
 
 	return out, nil
+}
+
+// diffstat uses `diffstat(1)` utility to summarize a `diff(1)` output
+func diffstat(d string) (*string, error) {
+	cmd := exec.Command("diffstat", "-C")
+	buf := bytes.Buffer{}
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = strings.NewReader(d)
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("invoking diffstat(1): %s", err.Error())
+	}
+
+	out := buf.String()
+	return &out, nil
 }
 
 // FilteredErr is a filtered Stderr. If one of the regular expressions match, the current input is discarded.


### PR DESCRIPTION
Adds a `--summarize` / `-s` flag to `tk diff`, to automatically pipe the output
of `diff(1)` through `diffstat(1)` to generate a histogram of the changes, just
as git sometimes does.

**Result:**
```diff
 extensions.v1beta1.DaemonSet.default.promtail                  |   97 +++
 rbac.authorization.k8s.io.v1beta1.ClusterRole..promtail        |   20
 rbac.authorization.k8s.io.v1beta1.ClusterRoleBinding..promtail |   15
 v1.ConfigMap.default.promtail                                  |  260 ++++++++++
 v1.Namespace..loki                                             |   12
 v1.ServiceAccount.default.promtail                             |    8
 6 files changed, 412 insertions(+)
```

Fixes #66 