### PR TITLE
chore(packaging): fix binary name

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -60,7 +60,7 @@ steps:
 
       # download the binary (adapt os and arch as needed)
 
-      $ curl -fSL -o "/usr/local/bin/tk" "https://github.com/sh0rez/tanka/releases/download/${DRONE_TAG}/img-linux-amd64"
+      $ curl -fSL -o "/usr/local/bin/tk" "https://github.com/sh0rez/tanka/releases/download/${DRONE_TAG}/tk-linux-amd64"
 
 
       # make it executable

--- a/.drone/release-note.md
+++ b/.drone/release-note.md
@@ -4,7 +4,7 @@ This is release ${DRONE_TAG} of Tanka (`tk`). Check out the [CHANGELOG](CHANGELO
 #### Binary:
 ```bash
 # download the binary (adapt os and arch as needed)
-$ curl -fSL -o "/usr/local/bin/tk" "https://github.com/sh0rez/tanka/releases/download/${DRONE_TAG}/img-linux-amd64"
+$ curl -fSL -o "/usr/local/bin/tk" "https://github.com/sh0rez/tanka/releases/download/${DRONE_TAG}/tk-linux-amd64"
 
 # make it executable
 $ chmod a+x "/usr/local/bin/tk"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ uninstall:
 $(GOX):
 	go get -u github.com/mitchellh/gox
 cross: $(GOX)
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64 arm64 arm" -os="linux" -osarch="darwin/amd64" ./cmd/tk
+	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64 arm64 arm" -os="linux" -osarch="darwin/amd64" ./cmd/tk
 
 # Docker container
 container: static


### PR DESCRIPTION
Gets `.drone/release-note.md` and `Makefile` in sync, so that copying the
download command actually works.