### PR TITLE
feat(cli): environment manipulation

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"text/tabwriter"
+
+	"github.com/grafana/tanka/pkg/config/v1alpha1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func envCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env [action]",
+		Short: "manipulate environments",
+	}
+	cmd.PersistentFlags().Bool("json", false, "output in json format")
+	cmd.AddCommand(envListCmd())
+	return cmd
+}
+
+func envListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list environments",
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		envs := []v1alpha1.Config{}
+		dirs := findBaseDirs()
+		useJson, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			// this err should never occur. Panic in case
+			panic(err)
+		}
+		for _, dir := range dirs {
+			viper.Reset()
+			envs = append(envs, *setupConfiguration(dir))
+		}
+
+		if useJson {
+			j, err := json.Marshal(envs)
+			if err != nil {
+				log.Fatalln("Formatting as json:", j)
+			}
+			fmt.Println(string(j))
+			return
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+		f := "%s\t%s\t%s\t\n"
+		fmt.Fprintf(w, f, "NAME", "NAMESPACE", "SERVER")
+		for _, e := range envs {
+			fmt.Fprintf(w, f, e.Metadata.Name, e.Spec.Namespace, e.Spec.APIServer)
+		}
+		w.Flush()
+	}
+	return cmd
+}

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -5,11 +5,15 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 
-	"github.com/grafana/tanka/pkg/config/v1alpha1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/grafana/tanka/pkg/config/v1alpha1"
+	"github.com/grafana/tanka/pkg/util"
 )
 
 func envCmd() *cobra.Command {
@@ -18,15 +22,155 @@ func envCmd() *cobra.Command {
 		Short: "manipulate environments",
 	}
 	cmd.PersistentFlags().Bool("json", false, "output in json format")
-	cmd.AddCommand(envListCmd())
+	cmd.AddCommand(
+		envAddCmd(),
+		envSetCmd(),
+		envListCmd(),
+		envRemoveCmd(),
+	)
 	return cmd
+}
+
+func envSettingsFlags(env *v1alpha1.Config, fs *pflag.FlagSet) {
+	fs.StringVar(&env.Spec.APIServer, "server", env.Spec.APIServer, "endpoint of the Kubernetes API")
+	fs.StringVar(&env.Spec.Namespace, "namespace", env.Spec.Namespace, "namespace to create objects in")
+	fs.StringVar(&env.Spec.DiffStrategy, "diff-strategy", env.Spec.DiffStrategy, "specify diff-strategy. Automatically detected otherwise.")
+}
+
+func envSetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "update properties of an environment",
+		Args:  cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			"args": "baseDir",
+		},
+	}
+	tmp := v1alpha1.Config{}
+	envSettingsFlags(&tmp, cmd.Flags())
+
+	name := cmd.Flags().String("name", "", "")
+	cmd.Flags().MarkHidden("name")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if *name != "" {
+			log.Fatalln("It looks like you attempted to rename the environment using `--name`. However, this is not possible with Tanka, because the environments name is inferred from the directories name. To rename the environment, rename its directory instead.")
+		}
+
+		path, err := filepath.Abs(args[0])
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		viper.Reset()
+		cfg := setupConfiguration(path)
+		if tmp.Spec.APIServer != "" && tmp.Spec.APIServer != cfg.Spec.APIServer {
+			fmt.Printf("updated spec.apiServer (`%s -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)
+			cfg.Spec.APIServer = tmp.Spec.APIServer
+		}
+		if tmp.Spec.Namespace != "" && tmp.Spec.Namespace != cfg.Spec.Namespace {
+			fmt.Printf("updated spec.namespace (`%s -> `%s`)\n", cfg.Spec.Namespace, tmp.Spec.Namespace)
+			cfg.Spec.Namespace = tmp.Spec.Namespace
+		}
+		if tmp.Spec.DiffStrategy != "" && tmp.Spec.DiffStrategy != cfg.Spec.DiffStrategy {
+			fmt.Printf("updated spec.diffStrategy (`%s -> `%s`)\n", cfg.Spec.DiffStrategy, tmp.Spec.DiffStrategy)
+			cfg.Spec.DiffStrategy = tmp.Spec.DiffStrategy
+		}
+
+		if err := writeJSON(cfg, filepath.Join(path, "spec.json")); err != nil {
+			log.Fatalln(err)
+		}
+	}
+	return cmd
+}
+
+func envAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add [path]",
+		Short: "create a new environment",
+		Args:  cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			"args": "dirs",
+		},
+	}
+	cfg := v1alpha1.New()
+	envSettingsFlags(cfg, cmd.Flags())
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if err := addEnv(args[0], cfg); err != nil {
+			log.Fatalln(err)
+		}
+	}
+	return cmd
+}
+
+// used by initCmd() as well
+func addEnv(dir string, cfg *v1alpha1.Config) error {
+	path, err := filepath.Abs(dir)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		// folder does not exist
+		if os.IsNotExist(err) {
+			os.MkdirAll(path, os.ModePerm)
+		} else {
+			// it exists
+			if os.IsExist(err) {
+				return fmt.Errorf("Directory %s already exists.", path)
+			}
+			// we have another error
+			return fmt.Errorf("Creating directory:", err)
+		}
+	}
+
+	// the other properties are already set by v1alpha1.New() and pflag.Parse()
+	cfg.Metadata.Name = filepath.Base(path)
+
+	// write spec.json
+	if err := writeJSON(cfg, filepath.Join(path, "spec.json")); err != nil {
+		log.Fatalln(err)
+	}
+
+	// write main.jsonnet
+	if err := writeJSON(struct{}{}, filepath.Join(path, "main.jsonnet")); err != nil {
+		log.Fatalln(err)
+	}
+
+	return nil
+}
+
+func envRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove [path]",
+		Aliases: []string{"rm"},
+		Short:   "delete an environment",
+		Annotations: map[string]string{
+			"args": "baseDir",
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, arg := range args {
+				path, err := filepath.Abs(arg)
+				if err != nil {
+					log.Fatalln("parsing environments name:", err)
+				}
+				if err := util.Confirm(fmt.Sprintf("Permanently removing the environment located at '%s'.", path), "yes"); err != nil {
+					log.Fatalln(err)
+				}
+				if err := os.RemoveAll(path); err != nil {
+					log.Fatalf("Removing '%s': %s", path, err)
+				}
+				fmt.Println("Removed", path)
+			}
+		},
+	}
 }
 
 func envListCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "list environments",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "list environments",
+		Args:    cobra.NoArgs,
 	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -119,7 +119,7 @@ func addEnv(dir string, cfg *v1alpha1.Config) error {
 				return fmt.Errorf("Directory %s already exists.", path)
 			}
 			// we have another error
-			return fmt.Errorf("Creating directory:", err)
+			return fmt.Errorf("Creating directory: %s", err)
 		}
 	}
 

--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -39,28 +39,12 @@ func initCmd() *cobra.Command {
 			log.Fatalln("Error creating `vendor/` folder:", err)
 		}
 
-		if err := os.MkdirAll("environments/default", os.ModePerm); err != nil {
-			log.Fatalln("Error creating environments folder")
+		cfg := v1alpha1.New()
+		if err := addEnv("environments/default", cfg); err != nil {
+			log.Fatalln(err)
 		}
 
-		if err := writeNewFile("environments/default/main.jsonnet", "{}"); err != nil {
-			log.Fatalln("Error creating `main.jsonnet`:", err)
-		}
-
-		cfg := v1alpha1.Config{
-			APIVersion: "tanka.dev/v1alpha1",
-			Kind:       "Environment",
-			Spec:       v1alpha1.Spec{},
-		}
-
-		spec, err := json.MarshalIndent(&cfg, "", "  ")
-		if err != nil {
-			log.Fatalln("Error creating spec.json:", err)
-		}
-
-		if err := writeNewFile("environments/default/spec.json", string(spec)); err != nil {
-			log.Fatalln("Error creating `environments/default/spec.json`:", err)
-		}
+		fmt.Println("Directory structure set up! Remember to configure the API endpoint:\n`tk env set environments/default --server=127.0.0.1:6443`")
 
 	}
 	return cmd

--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -14,7 +14,7 @@ import (
 func evalCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Short: "evaluate the jsonnet to json",
-		Use:   "eval [directory]",
+		Use:   "eval [path]",
 		Args:  cobra.ExactArgs(1),
 		Annotations: map[string]string{
 			"args": "baseDir",

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -74,6 +74,10 @@ func main() {
 		diffCmd(),
 	)
 
+	rootCmd.AddCommand(
+		envCmd(),
+	)
+
 	// jsonnet commands
 	rootCmd.AddCommand(
 		evalCmd(),
@@ -139,11 +143,12 @@ func setupConfiguration(baseDir string) *v1alpha1.Config {
 		checkDeprecated()
 	}
 
-	var config v1alpha1.Config
-	if err := viper.Unmarshal(&config); err != nil {
+	var config = v1alpha1.New()
+	if err := viper.Unmarshal(config); err != nil {
 		log.Fatalf("Parsing spec.json: %s", err)
 	}
-	return &config
+	config.Metadata.Name = filepath.Base(baseDir)
+	return config
 }
 
 func checkDeprecated() {

--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -49,4 +51,18 @@ func highlight(lang, s string) string {
 		log.Fatalln("Highlighting:", err)
 	}
 	return buf.String()
+}
+
+// writeJSON writes the given object to the path as a JSON file
+func writeJSON(i interface{}, path string) error {
+	out, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Marshalling: %s", err)
+	}
+
+	if err := ioutil.WriteFile(path, append(out, '\n'), 0644); err != nil {
+		return fmt.Errorf("Writing %s: %s", path, err)
+	}
+
+	return nil
 }

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -27,7 +27,7 @@ func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 
 func applyCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "apply [directory]",
+		Use:   "apply [path]",
 		Short: "apply the configuration to the cluster",
 		Args:  cobra.ExactArgs(1),
 		Annotations: map[string]string{
@@ -71,7 +71,7 @@ func diffCmd() *cobra.Command {
 	cmp.Handlers.Add("diffStrategy", complete.PredictSet("native", "subset"))
 
 	cmd := &cobra.Command{
-		Use:   "diff [directory]",
+		Use:   "diff [path]",
 		Short: "differences between the configuration and the cluster",
 		Args:  cobra.ExactArgs(1),
 		Annotations: map[string]string{
@@ -144,7 +144,7 @@ func diff(state []kubernetes.Manifest, pager bool, opts kubernetes.DiffOpts) (ch
 
 func showCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show [directory]",
+		Use:   "show [path]",
 		Short: "jsonnet as yaml",
 		Args:  cobra.ExactArgs(1),
 		Annotations: map[string]string{

--- a/pkg/cmp/complete.go
+++ b/pkg/cmp/complete.go
@@ -36,6 +36,10 @@ func (h CompletionHandlers) Has(k string) bool {
 // Handlers are global Handlers to be used in annotations
 var Handlers = CompletionHandlers{}
 
+func init() {
+	Handlers["dirs"] = complete.PredictDirs("*")
+}
+
 // Create parses a *cobra.Command into a complete.Command
 func Create(root *cobra.Command) complete.Command {
 	rootCmp := complete.Command{}

--- a/pkg/config/v1alpha1/config.go
+++ b/pkg/config/v1alpha1/config.go
@@ -1,5 +1,14 @@
 package v1alpha1
 
+// New creates a new Config object with internal values already set
+func New() *Config {
+	c := Config{}
+	c.APIVersion = "tanka.dev/v1alpha1"
+	c.Kind = "Environment"
+
+	return &c
+}
+
 // Config holds the configuration variables for config version v1alpha1
 // ApiVersion and Kind are currently unused, this may change in the future.
 type Config struct {
@@ -11,12 +20,13 @@ type Config struct {
 
 // Metadata is meant for humans and not parsed
 type Metadata struct {
-	Labels map[string]interface{} `json:"labels"`
+	Name   string                 `json:"name"`
+	Labels map[string]interface{} `json:"labels,omitempty"`
 }
 
 // Spec defines Kubernetes properties
 type Spec struct {
 	APIServer    string `json:"apiServer"`
 	Namespace    string `json:"namespace"`
-	DiffStrategy string `json:"diffStrategy"`
+	DiffStrategy string `json:"diffStrategy,omitempty"`
 }

--- a/pkg/config/v1alpha1/config.go
+++ b/pkg/config/v1alpha1/config.go
@@ -3,8 +3,13 @@ package v1alpha1
 // New creates a new Config object with internal values already set
 func New() *Config {
 	c := Config{}
+
+	// constants
 	c.APIVersion = "tanka.dev/v1alpha1"
 	c.Kind = "Environment"
+
+	// default namespace
+	c.Spec.Namespace = "default"
 
 	return &c
 }
@@ -20,7 +25,7 @@ type Config struct {
 
 // Metadata is meant for humans and not parsed
 type Metadata struct {
-	Name   string                 `json:"name"`
+	Name   string                 `json:"name,omitempty"`
 	Labels map[string]interface{} `json:"labels,omitempty"`
 }
 

--- a/pkg/kubernetes/kubectl.go
+++ b/pkg/kubernetes/kubectl.go
@@ -1,10 +1,8 @@
 package kubernetes
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +13,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/stretchr/objx"
 	funk "github.com/thoas/go-funk"
+
+	"github.com/grafana/tanka/pkg/util"
 )
 
 var (
@@ -143,20 +143,16 @@ func (k Kubectl) Apply(yaml, namespace string, opts ApplyOpts) error {
 	}
 
 	if !opts.AutoApprove {
-		reader := bufio.NewReader(os.Stdin)
-		fmt.Printf(`Applying to namespace '%s' of cluster '%s' at '%s' using context '%s'.
-Please type 'yes' to perform: `,
-			alert(namespace),
-			alert(k.cluster.Get("name").MustStr()),
-			alert(k.cluster.Get("cluster.server").MustStr()),
-			alert(k.context.Get("name").MustStr()),
-		)
-		approve, err := reader.ReadString('\n')
-		if err != nil {
+		if err := util.Confirm(
+			fmt.Sprintf(`Applying to namespace '%s' of cluster '%s' at '%s' using context '%s'.`,
+				alert(namespace),
+				alert(k.cluster.Get("name").MustStr()),
+				alert(k.cluster.Get("cluster.server").MustStr()),
+				alert(k.context.Get("name").MustStr()),
+			),
+			"yes",
+		); err != nil {
 			return err
-		}
-		if approve != "yes\n" {
-			return errors.New("aborted by user")
 		}
 	}
 

--- a/pkg/util/alert.go
+++ b/pkg/util/alert.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// Confirm asks the user for confirmation
+func Confirm(msg, approval string) error {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Println(msg)
+	fmt.Printf("Please type '%s' to confirm: ", approval)
+	read, err := reader.ReadString('\n')
+	if err != nil {
+		return errors.Wrap(err, "reading from stdin")
+	}
+	if read != approval+"\n" {
+		return errors.New("aborted by user")
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a set of commands to work with and manipulate environments:
- `tk env add`: Create a new environment, optionally setting parameters (now also used by `tk init`)
- `tk env remove` (`tk env rm`): Remove an environment
- `tk env list` (`tk env ls`): List environments (optionally as JSON)
- `tk env set`: set properties on environments (the same available for `tk env add`)

These commands aim to be `ks env` compatible. However, Tanka infers the environments name from the directory, so it is not possible to modify it using `add` / `set` `--name`. Just `mv` the directory in that case (included in the error message).

Fixes #72 
