### PR TITLE
fix(cli): panic on missing env

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -64,6 +64,10 @@ func envSetCmd() *cobra.Command {
 
 		viper.Reset()
 		cfg := setupConfiguration(path)
+		if cfg == nil {
+			fmt.Printf("failed to get config from `%s`\n", path)
+			os.Exit(1)
+		}
 		if tmp.Spec.APIServer != "" && tmp.Spec.APIServer != cfg.Spec.APIServer {
 			fmt.Printf("updated spec.apiServer (`%s -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)
 			cfg.Spec.APIServer = tmp.Spec.APIServer

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -65,8 +65,7 @@ func envSetCmd() *cobra.Command {
 		viper.Reset()
 		cfg := setupConfiguration(path)
 		if cfg == nil {
-			fmt.Printf("failed to get config from `%s`\n", path)
-			os.Exit(1)
+			log.Fatalf("Failed to load an environment at `%s`.\nMake sure it exists and is properly configured. See https://tanka.dev/environments/ for details.", path)
 		}
 		if tmp.Spec.APIServer != "" && tmp.Spec.APIServer != cfg.Spec.APIServer {
 			fmt.Printf("updated spec.apiServer (`%s -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)


### PR DESCRIPTION
Fix panic when specify wrong env:
```
# tk env add loki
# tk env set environments/loki --server=127.0.0.1:6443
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0xa732b5]

goroutine 1 [running]:
main.envSetCmd.func1(0xc00012a000, 0xc0004d2700, 0x1, 0x2)
	/drone/src/cmd/tk/env.go:67 +0x115
github.com/spf13/cobra.(*Command).execute(0xc00012a000, 0xc00001e080, 0x2, 0x2, 0xc00012a000, 0xc00001e080)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0xc000020a00, 0xc000249780, 0xc000311860, 0x0)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fc
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/drone/src/cmd/tk/main.go:110 +0x48c
[root@test tanka]# GO111MODULE=on go mod download
[root@test tanka]# go build ./cmd/tk
../../sh0rez/go-jsonnet/desugarer.go:27:2: cannot find package "github.com/google/go-jsonnet/parser" in any of:
	/usr/lib/golang/src/github.com/google/go-jsonnet/parser (from $GOROOT)
	/deploy/go/src/github.com/google/go-jsonnet/parser (from $GOPATH)
```

Signed-off-by: Xiang Dai <764524258@qq.com>