### PR TITLE
chore(packaging): preserve full git tag for docker

### DIFF
--- a/.drone/docker-manifest.tmpl
+++ b/.drone/docker-manifest.tmpl
@@ -1,4 +1,4 @@
-image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: grafana/tanka:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -6,16 +6,16 @@ tags:
 {{/each}}
 {{/if}}
 manifests:
-  - image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}amd64
+  - image: grafana/tanka:{{#if build.tag}}{{build.tag}}-{{/if}}amd64
     platform:
       architecture: amd64
       os: linux
-  - image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}arm64
+  - image: grafana/tanka:{{#if build.tag}}{{build.tag}}-{{/if}}arm64
     platform:
       architecture: arm64
       os: linux
       variant: v8
-  - image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}arm
+  - image: grafana/tanka:{{#if build.tag}}{{build.tag}}-{{/if}}arm
     platform:
       architecture: arm
       os: linux


### PR DESCRIPTION
At the moment, the CI strips the leading `v` from the version tag, which means
`v0.5.0` would become `grafana/tanka:0.5.0`.

This behavior is not intuitive, changed it accordingly