### PR TITLE
refactor(cli): spec parsing

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/grafana/tanka/pkg/config/v1alpha1"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/grafana/tanka/pkg/util"
 )
 

--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/grafana/tanka/pkg/config/v1alpha1"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -13,7 +13,7 @@ import (
 	funk "github.com/thoas/go-funk"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/grafana/tanka/pkg/config/v1alpha1"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
 
 // Kubernetes bridges tanka to the Kubernetse orchestrator.

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/grafana/tanka/pkg/config/v1alpha1"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/spec/depreciations.go
+++ b/pkg/spec/depreciations.go
@@ -1,0 +1,19 @@
+package spec
+
+import "fmt"
+
+type depreciation struct {
+	old, new string
+}
+
+// ErrDeprecated is a non-fatal error that occurs when deprecated fields are
+// used in the spec.json
+type ErrDeprecated []depreciation
+
+func (e ErrDeprecated) Error() string {
+	buf := ""
+	for _, d := range e {
+		buf += fmt.Sprintf("Warning: `%s` is deprecated, use `%s` instead.\n", d.old, d.new)
+	}
+	return buf
+}

--- a/pkg/spec/depreciations_test.go
+++ b/pkg/spec/depreciations_test.go
@@ -1,0 +1,37 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeprecated checks that deprecated fields are still respected, but can be
+// overwritten by the newer format.
+func TestDeprecated(t *testing.T) {
+	data := []byte(`
+	{
+      "spec": {
+        "namespace": "new"
+      },
+	  "server": "https://127.0.0.1",
+	  "team": "cool",
+      "namespace": "old"
+	}`)
+
+	got, err := Parse(data, "test")
+	require.Equal(t, ErrDeprecated{
+		{old: "server", new: "spec.apiServer"},
+		{old: "team", new: "metadata.labels.team"},
+	}, err)
+
+	want := v1alpha1.New()
+	want.Spec.APIServer = "https://127.0.0.1"
+	want.Spec.Namespace = "new"
+	want.Metadata.Labels["team"] = "cool"
+	want.Metadata.Name = "test"
+
+	assert.Equal(t, want, got)
+}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -42,7 +42,7 @@ func ParseDir(baseDir string) (*v1alpha1.Config, error) {
 
 	v := viper.New()
 	v.SetConfigName("spec")
-	v.AddConfigPath(fi.Name())
+	v.AddConfigPath(baseDir)
 
 	if err := v.ReadInConfig(); err != nil {
 		return nil, err

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -1,0 +1,81 @@
+package spec
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+)
+
+// list of deprecated config keys and their alternatives
+// however, they still work and are aliased internally
+var deprecated = []depreciation{
+	{old: "namespace", new: "spec.namespace"},
+	{old: "server", new: "spec.apiServer"},
+	{old: "team", new: "metadata.labels.team"},
+}
+
+// Parse parses the json `data` into a `v1alpha1.Config` object.
+// `name` is the name of the environment
+func Parse(data []byte, name string) (*v1alpha1.Config, error) {
+	v := viper.New()
+	v.SetConfigType("json")
+	if err := v.ReadConfig(bytes.NewReader(data)); err != nil {
+		return nil, err
+	}
+	return parse(v, name)
+}
+
+// ParseDir parses the given environments `spec.json` into a `v1alpha1.Config`
+// object with the name set to the directories name
+func ParseDir(baseDir string) (*v1alpha1.Config, error) {
+	fi, err := os.Stat(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	if !fi.IsDir() {
+		return nil, errors.New("baseDir is not an directory")
+	}
+
+	v := viper.New()
+	v.SetConfigName("spec")
+	v.AddConfigPath(fi.Name())
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+
+	return parse(v, filepath.Base(baseDir))
+}
+
+// parse accepts a viper.Viper already loaded with the actual config and
+// unmarshals it onto a v1alpha1.Config
+func parse(v *viper.Viper, name string) (*v1alpha1.Config, error) {
+	var errDepr ErrDeprecated
+
+	// handle deprecated ksonnet spec
+	for _, d := range deprecated {
+		if v.IsSet(d.old) && !v.IsSet(d.new) {
+			if errDepr == nil {
+				errDepr = ErrDeprecated{d}
+			} else {
+				errDepr = append(errDepr, d)
+			}
+			v.Set(d.new, v.Get(d.old))
+		}
+	}
+
+	config := v1alpha1.New()
+	if err := v.Unmarshal(config); err != nil {
+		return nil, errors.Wrap(err, "parsing spec.json")
+	}
+
+	// set the name field
+	config.Metadata.Name = name
+
+	// return depreciation notes in case any exist as well
+	return config, errDepr
+}

--- a/pkg/spec/v1alpha1/config.go
+++ b/pkg/spec/v1alpha1/config.go
@@ -11,6 +11,8 @@ func New() *Config {
 	// default namespace
 	c.Spec.Namespace = "default"
 
+	c.Metadata.Labels = make(map[string]string)
+
 	return &c
 }
 
@@ -25,8 +27,8 @@ type Config struct {
 
 // Metadata is meant for humans and not parsed
 type Metadata struct {
-	Name   string                 `json:"name,omitempty"`
-	Labels map[string]interface{} `json:"labels,omitempty"`
+	Name   string            `json:"name,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Spec defines Kubernetes properties


### PR DESCRIPTION
Refactors the parsing of an environments `spec.json` into a separate package
`pkg/spec` to allow working with Tanka environments from outside of our
codebase.

A separate package was required because spec parsing also involves dealing with
deprecated ksonnet attributes and correctly setting constants and the
environments name, which would be too much logic to re-implement in every
project needing to parse our `spec.json`.