### PR TITLE
fix(docs): ksonnet-lib installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ After you initialized the directory structure, install the required libraries
 using `jb`:
 ```bash
 # Ksonnet kubernetes libraries
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k.libsonnet
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k8s.libsonnet
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3
 
 # Promtail library
 $ jb install github.com/grafana/loki/production/ksonnet/promtail

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -14,8 +14,7 @@ paths](directory-structure.md/#import-paths).
 This error can occur when the `ksonnet` kubernetes libraries are missing in the import paths. While `ksonnet` used to magically include them, Tanka follows a more explicit approach and requires you to install them using `jb`:
 
 ```bash
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k.libsonnet
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k8s.libsonnet
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3
 ```
 
 This installs version `beta.3` of the libraries, matching Kubernetes version


### PR DESCRIPTION
:warning: **DO NOT MERGE. This doesn't even work** :warning: 

As https://github.com/jsonnet-bundler/jsonnet-bundler does not support
installing single files from a repository anymore, we need to use the parent
directory instead. See https://github.com/jsonnet-bundler/jsonnet-bundler/issues/43 for reference.

~~Fixes #95 for now~~