### PR TITLE
Use ksonnet.beta.4 in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ After you initialized the directory structure, install the required libraries
 using `jb`:
 ```bash
 # Ksonnet kubernetes libraries
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k.libsonnet
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k8s.libsonnet
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k8s.libsonnet
 
 # Promtail library
 $ jb install github.com/grafana/loki/production/ksonnet/promtail

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -14,8 +14,8 @@ paths](directory-structure.md/#import-paths).
 This error can occur when the `ksonnet` kubernetes libraries are missing in the import paths. While `ksonnet` used to magically include them, Tanka follows a more explicit approach and requires you to install them using `jb`:
 
 ```bash
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k.libsonnet
-$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k8s.libsonnet
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet
+$ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k8s.libsonnet
 ```
 
 This installs version `beta.3` of the libraries, matching Kubernetes version


### PR DESCRIPTION
You should start using ksonnet.beta.4 as 3 is going to not work soon anymore, with deployments being still in apps/v1beta2. The API group was deprecated and will be removed in the next Kubernetes version.