### PR TITLE
Support nested lists when discovering manifests

### DIFF
--- a/pkg/kubernetes/data_test.go
+++ b/pkg/kubernetes/data_test.go
@@ -220,10 +220,10 @@ func testDataDeep() testData {
 // flattened
 func testDataArray() testData {
 	return testData{
-		deep: append(make([]map[string]interface{}, 0),
+		deep: []interface{}{
 			testDataDeep().deep.(map[string]interface{}),
 			testDataFlat().deep.(map[string]interface{}),
-		),
+		},
 
 		flat: map[string]manifest.Manifest{
 			".[0].app.web.backend.server.nginx.deployment":    testDataDeep().flat[".app.web.backend.server.nginx.deployment"],

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -128,10 +128,3 @@ func (k *Kubernetes) Diff(state manifest.List, opts DiffOpts) (*string, error) {
 func (k *Kubernetes) Info() client.Info {
 	return k.info
 }
-
-func objectspec(m manifest.Manifest) string {
-	return fmt.Sprintf("%s/%s",
-		m.Kind(),
-		m.Metadata().Name(),
-	)
-}

--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/objx"
@@ -65,6 +66,11 @@ func (m Manifest) Verify() error {
 // Kind returns the kind of the API object
 func (m Manifest) Kind() string {
 	return m["kind"].(string)
+}
+
+// KindName returns a <kind>/<name> string
+func (m Manifest) KindName() string {
+	return fmt.Sprintf("%s/%s", m.Kind(), m.Metadata().Name())
 }
 
 // APIVersion returns the version of the API this object uses

--- a/pkg/kubernetes/reconcile.go
+++ b/pkg/kubernetes/reconcile.go
@@ -14,138 +14,129 @@ import (
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
 
-// Reconcile extracts all valid Kubernetes objects from the raw output of the
-// Jsonnet compiler. A valid object is identified by the presence of `kind` and
-// `apiVersion`.
-// TODO: Check on `metadata.name` as well and assert that they are
-// not only set but also strings.
-func Reconcile(raw map[string]interface{}, spec v1alpha1.Spec, targets []*regexp.Regexp) (state manifest.List, err error) {
-	extracted, err := extract(raw)
+// Manifest is a type alias so we can use local variable name manifest without colliding
+// with the package
+type Manifest = manifest.Manifest
+
+// Reconcile extracts kubernetes Manifests from raw evaluated jsonnet <kind>/<name>,
+// provided the manifests match the given regular expressions. It finds each manifest by
+// recursively walking the jsonnet structure.
+//
+// In addition, we sort the manifests to ensure the order is consistent in each
+// show/diff/apply cycle. This isn't necessary, but it does help users by producing
+// consistent diffs.
+func Reconcile(raw map[string]interface{}, spec v1alpha1.Spec, kindNameMatchers []*regexp.Regexp) (state manifest.List, err error) {
+	manifests, err := walkJSON(raw)
 	if err != nil {
 		return nil, errors.Wrap(err, "flattening manifests")
 	}
 
-	out := make(manifest.List, 0, len(extracted))
-	for _, m := range extracted {
-		if spec.Namespace != "" && !m.Metadata().HasNamespace() {
-			m.Metadata()["namespace"] = spec.Namespace
+	// If we don't have a namespace, we want to set it to the default that is configured in
+	// our kubernetes specification
+	for _, manifest := range manifests {
+		if spec.Namespace != "" && !manifest.Metadata().HasNamespace() {
+			manifest.Metadata()["namespace"] = spec.Namespace
 		}
-
-		out = append(out, m)
 	}
 
-	// optionally filter the working set of objects
-	if len(targets) > 0 {
-		tmp := funk.Filter(out, func(i interface{}) bool {
-			p := objectspec(i.(manifest.Manifest))
-			for _, t := range targets {
-				if t.MatchString(strings.ToLower(p)) {
+	// If we have any kind-name matchers, we should filter all the manifests by matching
+	// against their <kind>/<name> identifier.
+	if len(kindNameMatchers) > 0 {
+		manifests = funk.Filter(manifests, func(elem interface{}) bool {
+			manifest := elem.(Manifest)
+			kindName := strings.ToLower(manifest.KindName())
+			for _, matcher := range kindNameMatchers {
+				if matcher.MatchString(kindName) {
 					return true
 				}
 			}
+
 			return false
-		}).([]manifest.Manifest)
-		out = manifest.List(tmp)
+		}).([]Manifest)
 	}
 
-	// Stable output order
-	sort.SliceStable(out, func(i int, j int) bool {
-		if out[i].Kind() != out[j].Kind() {
-			return out[i].Kind() < out[j].Kind()
-		}
-		return out[i].Metadata().Name() < out[j].Metadata().Name()
+	sort.SliceStable(manifests, func(i int, j int) bool {
+		return manifests[i].KindName() < manifests[j].KindName()
 	})
 
-	return out, nil
+	return manifests, nil
 }
 
-func extract(deep interface{}) (map[string]manifest.Manifest, error) {
-	extracted := make(map[string]manifest.Manifest)
-	if err := walkJSON(deep, extracted, nil); err != nil {
-		return nil, err
-	}
-	return extracted, nil
-}
-
-// walkJSON traverses deeply nested kubernetes manifest and extracts them into a flat []dict.
-func walkJSON(deep interface{}, extracted map[string]manifest.Manifest, path trace) error {
-	// array: walkJSON for each
-	if d, ok := deep.([]map[string]interface{}); ok {
-		for i, j := range d {
-			path := append(path, fmt.Sprintf("[%v]", i))
-			if err := walkJSON(j, extracted, path); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	// assert for map[string]interface{} (also aliased objx.Map)
-	if m, ok := deep.(objx.Map); ok {
-		deep = map[string]interface{}(m)
-	}
-	deep, ok := deep.(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("deep has unexpected type %T @ %s", deep, path)
-	}
-
-	// already flat?
-	r := objx.New(deep)
-
-	if r.Has("apiVersion") && r.Has("kind") {
-		extracted[path.Full()] = deep.(map[string]interface{})
-		return nil
-	}
-
-	// walk it
-	for key, d := range deep.(map[string]interface{}) {
-		if key == "__ksonnet" {
-			continue
-		}
-		path := append(path, key)
-
-		if _, ok := d.(map[string]interface{}); !ok {
-			return ErrorPrimitiveReached{path.Base(), key, d}
-		}
-
-		m := objx.New(d)
-		if m.Has("apiVersion") && m.Has("kind") {
-			mf, err := manifest.NewFromObj(m)
-			if err != nil {
-				return err.(*manifest.SchemaError).WithName(path.Full())
-			}
-			extracted[path.Full()] = mf
-		} else {
-			if err := walkJSON(m, extracted, path); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-type trace []string
-
-func (t trace) Full() string {
-	return "." + strings.Join(t, ".")
-}
-
-func (t trace) Base() string {
-	if len(t) > 0 {
-		t = t[:len(t)-1]
-	}
-	return "." + strings.Join(t, ".")
-}
-
-// ErrorPrimitiveReached occurs when walkJSON reaches the end of nested dicts without finding a valid Kubernetes manifest
 type ErrorPrimitiveReached struct {
-	path, key string
+	path      string
 	primitive interface{}
 }
 
 func (e ErrorPrimitiveReached) Error() string {
-	return fmt.Sprintf("recursion did not resolve in a valid Kubernetes object, "+
-		"because one of `kind` or `apiVersion` is missing in path `%s`."+
-		" Found non-dict value `%s` of type `%T` instead.",
-		e.path, e.key, e.primitive)
+	return fmt.Sprintf("found an object at %s of type %T that was not a valid Kubernetes object", e.path, e.primitive)
+}
+
+// walkJSON recurses into either a map or list, returning a list of all objects that look
+// like kubernetes resources. We support resources at an arbitrary level of nesting, and
+// return an error if any leaf nodes f
+//
+// Handling the different types is quite gross, so we split this method into a generic
+// walkJSON, and then walkObj/walkList to handle the two different types of collection we
+// support.
+func walkJSON(ptr interface{}, paths ...string) ([]Manifest, error) {
+	if obj, ok := ptr.(map[string]interface{}); ok {
+		return walkObj(obj, paths...)
+	}
+
+	if list, ok := ptr.([]interface{}); ok {
+		return walkList(list, paths...)
+	}
+
+	return nil, ErrorPrimitiveReached{path: strings.Join(paths, "/"), primitive: ptr}
+}
+
+func walkObj(obj objx.Map, paths ...string) ([]Manifest, error) {
+	obj = obj.Exclude([]string{"__ksonnet"}) // remove our private ksonnet field
+
+	// This looks like a kubernetes manifest, so make one and return it
+	if isKubernetesManifest(obj) {
+		manifest := Manifest(obj.Value().MSI())
+
+		return []Manifest{manifest}, nil
+	}
+
+	manifests := []Manifest{}
+	for key, value := range obj {
+		children, err := walkJSON(value, append(paths, key)...)
+		if err != nil {
+			return nil, err
+		}
+
+		manifests = append(manifests, children...)
+	}
+
+	return manifests, nil
+}
+
+func walkList(list []interface{}, paths ...string) ([]Manifest, error) {
+	manifests := []Manifest{}
+	for idx, value := range list {
+		children, err := walkJSON(value, append(paths, fmt.Sprintf("%d", idx))...)
+		if err != nil {
+			return nil, err
+		}
+
+		manifests = append(manifests, children...)
+	}
+
+	return manifests, nil
+}
+
+// isKubernetesManifest attempts to infer whether the given object is a valid kubernetes
+// resource by verifying the presence of apiVersion, kind and metadata.name. These three
+// fields are required for kubernetes to accept any resource.
+//
+// In future, it might be a good idea to allow users to opt their object out of being
+// interpreted as a kubernetes resource, perhaps with a field like `exclude: true`. For
+// now, any object within the jsonnet output that quacks like a kubernetes resource will
+// be provided to the kubernetes API.
+func isKubernetesManifest(obj objx.Map) bool {
+	return obj.Get("apiVersion").IsStr() && obj.Get("apiVersion").Str() != "" &&
+		obj.Get("kind").IsStr() && obj.Get("kind").Str() != "" &&
+		obj.Get("metadata.name").IsStr() && obj.Get("metadata.name").Str() != ""
 }

--- a/pkg/kubernetes/reconcile_test.go
+++ b/pkg/kubernetes/reconcile_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtract(t *testing.T) {
+func TestWalkJSON(t *testing.T) {
 	tests := []struct {
 		name string
 		data testData
@@ -24,7 +24,7 @@ func TestExtract(t *testing.T) {
 		{
 			name: "primitive",
 			data: testDataPrimitive(),
-			err:  ErrorPrimitiveReached{path: ".nginx.service", key: "note", primitive: "invalid because apiVersion and kind are missing"},
+			err:  ErrorPrimitiveReached{path: "nginx/service/note", primitive: "invalid because apiVersion and kind are missing"},
 		},
 		{
 			name: "deep",
@@ -38,10 +38,15 @@ func TestExtract(t *testing.T) {
 
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			extracted, err := extract(c.data.deep)
+			manifests, err := walkJSON(c.data.deep)
+
+			expectedManifests := []Manifest{}
+			for _, manifest := range c.data.flat {
+				expectedManifests = append(expectedManifests, manifest)
+			}
 
 			require.Equal(t, c.err, err)
-			assert.EqualValues(t, c.data.flat, extracted)
+			assert.ElementsMatch(t, expectedManifests, manifests)
 		})
 	}
 }


### PR DESCRIPTION
This commit modifies the generation of kubernetes manifests so that we
can support lists of resources, at arbitrary levels of nesting. As an
example, where before the following jsonnet would fail:

    ```json
    {
      resources: [
        {
          apiVersion: "v1",
          kind: "ConfigMap",
          metadata: {
            name: "config",
          },
        }
      ],
    }
    ```

We will now return a valid configmap resource.