### PR TITLE
Deletions (third attempt)

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -45,13 +45,13 @@ func applyCmd() *cobra.Command {
 	vars := workflowFlags(cmd.Flags())
 	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
-	prune := cmd.Flags().Bool("prune", false, "delete resources from cluster not present in Jsonnet")
+	prune := cmd.Flags().Bool("prune", false, "delete resources from the cluster that are not present in Jsonnet")
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		err := tanka.Apply(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
 			tanka.WithApplyForce(*force),
 			tanka.WithApplyAutoApprove(*autoApprove),
-			tanka.WithPrune(*prune),
+			tanka.WithApplyPrune(*prune),
 		)
 		if err != nil {
 			log.Fatalln(err)

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -45,11 +45,13 @@ func applyCmd() *cobra.Command {
 	vars := workflowFlags(cmd.Flags())
 	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	prune := cmd.Flags().Bool("prune", false, "delete resources from cluster not present in Jsonnet")
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		err := tanka.Apply(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
 			tanka.WithApplyForce(*force),
 			tanka.WithApplyAutoApprove(*autoApprove),
+			tanka.WithPrune(*prune),
 		)
 		if err != nil {
 			log.Fatalln(err)

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -15,7 +15,10 @@ type Client interface {
 
 	// Apply the configuration to the cluster. `data` must contain a plaintext
 	// format that is `kubectl-apply(1)` compatible
-	Apply(data manifest.List, opts ApplyOpts) error
+	Apply(labels []string, data manifest.List, opts ApplyOpts) error
+
+	// ApplyDryRun runs an apply with prune enabled
+	ApplyDryRun(labels []string, data manifest.List) (string, error)
 
 	// DiffServerSide runs the diff operation on the server and returns the
 	// result in `diff(1)` format
@@ -53,6 +56,9 @@ type ApplyOpts struct {
 
 	// autoApprove allows to skip the interactive approval
 	AutoApprove bool
+
+	// Prune causes k8s API to remove resources not present in manifests
+	Prune bool
 }
 
 // DeleteOpts allow to specify additional parameters for delete operations

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -82,11 +82,9 @@ func (k *Kubernetes) Apply(baseDir string, state manifest.List, opts ApplyOpts) 
 	alert := color.New(color.FgRed, color.Bold).SprintFunc()
 
 	if !opts.AutoApprove {
-		var message string
+		message := `Applying to namespace '%s' of cluster '%s' at '%s' using context '%s'.`
 		if opts.Prune {
 			message = `Applying to and pruning namespace '%s' of cluster '%s' at '%s' using context '%s'.`
-		} else {
-			message = `Applying to namespace '%s' of cluster '%s' at '%s' using context '%s'.`
 		}
 		if err := cli.Confirm(
 			fmt.Sprintf(message,

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -136,10 +136,11 @@ func (k *Kubernetes) Diff(baseDir string, state manifest.List, opts DiffOpts) (*
 	output, err := k.ctl.ApplyDryRun(labels, state)
 	if err != nil {
 		return nil, err
-	} else if output == "" {
-		return d, nil
 	}
 	prunes := extractPrunes(output)
+	if len(prunes) == 0 {
+		return d, nil
+	}
 	lines := []string{}
 	if d != nil {
 		lines = append(lines, *d)

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestReconcile(t *testing.T) {
 	tests := []struct {
-		name string
-		spec v1alpha1.Spec
+		name   string
+		config v1alpha1.Config
 
 		deep interface{}
 		flat manifest.List
@@ -50,9 +50,9 @@ func TestReconcile(t *testing.T) {
 			targets: []*regexp.Regexp{regexp.MustCompile("deployment/.*")},
 		},
 		{
-			name: "force-namespace",
-			spec: v1alpha1.Spec{Namespace: "tanka"},
-			deep: testDataFlat().deep,
+			name:   "force-namespace",
+			config: v1alpha1.Config{Spec: v1alpha1.Spec{Namespace: "tanka"}},
+			deep:   testDataFlat().deep,
 			flat: func() manifest.List {
 				f := testDataFlat().flat["."]
 				f.Metadata()["namespace"] = "tanka"
@@ -60,8 +60,8 @@ func TestReconcile(t *testing.T) {
 			}(),
 		},
 		{
-			name: "custom-namespace",
-			spec: v1alpha1.Spec{Namespace: "tanka"},
+			name:   "custom-namespace",
+			config: v1alpha1.Config{Spec: v1alpha1.Spec{Namespace: "tanka"}},
 			deep: func() map[string]interface{} {
 				d := objx.New(testDataFlat().deep)
 				d.Set("metadata.namespace", "custom")
@@ -77,7 +77,7 @@ func TestReconcile(t *testing.T) {
 
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			got, err := Reconcile(c.deep.(map[string]interface{}), c.spec, c.targets)
+			got, err := Reconcile(c.deep.(map[string]interface{}), c.config, c.targets)
 
 			require.Equal(t, c.err, err)
 			assert.ElementsMatch(t, c.flat, got)
@@ -88,7 +88,7 @@ func TestReconcile(t *testing.T) {
 func TestReconcileOrder(t *testing.T) {
 	got := make([]manifest.List, 10)
 	for i := 0; i < 10; i++ {
-		r, err := Reconcile(testDataDeep().deep.(map[string]interface{}), v1alpha1.Spec{}, nil)
+		r, err := Reconcile(testDataDeep().deep.(map[string]interface{}), v1alpha1.Config{}, nil)
 		require.NoError(t, err)
 		got[i] = r
 	}

--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -133,11 +133,6 @@ func (m Metadata) Labels() map[string]interface{} {
 	return m["labels"].(map[string]interface{})
 }
 
-// SetLabels sets the labels of a manifest
-func (m Metadata) SetLabels(labels map[string]interface{}) {
-	m["labels"] = labels
-}
-
 // HasAnnotations returns whether the manifest has annotations
 func (m Metadata) HasAnnotations() bool {
 	return m2o(m).Get("annotations").IsMSI()

--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -133,6 +133,11 @@ func (m Metadata) Labels() map[string]interface{} {
 	return m["labels"].(map[string]interface{})
 }
 
+// SetLabels sets the labels of a manifest
+func (m Metadata) SetLabels(labels map[string]interface{}) {
+	m["labels"] = labels
+}
+
 // HasAnnotations returns whether the manifest has annotations
 func (m Metadata) HasAnnotations() bool {
 	return m2o(m).Get("annotations").IsMSI()

--- a/pkg/kubernetes/reconcile.go
+++ b/pkg/kubernetes/reconcile.go
@@ -16,7 +16,7 @@ import (
 
 // TankaEnvironmentLabel is the label applied to all resources. Used to identify resources that are
 // eligible for deletion, if not present in the generated set of manifests.
-const TankaEnvironmentLabel = "tanka/environment"
+const TankaEnvironmentLabel = "tanka.dev/environment"
 
 // Reconcile extracts all valid Kubernetes objects from the raw output of the
 // Jsonnet compiler. A valid object is identified by the presence of `kind` and
@@ -39,7 +39,6 @@ func Reconcile(raw map[string]interface{}, baseDir string, spec v1alpha1.Spec, t
 
 		labels := m.Metadata().Labels()
 		labels[TankaEnvironmentLabel] = environmentLabel
-		m.Metadata().SetLabels(labels)
 
 		out = append(out, m)
 	}

--- a/pkg/spec/depreciations_test.go
+++ b/pkg/spec/depreciations_test.go
@@ -32,6 +32,7 @@ func TestDeprecated(t *testing.T) {
 	want.Spec.APIServer = "https://127.0.0.1"
 	want.Spec.Namespace = "new"
 	want.Metadata.Labels["team"] = "cool"
+	want.Metadata.Labels["path"] = "test"
 	want.Metadata.Name = "test"
 
 	assert.Equal(t, want, got)

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -20,14 +20,14 @@ var deprecated = []depreciation{
 }
 
 // Parse parses the json `data` into a `v1alpha1.Config` object.
-// `name` is the name of the environment
-func Parse(data []byte, name string) (*v1alpha1.Config, error) {
+// `baseDir` is the path of the environment
+func Parse(data []byte, baseDir string) (*v1alpha1.Config, error) {
 	v := viper.New()
 	v.SetConfigType("json")
 	if err := v.ReadConfig(bytes.NewReader(data)); err != nil {
 		return nil, err
 	}
-	return parse(v, name)
+	return parse(v, baseDir)
 }
 
 // ParseDir parses the given environments `spec.json` into a `v1alpha1.Config`
@@ -49,12 +49,12 @@ func ParseDir(baseDir string) (*v1alpha1.Config, error) {
 		return nil, err
 	}
 
-	return parse(v, filepath.Base(baseDir))
+	return parse(v, baseDir)
 }
 
 // parse accepts a viper.Viper already loaded with the actual config and
 // unmarshals it onto a v1alpha1.Config
-func parse(v *viper.Viper, name string) (*v1alpha1.Config, error) {
+func parse(v *viper.Viper, baseDir string) (*v1alpha1.Config, error) {
 	var errDepr ErrDeprecated
 
 	// handle deprecated ksonnet spec
@@ -75,7 +75,8 @@ func parse(v *viper.Viper, name string) (*v1alpha1.Config, error) {
 	}
 
 	// set the name field
-	config.Metadata.Name = name
+	config.Metadata.Name = filepath.Base(baseDir)
+	config.Metadata.Labels["path"] = baseDir
 
 	// return depreciation notes in case any exist as well
 	return config, errDepr

--- a/pkg/spec/v1alpha1/config.go
+++ b/pkg/spec/v1alpha1/config.go
@@ -11,6 +11,8 @@ func New() *Config {
 	// default namespace
 	c.Spec.Namespace = "default"
 
+	c.Spec.InjectLabels.Environment = true
+
 	c.Metadata.Labels = make(map[string]string)
 
 	return &c
@@ -33,7 +35,13 @@ type Metadata struct {
 
 // Spec defines Kubernetes properties
 type Spec struct {
-	APIServer    string `json:"apiServer"`
-	Namespace    string `json:"namespace"`
-	DiffStrategy string `json:"diffStrategy,omitempty"`
+	APIServer    string       `json:"apiServer"`
+	Namespace    string       `json:"namespace"`
+	DiffStrategy string       `json:"diffStrategy,omitempty"`
+	InjectLabels InjectLabels `json:"injectLabels,omitempty"`
+}
+
+// InjectLabels defines labels that Tanka will inject into manifests
+type InjectLabels struct {
+	Environment bool `json:"environment,omitempty"`
 }

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -45,7 +45,7 @@ func parse(baseDir string, opts *options) (*ParseResult, error) {
 		return nil, errors.Wrap(err, "evaluating jsonnet")
 	}
 
-	rec, err := kubernetes.Reconcile(raw, env.Spec, opts.targets)
+	rec, err := kubernetes.Reconcile(raw, baseDir, env.Spec, opts.targets)
 	if err != nil {
 		return nil, errors.Wrap(err, "reconciling")
 	}

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -25,7 +25,7 @@ type ParseResult struct {
 }
 
 func (p *ParseResult) newKube() (*kubernetes.Kubernetes, error) {
-	kube, err := kubernetes.New(p.Env.Spec)
+	kube, err := kubernetes.New(*p.Env)
 	if err != nil {
 		return nil, errors.Wrap(err, "connecting to Kubernetes")
 	}
@@ -45,7 +45,7 @@ func parse(baseDir string, opts *options) (*ParseResult, error) {
 		return nil, errors.Wrap(err, "evaluating jsonnet")
 	}
 
-	rec, err := kubernetes.Reconcile(raw, baseDir, env.Spec, opts.targets)
+	rec, err := kubernetes.Reconcile(raw, *env, opts.targets)
 	if err != nil {
 		return nil, errors.Wrap(err, "reconciling")
 	}

--- a/pkg/tanka/status.go
+++ b/pkg/tanka/status.go
@@ -28,7 +28,7 @@ func Status(baseDir string, mods ...Modifier) (*Info, error) {
 		return nil, err
 	}
 
-	r.Env.Spec.DiffStrategy = kube.Spec.DiffStrategy
+	r.Env.Spec.DiffStrategy = kube.Config.Spec.DiffStrategy
 
 	return &Info{
 		Env:       r.Env,

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -85,3 +85,10 @@ func WithApplyAutoApprove(b bool) Modifier {
 		opts.apply.AutoApprove = b
 	}
 }
+
+// WithPrune invokes `kubectl apply` with the `--prune` flag
+func WithPrune(b bool) Modifier {
+	return func(opts *options) {
+		opts.apply.Prune = b
+	}
+}

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -86,8 +86,8 @@ func WithApplyAutoApprove(b bool) Modifier {
 	}
 }
 
-// WithPrune invokes `kubectl apply` with the `--prune` flag
-func WithPrune(b bool) Modifier {
+// WithApplyPrune invokes `kubectl apply` with the `--prune` flag
+func WithApplyPrune(b bool) Modifier {
 	return func(opts *options) {
 		opts.apply.Prune = b
 	}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -27,7 +27,7 @@ func Apply(baseDir string, mods ...Modifier) error {
 		return err
 	}
 
-	diff, err := kube.Diff(p.Resources, kubernetes.DiffOpts{})
+	diff, err := kube.Diff(baseDir, p.Resources, kubernetes.DiffOpts{})
 	if err != nil {
 		return errors.Wrap(err, "diffing")
 	}
@@ -41,7 +41,7 @@ func Apply(baseDir string, mods ...Modifier) error {
 	}
 	fmt.Fprintln(opts.wWarn, *diff)
 
-	return kube.Apply(p.Resources, opts.apply)
+	return kube.Apply(baseDir, p.Resources, opts.apply)
 }
 
 // Diff parses the environment at the given directory (a `baseDir`) and returns
@@ -62,7 +62,7 @@ func Diff(baseDir string, mods ...Modifier) (*string, error) {
 		return nil, err
 	}
 
-	return kube.Diff(p.Resources, opts.diff)
+	return kube.Diff(baseDir, p.Resources, opts.diff)
 }
 
 // Show parses the environment at the given directory (a `baseDir`) and returns


### PR DESCRIPTION
@sh0rez pointed out that `kubectl` supports `--prune` which does the heavy lifting for us.

This PR replaces #117 (which was itself a second try!) and implements #88, using `--prune`. Because of that, it has called the feature "prune" to follow `kubectl`.

This fix is much more in line with what Tanka has been so far - just passing data around rather than doing heavy lifting.