### PR TITLE
kubernetes/client: only apply namespaces if there is a namespace object to apply

### DIFF
--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -13,8 +13,10 @@ import (
 func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
 	// create namespaces first to succeed first try
 	ns := filterNamespace(data)
-	if err := k.apply(ns, opts); err != nil {
-		return err
+	if len(ns) > 0 {
+		if err := k.apply(ns, opts); err != nil {
+			return err
+		}
 	}
 
 	return k.apply(data, opts)


### PR DESCRIPTION
If an environment doesn't define any namespaces, `tk apply` will fail with a "no objects passed to apply" error. This commit adds an extra check to only run that initial namespace apply if the filtered list of objects is non-empty.

Fixes #124.