### PR TITLE
feat(kubernetes): Pruning

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/posener/complete"
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/grafana/tanka/pkg/cli/cmp"
+	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/spec"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
@@ -86,7 +88,15 @@ func main() {
 }
 
 func setupConfiguration(baseDir string) *v1alpha1.Config {
-	config, err := spec.ParseDir(baseDir)
+	_, baseDir, rootDir, err := jpath.Resolve(baseDir)
+	if err != nil {
+		log.Fatalln("Resolving jpath:", err)
+	}
+
+	// name of the environment: relative path from rootDir
+	name, _ := filepath.Rel(rootDir, baseDir)
+
+	config, err := spec.ParseDir(baseDir, name)
 	if err != nil {
 		switch err.(type) {
 		// just run fine without config. Provider features won't work (apply, show, diff)

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -32,7 +32,7 @@ type workflowFlagVars struct {
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
 	fs.StringSliceVarP(&v.targets, "target", "t", nil, "only use the specified objects (Format: <type>/<name>)")
-	fs.BoolVarP(&v.prune.Prune, "prune", "p", true, "automatically remove objects from the cluster that are not present in Jsonnet anymore")
+	fs.BoolVarP(&v.prune.Prune, "prune", "p", false, "automatically remove objects from the cluster that are not present in Jsonnet anymore")
 	fs.BoolVar(&v.prune.AllKinds, "prune-all-kinds", false, "prune all object kinds, not just the most common ones (much slower)")
 	return &v
 }

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/grafana/tanka/pkg/cli/cmp"
+	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/kubernetes/util"
 	"github.com/grafana/tanka/pkg/tanka"
 )
@@ -25,11 +26,14 @@ const (
 
 type workflowFlagVars struct {
 	targets []string
+	prune   kubernetes.PruneOpts
 }
 
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
 	fs.StringSliceVarP(&v.targets, "target", "t", nil, "only use the specified objects (Format: <type>/<name>)")
+	fs.BoolVarP(&v.prune.Prune, "prune", "p", true, "automatically remove objects from the cluster that are not present in Jsonnet anymore")
+	fs.BoolVar(&v.prune.AllKinds, "prune-all-kinds", false, "prune all object kinds, not just the most common ones (much slower)")
 	return &v
 }
 
@@ -50,6 +54,8 @@ func applyCmd() *cobra.Command {
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
 			tanka.WithApplyForce(*force),
 			tanka.WithApplyAutoApprove(*autoApprove),
+			tanka.WithPrune(vars.prune.Prune),
+			tanka.WithPruneAllKinds(vars.prune.AllKinds),
 		)
 		if err != nil {
 			log.Fatalln(err)
@@ -84,6 +90,8 @@ func diffCmd() *cobra.Command {
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
 			tanka.WithDiffStrategy(*diffStrategy),
 			tanka.WithDiffSummarize(*summarize),
+			tanka.WithPrune(vars.prune.Prune),
+			tanka.WithPruneAllKinds(vars.prune.AllKinds),
 		)
 		if err != nil {
 			log.Fatalln(err)

--- a/pkg/jsonnet/imports_test.go
+++ b/pkg/jsonnet/imports_test.go
@@ -1,6 +1,7 @@
 package jsonnet
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,15 +11,15 @@ import (
 // TestTransitiveImports checks that TransitiveImports is able to report all
 // recursive imports of a file
 func TestTransitiveImports(t *testing.T) {
-	imports, err := TransitiveImports("testdata/main.jsonnet")
+	imports, err := TransitiveImports("testdata")
+	fmt.Println(imports)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{
-		"testdata/trees.jsonnet",
-
-		"testdata/trees/apple.jsonnet",
-		"testdata/trees/cherry.jsonnet",
-		"testdata/trees/peach.jsonnet",
-
-		"testdata/trees/generic.libsonnet",
+	assert.Equal(t, []string{
+		"main.jsonnet",
+		"trees.jsonnet",
+		"trees/apple.jsonnet",
+		"trees/cherry.jsonnet",
+		"trees/generic.libsonnet",
+		"trees/peach.jsonnet",
 	}, imports)
 }

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -32,6 +32,11 @@ func (e ErrorFileNotFound) Error() string {
 // This results in predictable imports, as it doesn't matter whether the user called
 // called the command further down tree or not. A little bit like git.
 func Resolve(workdir string) (path []string, base, root string, err error) {
+	workdir, err = filepath.Abs(workdir)
+	if err != nil {
+		return nil, "", "", err
+	}
+
 	root, err = FindParentFile("jsonnetfile.json", workdir, "/")
 	if err != nil {
 		if _, ok := err.(ErrorFileNotFound); ok {

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -11,7 +11,7 @@ import (
 type Client interface {
 	// Get the specified object(s) from the cluster
 	Get(namespace, kind, name string) (manifest.Manifest, error)
-	GetByLabels(namespace string, labels map[string]interface{}) (manifest.List, error)
+	GetByLabels(namespace, kind string, labels map[string]string) (manifest.List, error)
 
 	// Apply the configuration to the cluster. `data` must contain a plaintext
 	// format that is `kubectl-apply(1)` compatible
@@ -27,6 +27,9 @@ type Client interface {
 
 	// Namespaces the cluster currently has
 	Namespaces() (map[string]bool, error)
+
+	// APIResources returns all kinds known by the cluster
+	APIResources() ([]string, error)
 
 	// Info returns known informational data about the client. Best effort based,
 	// fields of `Info` that cannot be stocked with valuable data, e.g.
@@ -50,9 +53,6 @@ type Info struct {
 type ApplyOpts struct {
 	// force allows to ignore checks and force the operation
 	Force bool
-
-	// autoApprove allows to skip the interactive approval
-	AutoApprove bool
 }
 
 // DeleteOpts allow to specify additional parameters for delete operations

--- a/pkg/kubernetes/client/get.go
+++ b/pkg/kubernetes/client/get.go
@@ -12,17 +12,17 @@ import (
 
 // Get retrieves a single Kubernetes object from the cluster
 func (k Kubectl) Get(namespace, kind, name string) (manifest.Manifest, error) {
-	return k.get(namespace, []string{kind, name})
+	return k.get(namespace, kind, []string{name})
 }
 
 // GetByLabels retrieves all objects matched by the given labels from the cluster
-func (k Kubectl) GetByLabels(namespace string, labels map[string]interface{}) (manifest.List, error) {
+func (k Kubectl) GetByLabels(namespace, kind string, labels map[string]string) (manifest.List, error) {
 	lArgs := make([]string, 0, len(labels))
 	for k, v := range labels {
 		lArgs = append(lArgs, fmt.Sprintf("-l=%s=%s", k, v))
 	}
 
-	list, err := k.get(namespace, lArgs)
+	list, err := k.get(namespace, kind, lArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -40,12 +40,17 @@ func (k Kubectl) GetByLabels(namespace string, labels map[string]interface{}) (m
 	return ms, nil
 }
 
-func (k Kubectl) get(namespace string, sel []string) (manifest.Manifest, error) {
-	argv := append([]string{"get",
-		"-o", "json",
-		"-n", namespace,
-		"--context", k.context.Get("name").MustStr(),
-	}, sel...)
+func (k Kubectl) get(namespace, kind string, sel []string) (manifest.Manifest, error) {
+	argv := []string{"get", "-o", "json"}
+	if namespace == "" {
+		argv = append(argv, "--all-namespaces")
+	} else {
+		argv = append(argv, "-n", namespace)
+	}
+	argv = append(argv, "--context", k.context.Get("name").MustStr())
+	argv = append(argv, kind)
+	argv = append(argv, sel...)
+
 	cmd := exec.Command("kubectl", argv...)
 
 	var sout, serr bytes.Buffer

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
@@ -105,6 +106,24 @@ func (k Kubectl) Namespaces() (map[string]bool, error) {
 		namespaces[m.Metadata().Name()] = true
 	}
 	return namespaces, nil
+}
+
+func (k Kubectl) APIResources() ([]string, error) {
+	argv := []string{"api-resources",
+		"--context", k.context.Get("name").MustStr(),
+		"--verbs=list", "-o=name",
+	}
+	cmd := exec.Command("kubectl", argv...)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	return strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n"), nil
 }
 
 // FilterWriter is an io.Writer that discards every message that matches at

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/fatih/color"
@@ -24,6 +25,9 @@ type Kubernetes struct {
 
 	// Diffing
 	differs map[string]Differ // List of diff strategies
+
+	// pruning
+	orphaned manifest.List
 }
 
 // Differ is responsible for comparing the given manifests to the cluster and
@@ -67,7 +71,15 @@ func New(c v1alpha1.Config) (*Kubernetes, error) {
 }
 
 // ApplyOpts allow set additional parameters for the apply operation
-type ApplyOpts client.ApplyOpts
+type ApplyOpts struct {
+	PruneOpts
+
+	// force allows to ignore checks and force the operation
+	Force bool
+
+	// autoApprove allows to skip the interactive approval
+	AutoApprove bool
+}
 
 // Apply receives a state object generated using `Reconcile()` and may apply it to the target system
 func (k *Kubernetes) Apply(state manifest.List, opts ApplyOpts) error {
@@ -90,11 +102,28 @@ func (k *Kubernetes) Apply(state manifest.List, opts ApplyOpts) error {
 			return err
 		}
 	}
-	return k.ctl.Apply(state, client.ApplyOpts(opts))
+
+	if err := k.ctl.Apply(state, client.ApplyOpts{
+		Force: opts.Force,
+	}); err != nil {
+		return err
+	}
+
+	// no prune? exit early
+	if !opts.PruneOpts.Prune {
+		return nil
+	}
+
+	if err := k.prune(state, opts.PruneOpts); err != nil {
+		return errors.Wrap(err, "removing orphaned resources")
+	}
+	return nil
 }
 
 // DiffOpts allow to specify additional parameters for diff operations
 type DiffOpts struct {
+	PruneOpts
+
 	// Use `diffstat(1)` to create a histogram of the changes instead
 	Summarize bool
 
@@ -109,19 +138,90 @@ func (k *Kubernetes) Diff(state manifest.List, opts DiffOpts) (*string, error) {
 		strategy = opts.Strategy
 	}
 
-	d, err := k.differs[strategy](state)
-	switch {
-	case err != nil:
+	diff, err := multiDiff(state, []Differ{
+		k.differs[strategy],
+		k.diffOrphaned(opts.PruneOpts.AllKinds),
+	})
+	if err != nil {
 		return nil, err
-	case d == nil:
-		return nil, nil
 	}
 
 	if opts.Summarize {
-		return util.Diffstat(*d)
+		return util.Diffstat(*diff)
 	}
 
-	return d, nil
+	return diff, nil
+}
+
+func multiDiff(state manifest.List, differs []Differ) (*string, error) {
+	diffs := make(chan (*string))
+	errs := make(chan (error))
+
+	for _, diff := range differs {
+		go diffParallel(diff, state, diffs, errs)
+	}
+
+	var d string
+	var lastErr error
+
+	for _ = range differs {
+		select {
+		case result := <-diffs:
+			if result == nil {
+				continue
+			}
+			d += *result
+		case err := <-errs:
+			lastErr = err
+		}
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	if d == "" {
+		return nil, nil
+	}
+	return &d, nil
+}
+
+func diffParallel(diff Differ, state manifest.List, results chan (*string), errs chan (error)) {
+	r, err := diff(state)
+	if err != nil {
+		errs <- err
+		return
+	}
+	results <- r
+}
+
+func (k *Kubernetes) diffOrphaned(all bool) Differ {
+	return func(state manifest.List) (*string, error) {
+		orphan, err := k.listOrphaned(state, all)
+		if err != nil {
+			return nil, err
+		}
+		var diffs string
+		for _, o := range orphan {
+			// diff against empty string = looks like removed
+			diffStr, err := util.DiffStr(util.DiffName(o), o.String(), "")
+			if err != nil {
+				return nil, errors.Wrap(err, "invoking diff")
+			}
+			if diffStr != "" {
+				diffStr += "\n"
+			}
+			diffs += diffStr
+		}
+
+		diffs = strings.TrimSuffix(diffs, "\n")
+
+		if diffs == "" {
+			return nil, nil
+		}
+
+		return &diffs, nil
+	}
 }
 
 // Info about the client, etc.

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -138,10 +138,13 @@ func (k *Kubernetes) Diff(state manifest.List, opts DiffOpts) (*string, error) {
 		strategy = opts.Strategy
 	}
 
-	diff, err := multiDiff(state, []Differ{
-		k.differs[strategy],
-		k.diffOrphaned(opts.PruneOpts.AllKinds),
-	})
+	differs := []Differ{k.differs[strategy]}
+	if opts.PruneOpts.Prune {
+		differs = append(differs, k.diffOrphaned(opts.PruneOpts.AllKinds))
+	}
+
+	diff, err := multiDiff(state, differs)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -167,7 +167,7 @@ func multiDiff(state manifest.List, differs []Differ) (*string, error) {
 	var d string
 	var lastErr error
 
-	for _ = range differs {
+	for range differs {
 		select {
 		case result := <-diffs:
 			if result == nil {

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -88,7 +88,9 @@ func TestReconcile(t *testing.T) {
 
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			got, err := Reconcile(c.deep.(map[string]interface{}), c.spec, c.targets)
+			config := v1alpha1.New()
+			config.Spec = c.spec
+			got, err := Reconcile(c.deep.(map[string]interface{}), *config, c.targets)
 
 			require.Equal(t, c.err, err)
 			assert.ElementsMatch(t, c.flat, got)
@@ -99,7 +101,7 @@ func TestReconcile(t *testing.T) {
 func TestReconcileOrder(t *testing.T) {
 	got := make([]manifest.List, 10)
 	for i := 0; i < 10; i++ {
-		r, err := Reconcile(testDataDeep().deep.(map[string]interface{}), v1alpha1.Spec{}, nil)
+		r, err := Reconcile(testDataDeep().deep.(map[string]interface{}), *v1alpha1.New(), nil)
 		require.NoError(t, err)
 		got[i] = r
 	}

--- a/pkg/kubernetes/manifest/errors.go
+++ b/pkg/kubernetes/manifest/errors.go
@@ -21,7 +21,7 @@ func (s *SchemaError) Error() string {
 		e += ", " + k
 	}
 	e = strings.TrimPrefix(e, ", ")
-	return fmt.Sprintf("%s missing or invalid fields: %s", s.name, e)
+	return fmt.Sprintf("%smissing or invalid fields: %s", s.name, e)
 }
 
 func (s *SchemaError) add(field string) {
@@ -38,6 +38,6 @@ func (s *SchemaError) Missing(field string) bool {
 
 // WithName inserts a path into the error message
 func (s *SchemaError) WithName(name string) *SchemaError {
-	s.name = name
+	s.name = fmt.Sprintf("%s has ", name)
 	return s
 }

--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -122,28 +122,30 @@ func (m Metadata) Namespace() string {
 
 // HasLabels returns whether the manifest has labels
 func (m Metadata) HasLabels() bool {
-	return m2o(m).Get("labels").IsMSI()
+	_, ok := m["labels"].(map[string]string)
+	return ok
 }
 
 // Labels of the manifest
-func (m Metadata) Labels() map[string]interface{} {
+func (m Metadata) Labels() map[string]string {
 	if !m.HasLabels() {
-		return make(map[string]interface{})
+		m["labels"] = make(map[string]string)
 	}
-	return m["labels"].(map[string]interface{})
+	return m["labels"].(map[string]string)
 }
 
-// HasAnnotations returns whether the manifest has annotations
+// HasAnnotations returns whether the manifest has labels
 func (m Metadata) HasAnnotations() bool {
-	return m2o(m).Get("annotations").IsMSI()
+	_, ok := m["annotations"].(map[string]string)
+	return ok
 }
 
 // Annotations of the manifest
-func (m Metadata) Annotations() map[string]interface{} {
+func (m Metadata) Annotations() map[string]string {
 	if !m.HasAnnotations() {
-		return make(map[string]interface{})
+		m["annotations"] = make(map[string]string)
 	}
-	return m["annotations"].(map[string]interface{})
+	return m["annotations"].(map[string]string)
 }
 
 // List of individual Manifests

--- a/pkg/kubernetes/prune.go
+++ b/pkg/kubernetes/prune.go
@@ -92,6 +92,14 @@ func (k *Kubernetes) listOrphaned(state manifest.List, all bool) (orphaned manif
 		select {
 		case list := <-results:
 			for _, m := range list {
+				// ComponentStatus resource is broken in Kubernetes versions
+				// below 1.17, it will be returned even if the label does not
+				// match. Ignoring it here is fine, as it is an internal object
+				// type.
+				if m.APIVersion() == "v1" && m.Kind() == "ComponentStatus" {
+					continue
+				}
+
 				if state.Has(m) {
 					continue
 				}

--- a/pkg/kubernetes/prune.go
+++ b/pkg/kubernetes/prune.go
@@ -1,0 +1,122 @@
+package kubernetes
+
+import (
+	"github.com/grafana/tanka/pkg/kubernetes/client"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/pkg/errors"
+)
+
+var defaultPruneKinds = []string{
+	// core
+	"ConfigMap",
+	"Endpoints",
+	"Namespace",
+	"PersistentVolumeClaim",
+	"PersistentVolume",
+	"Pod",
+	"ReplicationController",
+	"Secret",
+	"ServiceAccount",
+	"Service",
+
+	// jobs
+	"DaemonSet",
+	"Deployment",
+	"ReplicaSet",
+	"StatefulSet",
+
+	// batch
+	"Job",
+	"CronJob",
+
+	// networking
+	"Ingress",
+
+	// rbac
+	"ClusterRole",
+	"ClusterRoleBinding",
+	"Role",
+	"RoleBinding",
+}
+
+type PruneOpts struct {
+	// Whether to remove orphaned objects from the cluster
+	Prune bool
+
+	// Check all kinds instead of only the most common ones
+	AllKinds bool
+
+	// Skip verification and force deleting
+	Force bool
+}
+
+func (k *Kubernetes) prune(state manifest.List, opts PruneOpts) error {
+	orphan, err := k.listOrphaned(state, opts.AllKinds)
+	if err != nil {
+		return errors.Wrap(err, "listing orphaned objects")
+	}
+
+	for _, o := range orphan {
+		k.ctl.Delete(o.Metadata().Namespace(), o.Kind(), o.Metadata().Name(), client.DeleteOpts{
+			Force: opts.Force,
+		})
+	}
+	return nil
+}
+
+// listOrphaned returns all resources known to the cluster not present in
+// Jsonnet
+func (k *Kubernetes) listOrphaned(state manifest.List, all bool) (orphaned manifest.List, err error) {
+	if k.orphaned != nil {
+		return k.orphaned, nil
+	}
+
+	kinds := defaultPruneKinds
+	if all {
+		kinds, err = k.ctl.APIResources()
+		if err != nil {
+			return nil, errors.Wrap(err, "listing apiResources")
+		}
+	}
+
+	results := make(chan (manifest.List))
+	errs := make(chan (error))
+
+	// list all objects matching our label
+	for _, kind := range kinds {
+		go k.parallelGetByLabels(kind, k.Env.Metadata.NameLabel(), results, errs)
+	}
+
+	var lastErr error
+	for _ = range kinds {
+		select {
+		case list := <-results:
+			for _, m := range list {
+				if state.Has(m) {
+					continue
+				}
+				orphaned = append(orphaned, m)
+			}
+		case err := <-errs:
+			lastErr = err
+		}
+	}
+	close(results)
+	close(errs)
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	return orphaned, nil
+}
+
+func (k *Kubernetes) parallelGetByLabels(kind, envName string, r chan (manifest.List), e chan (error)) {
+	list, err := k.ctl.GetByLabels("", kind, map[string]string{
+		LabelEnvironment: envName,
+	})
+	if err != nil {
+		e <- errors.Wrapf(err, "getting orphans of kind '%s':", kind)
+	}
+	r <- list
+}

--- a/pkg/kubernetes/prune.go
+++ b/pkg/kubernetes/prune.go
@@ -88,7 +88,7 @@ func (k *Kubernetes) listOrphaned(state manifest.List, all bool) (orphaned manif
 	}
 
 	var lastErr error
-	for _ = range kinds {
+	for range kinds {
 		select {
 		case list := <-results:
 			for _, m := range list {

--- a/pkg/kubernetes/reconcile.go
+++ b/pkg/kubernetes/reconcile.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/objx"
-	funk "github.com/thoas/go-funk"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/grafana/tanka/pkg/kubernetes/util"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
 
@@ -48,18 +48,7 @@ func Reconcile(raw map[string]interface{}, config v1alpha1.Config, targets []*re
 	}
 
 	// optionally filter the working set of objects
-	if len(targets) > 0 {
-		tmp := funk.Filter(out, func(i interface{}) bool {
-			p := objectspec(i.(manifest.Manifest))
-			for _, t := range targets {
-				if t.MatchString(p) {
-					return true
-				}
-			}
-			return false
-		}).([]manifest.Manifest)
-		out = manifest.List(tmp)
-	}
+	out = util.FilterTargets(out, targets)
 
 	// Stable output order
 	sort.SliceStable(out, func(i int, j int) bool {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -3,7 +3,6 @@ package spec
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -32,7 +31,7 @@ func Parse(data []byte, name string) (*v1alpha1.Config, error) {
 
 // ParseDir parses the given environments `spec.json` into a `v1alpha1.Config`
 // object with the name set to the directories name
-func ParseDir(baseDir string) (*v1alpha1.Config, error) {
+func ParseDir(baseDir, name string) (*v1alpha1.Config, error) {
 	fi, err := os.Stat(baseDir)
 	if err != nil {
 		return nil, err
@@ -49,7 +48,7 @@ func ParseDir(baseDir string) (*v1alpha1.Config, error) {
 		return nil, err
 	}
 
-	return parse(v, filepath.Base(baseDir))
+	return parse(v, name)
 }
 
 // parse accepts a viper.Viper already loaded with the actual config and

--- a/pkg/spec/v1alpha1/config.go
+++ b/pkg/spec/v1alpha1/config.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import "strings"
+
 // New creates a new Config object with internal values already set
 func New() *Config {
 	c := Config{}
@@ -8,8 +10,9 @@ func New() *Config {
 	c.APIVersion = "tanka.dev/v1alpha1"
 	c.Kind = "Environment"
 
-	// default namespace
+	// defaults
 	c.Spec.Namespace = "default"
+	c.Spec.InjectLabels.Environment = true
 
 	c.Metadata.Labels = make(map[string]string)
 
@@ -25,15 +28,26 @@ type Config struct {
 	Spec       Spec     `json:"spec"`
 }
 
-// Metadata is meant for humans and not parsed
+// Metadata is meant for humans and not parsed Name is an exception to this
+// rule, as it's value is discovered at runtime from the directories name.
 type Metadata struct {
 	Name   string            `json:"name,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
+func (m Metadata) NameLabel() string {
+	return strings.Replace(m.Name, "/", ".", -1)
+}
+
 // Spec defines Kubernetes properties
 type Spec struct {
-	APIServer    string `json:"apiServer"`
-	Namespace    string `json:"namespace"`
-	DiffStrategy string `json:"diffStrategy,omitempty"`
+	APIServer    string       `json:"apiServer"`
+	Namespace    string       `json:"namespace"`
+	DiffStrategy string       `json:"diffStrategy,omitempty"`
+	InjectLabels InjectLabels `json:"injectLabels,omitempty"`
+}
+
+// InjectLabels defines labels that Tanka will inject into manifests
+type InjectLabels struct {
+	Environment bool `json:"environment,omitempty"`
 }

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -25,7 +25,7 @@ type ParseResult struct {
 }
 
 func (p *ParseResult) newKube() (*kubernetes.Kubernetes, error) {
-	kube, err := kubernetes.New(p.Env.Spec)
+	kube, err := kubernetes.New(*p.Env)
 	if err != nil {
 		return nil, errors.Wrap(err, "connecting to Kubernetes")
 	}

--- a/pkg/tanka/status.go
+++ b/pkg/tanka/status.go
@@ -28,7 +28,7 @@ func Status(baseDir string, mods ...Modifier) (*Info, error) {
 		return nil, err
 	}
 
-	r.Env.Spec.DiffStrategy = kube.Spec.DiffStrategy
+	r.Env.Spec.DiffStrategy = kube.Env.Spec.DiffStrategy
 
 	return &Info{
 		Env:       r.Env,

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -24,9 +24,13 @@ func parseModifiers(mods []Modifier) *options {
 		mod(o)
 	}
 
+	// finish prune object
+	o.prune.Targets = o.targets
 	o.prune.Force = o.apply.Force
-	o.apply.PruneOpts = o.prune
-	o.diff.PruneOpts = o.prune
+
+	// add finished object to apply and diff (they need this info as well)
+	o.apply.PruneOpts = &o.prune
+	o.diff.PruneOpts = &o.prune
 
 	return o
 }

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -27,7 +27,9 @@ func Apply(baseDir string, mods ...Modifier) error {
 		return err
 	}
 
-	diff, err := kube.Diff(p.Resources, kubernetes.DiffOpts{})
+	diff, err := kube.Diff(p.Resources, kubernetes.DiffOpts{
+		PruneOpts: opts.prune,
+	})
 	if err != nil {
 		return errors.Wrap(err, "diffing")
 	}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -27,9 +27,7 @@ func Apply(baseDir string, mods ...Modifier) error {
 		return err
 	}
 
-	diff, err := kube.Diff(p.Resources, kubernetes.DiffOpts{
-		PruneOpts: opts.prune,
-	})
+	diff, err := kube.Diff(p.Resources, kubernetes.DiffOpts{})
 	if err != nil {
 		return errors.Wrap(err, "diffing")
 	}


### PR DESCRIPTION
This PR is another take on implementing a garbage collection of resources, that are no longer present in the Jsonnet code.

@malcolmholmes already experimented with using a label and removing resources (#117) and `kubectl apply --prune` (#123). Both attempts had their shortcomings (performance, reliability).

Just out of interest I tried what I could come up with and so far I think this is robust enough to be used in production:

1. we label each resource with `tanka.dev/environment: <relative-path-from-project-root>`
2. on apply / diff we get all most common resources (the same list `kubectl apply --prune` uses) and check if there is anything labeled in there we don't know about
3. These will be marked as being deleted in diff
4. On apply, they are deleted.
5. This behavior defaults to **enabled**, as it ensures that the Jsonnet is declarative
6. It can be disabled by using `--prune=false`, labeling can be disabled using `spec.injectLabels.environment`.

Can I get some opinions on this @rfratto @gouthamve @tomwilkie?

Co-authored-by: Malcolm Holmes <mdh@odoko.co.uk>