### PR TITLE
Unify docker tagging style

### DIFF
--- a/.drone/docker-manifest.tmpl
+++ b/.drone/docker-manifest.tmpl
@@ -1,4 +1,4 @@
-image: grafana/tanka:{{#if build.tag}}{{build.tag}}{{else}}latest{{/if}}
+image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -6,16 +6,16 @@ tags:
 {{/each}}
 {{/if}}
 manifests:
-  - image: grafana/tanka:{{#if build.tag}}{{build.tag}}-{{/if}}amd64
+  - image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}amd64
     platform:
       architecture: amd64
       os: linux
-  - image: grafana/tanka:{{#if build.tag}}{{build.tag}}-{{/if}}arm64
+  - image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}arm64
     platform:
       architecture: arm64
       os: linux
       variant: v8
-  - image: grafana/tanka:{{#if build.tag}}{{build.tag}}-{{/if}}arm
+  - image: grafana/tanka:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}arm
     platform:
       architecture: arm
       os: linux

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -62,7 +62,7 @@ steps:
     api_key:
       from_secret: GITHUB_TOKEN
     files: dist/*
-    note: "This is release ${DRONE_TAG} of Tanka (`tk`). Check out the [CHANGELOG](CHANGELOG.md) for detailed release notes.\n## Install instructions\n\n#### Binary:\n```bash\n# download the binary (adapt os and arch as needed)\n$ curl -fSL -o \"/usr/local/bin/tk\" \"https://github.com/sh0rez/tanka/releases/download/${DRONE_TAG}/tk-linux-amd64\"\n\n# make it executable\n$ chmod a+x \"/usr/local/bin/tk\"\n\n# have fun :)\n$ tk --help\n```\n\n#### Docker container:\nhttps://hub.docker.com/r/grafana/tanka\n```bash\n$ docker pull grafana/tanka:${DRONE_TAG}\n```\n"
+    note: "This is release ${DRONE_TAG} of Tanka (`tk`). Check out the [CHANGELOG](CHANGELOG.md) for detailed release notes.\n## Install instructions\n\n#### Binary:\n```bash\n# download the binary (adapt os and arch as needed)\n$ curl -fSL -o \"/usr/local/bin/tk\" \"https://github.com/sh0rez/tanka/releases/download/${DRONE_TAG}/tk-linux-amd64\"\n\n# make it executable\n$ chmod a+x \"/usr/local/bin/tk\"\n\n# have fun :)\n$ tk --help\n```\n\n#### Docker container:\nhttps://hub.docker.com/r/grafana/tanka\n```bash\n$ docker pull grafana/tanka:${DRONE_TAG#v}\n```\n"
     title: ${DRONE_TAG}
 
 volumes:

--- a/.drone/release-note.md
+++ b/.drone/release-note.md
@@ -16,5 +16,5 @@ $ tk --help
 #### Docker container:
 https://hub.docker.com/r/grafana/tanka
 ```bash
-$ docker pull grafana/tanka:${DRONE_TAG}
+$ docker pull grafana/tanka:${DRONE_TAG#v}
 ```


### PR DESCRIPTION
In #90 we broke docker tagging, because we instructed the template to leave the v prefix, drone docker removes.

This PR reverts the invalid change and adapts the release note, so it says `grafana/tanka:1.2.3`

Fixes https://github.com/grafana/tanka/issues/129