### PR TITLE
feat(cli): set env server from context

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -82,7 +82,7 @@ func envSetCmd() *cobra.Command {
 		if cmd.Flags().Changed("server-from-context") {
 			server, err := client.IPFromContext(tmp.Spec.APIServer)
 			if err != nil {
-				log.Fatalln("Resolving IP from context: %s", err)
+				log.Fatalf("Resolving IP from context: %s", err)
 			}
 			tmp.Spec.APIServer = server
 		}


### PR DESCRIPTION
Allows to set the `spec.apiServer` of an `Environment` using an already known
context:

```bash
$ tk env set environments/default --server-from-context eu-west1
```

The `--server-from-context` flag is autocompleted using data from `kubectl
config get-contexts`