### PR TITLE
fix(kubernetes): ignore nil during reconcile

### DIFF
--- a/pkg/kubernetes/reconcile.go
+++ b/pkg/kubernetes/reconcile.go
@@ -99,9 +99,13 @@ func walkJSON(deep interface{}, extracted map[string]manifest.Manifest, path tra
 
 	// walk it
 	for key, d := range deep.(map[string]interface{}) {
-		if key == "__ksonnet" {
+		switch {
+		case key == "__ksonnet": // exclude ksonnet object
+			continue
+		case d == nil: // result from false if condition in Jsonnet
 			continue
 		}
+
 		path := append(path, key)
 
 		if _, ok := d.(map[string]interface{}); !ok {

--- a/pkg/kubernetes/reconcile_test.go
+++ b/pkg/kubernetes/reconcile_test.go
@@ -34,6 +34,15 @@ func TestExtract(t *testing.T) {
 			name: "array",
 			data: testDataArray(),
 		},
+		{
+			name: "nil",
+			data: func() testData {
+				d := testDataRegular()
+				d.deep.(map[string]interface{})["disabledObject"] = nil
+				return d
+			}(),
+			err: nil, // we expect no error, just the result of testDataRegular
+		},
 	}
 
 	for _, c := range tests {


### PR DESCRIPTION
While extracting the objects from the Jsonnet output, Tanka was not correctly
dealing with keys that were set to `nil`, leading those to be classified as
invalid objects, while they were no objects at all.

Such a case, where a key is explicitely set to `nil` is Jsonnet if:

```jsonnet
{
  key: if false then "ouch"
}
```

Because the condition is false, Jsonnet adds an implicit `else null`.

Fixes #160 