### PR TITLE
feat(jsonnet): expose Environment at runtime

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -35,20 +35,3 @@ func evalCmd() *cobra.Command {
 
 	return cmd
 }
-
-// func eval(workdir string) (string, error) {
-// 	// pwd, err := filepath.Abs(workdir)
-// 	// if err != nil {
-// 	// 	return "", err
-// 	// }
-// 	// _, baseDir, _, err := jpath.Resolve(pwd)
-// 	// if err != nil {
-// 	// 	return "", errors.Wrap(err, "resolving jpath")
-// 	// }
-// 	// json, err := jsonnet.EvaluateFile(filepath.Join(baseDir, "main.jsonnet"))
-// 	// if err != nil {
-// 	// 	return "", err
-// 	// }
-
-// 	return json, nil
-// }

--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -1,14 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
-	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/grafana/tanka/pkg/jsonnet"
-	"github.com/grafana/tanka/pkg/jsonnet/jpath"
+	"github.com/grafana/tanka/pkg/tanka"
 )
 
 func evalCmd() *cobra.Command {
@@ -22,28 +20,35 @@ func evalCmd() *cobra.Command {
 	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		json, err := eval(args[0])
+		raw, _, err := tanka.Eval(args[0], nil)
 		if err != nil {
-			log.Fatalln("evaluating:", err)
+			log.Fatalln(err, nil)
 		}
-		pageln(json)
+
+		out, err := json.MarshalIndent(raw, "", "  ")
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		pageln(string(out))
 	}
 
 	return cmd
 }
 
-func eval(workdir string) (string, error) {
-	pwd, err := filepath.Abs(workdir)
-	if err != nil {
-		return "", err
-	}
-	_, baseDir, _, err := jpath.Resolve(pwd)
-	if err != nil {
-		return "", errors.Wrap(err, "resolving jpath")
-	}
-	json, err := jsonnet.EvaluateFile(filepath.Join(baseDir, "main.jsonnet"))
-	if err != nil {
-		return "", err
-	}
-	return json, nil
-}
+// func eval(workdir string) (string, error) {
+// 	// pwd, err := filepath.Abs(workdir)
+// 	// if err != nil {
+// 	// 	return "", err
+// 	// }
+// 	// _, baseDir, _, err := jpath.Resolve(pwd)
+// 	// if err != nil {
+// 	// 	return "", errors.Wrap(err, "resolving jpath")
+// 	// }
+// 	// json, err := jsonnet.EvaluateFile(filepath.Join(baseDir, "main.jsonnet"))
+// 	// if err != nil {
+// 	// 	return "", err
+// 	// }
+
+// 	return json, nil
+// }

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/tanka/pkg/jsonnet/native"
 )
 
+// Modifiers allow to set optional paramters on the Jsonnet VM.
+// See jsonnet.With* for this.
 type Modifier func(vm *jsonnet.VM) error
 
 // EvaluateFile opens the file, reads it into memory and evaluates it afterwards (`Evaluate()`)
@@ -45,6 +47,8 @@ func Evaluate(sonnet string, jpath []string, mods ...Modifier) (string, error) {
 	return vm.EvaluateSnippet("main.jsonnet", sonnet)
 }
 
+// WithExtCode allows to make the supplied snippet available to Jsonnet as an
+// ext var
 func WithExtCode(key, code string) Modifier {
 	return func(vm *jsonnet.VM) error {
 		vm.ExtCode(key, code)

--- a/pkg/jsonnet/importer.go
+++ b/pkg/jsonnet/importer.go
@@ -37,8 +37,8 @@ func NewExtendedImporter(jpath []string) *ExtendedImporter {
 		fi: &jsonnet.FileImporter{
 			JPaths: jpath,
 		},
-		processors:   []ImportProcessor{yamlProcessor},
 		interceptors: []ImportInterceptor{tkInterceptor},
+		processors:   []ImportProcessor{yamlProcessor},
 	}
 }
 
@@ -79,6 +79,7 @@ func (i *ExtendedImporter) Import(importedFrom, importedPath string) (contents j
 	return contents, foundAt, nil
 }
 
+// tkInterceptor provides `tk.libsonnet` from memory (builtin)
 func tkInterceptor(importedFrom, importedPath string) (contents *string, foundAt string, err error) {
 	if importedPath != "tk" {
 		return nil, "", nil
@@ -88,6 +89,8 @@ func tkInterceptor(importedFrom, importedPath string) (contents *string, foundAt
 	return &s, filepath.Join(locationInternal, "tk.libsonnet"), nil
 }
 
+// yamlProcessor catches yaml files and converts them to JSON so that they can
+// be used with `import`
 func yamlProcessor(contents, foundAt string) (c *string, err error) {
 	ext := filepath.Ext(foundAt)
 	if yaml := ext == ".yaml" || ext == ".yml"; !yaml {

--- a/pkg/jsonnet/importer.go
+++ b/pkg/jsonnet/importer.go
@@ -1,21 +1,34 @@
 package jsonnet
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"path/filepath"
+	"strings"
 
 	jsonnet "github.com/google/go-jsonnet"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
+const locationInternal = "<internal>"
+
 // ExtendedImporter wraps jsonnet.FileImporter to add additional functionality:
 // - `import "file.yaml"`
+// - `import "tk"`
 type ExtendedImporter struct {
-	fi *jsonnet.FileImporter
+	fi           *jsonnet.FileImporter
+	interceptors []ImportInterceptor
+	processors   []ImportProcessor
 }
+
+// ImportInterceptor are executed before the actual importing. If they return
+// something, this value is used.
+type ImportInterceptor func(importedFrom, importedPath string) (c *string, foundAt string, err error)
+
+// ImportProcessor are executed after the file import and may modify the result
+// further
+type ImportProcessor func(contents, foundAt string) (c *string, err error)
 
 // NewExtendedImporter returns a new instance of ExtendedImporter with the
 // correct jpaths set up
@@ -24,44 +37,86 @@ func NewExtendedImporter(jpath []string) *ExtendedImporter {
 		fi: &jsonnet.FileImporter{
 			JPaths: jpath,
 		},
+		processors:   []ImportProcessor{yamlProcessor},
+		interceptors: []ImportInterceptor{tkInterceptor},
 	}
 }
 
 // Import implements the functionality offered by the ExtendedImporter
 func (i *ExtendedImporter) Import(importedFrom, importedPath string) (contents jsonnet.Contents, foundAt string, err error) {
+	// check if an interceptor handles this
+	for _, interceptor := range i.interceptors {
+		c, foundAt, err := interceptor(importedFrom, importedPath)
+		switch {
+		case err != nil:
+			return jsonnet.Contents{}, "", err
+		case c == nil:
+			continue
+		default:
+			return jsonnet.MakeContents(*c), foundAt, nil
+		}
+	}
+
 	// regularly import
 	contents, foundAt, err = i.fi.Import(importedFrom, importedPath)
 	if err != nil {
 		return jsonnet.Contents{}, "", err
 	}
 
-	// if yaml -> convert to json
-	ext := filepath.Ext(foundAt)
-	if ext == ".yaml" || ext == ".yml" {
-		ret := []interface{}{}
-		d := yaml.NewDecoder(bytes.NewReader([]byte(contents.String())))
-		for {
-			var doc interface{}
-			if err := d.Decode(&doc); err != nil {
-				if err == io.EOF {
-					break
-				}
-				return jsonnet.Contents{}, "", errors.Wrapf(err, "unmarshalling yaml import '%s'", foundAt)
-			}
-			ret = append(ret, doc)
+	// check if needs postprocessing
+	for _, processor := range i.processors {
+		c, err := processor(contents.String(), foundAt)
+		switch {
+		case err != nil:
+			return jsonnet.Contents{}, "", err
+		case c == nil:
+			continue
+		default:
+			return jsonnet.MakeContents(*c), foundAt, nil
 		}
-		var data interface{}
-		if len(ret) == 1 {
-			data = ret[0]
-		} else {
-			data = ret
-		}
-		out, err := json.Marshal(data)
-		if err != nil {
-			return jsonnet.Contents{}, "", errors.Wrapf(err, "converting '%s' to json", foundAt)
-		}
-		contents = jsonnet.MakeContents(string(out))
 	}
 
-	return
+	return contents, foundAt, nil
+}
+
+func tkInterceptor(importedFrom, importedPath string) (contents *string, foundAt string, err error) {
+	if importedPath != "tk" {
+		return nil, "", nil
+	}
+
+	s := tkLibsonnet
+	return &s, filepath.Join(locationInternal, "tk.libsonnet"), nil
+}
+
+func yamlProcessor(contents, foundAt string) (c *string, err error) {
+	ext := filepath.Ext(foundAt)
+	if yaml := ext == ".yaml" || ext == ".yml"; !yaml {
+		return nil, nil
+	}
+
+	ret := []interface{}{}
+	d := yaml.NewDecoder(strings.NewReader(contents))
+	for {
+		var doc interface{}
+		if err := d.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, errors.Wrapf(err, "unmarshalling yaml import '%s'", foundAt)
+		}
+		ret = append(ret, doc)
+	}
+
+	var data interface{} = ret
+	if len(ret) == 1 {
+		data = ret[0]
+	}
+
+	out, err := json.Marshal(data)
+	if err != nil {
+		return nil, errors.Wrapf(err, "converting '%s' to json", foundAt)
+	}
+
+	s := string(out)
+	return &s, nil
 }

--- a/pkg/jsonnet/tk.libsonnet.go
+++ b/pkg/jsonnet/tk.libsonnet.go
@@ -1,4 +1,3 @@
-// -*- php; -*-
 package jsonnet
 
 const tkLibsonnet = `

--- a/pkg/jsonnet/tk.libsonnet.go
+++ b/pkg/jsonnet/tk.libsonnet.go
@@ -1,0 +1,8 @@
+// -*- php; -*-
+package jsonnet
+
+const tkLibsonnet = `
+{
+  env: std.extVar("tanka.dev/environment"),
+}
+`

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
 
+const APIGroup = "tanka.dev"
+
 // list of deprecated config keys and their alternatives
 // however, they still work and are aliased internally
 var deprecated = []depreciation{


### PR DESCRIPTION
This change allows to use the parsed `spec.json` contents at runtime:

```jsonnet
local tk = import "tk";

{
  env: tk.env,
}
```

It also introduces a Tanka native API extension (`import "tk"`), which serves as
a wrapper for all `std.extVar` and `std.nativeFunc` we use, so that we can make
breaking changes to those internals, without affecting the public API.

:warning: **There is a bug at the moment, that the `metadata.name` of the Environment is the CLI argument and not the actual name. This is fixed in #131 but not merged yet**

Fixes #161 