### PR TITLE
fix(jsonnet): disable import .yaml for importstr

### DIFF
--- a/pkg/jsonnet/importer.go
+++ b/pkg/jsonnet/importer.go
@@ -39,7 +39,10 @@ func NewExtendedImporter(jpath []string) *ExtendedImporter {
 				JPaths: jpath,
 			})},
 		processors: []importProcessor{
-			yamlProcessor,
+			// TODO: re-enable this once we can without side-effects
+			// (https://github.com/grafana/tanka/issues/135)
+			//
+			// yamlProcessor,
 		},
 	}
 }


### PR DESCRIPTION
The current implementation of this feature broke support for using
`importstr`. While extending Jsonnet is nice, we must stay 100%
compatible, which we are not at the moment.