### PR TITLE
feat(cli): extVars

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/grafana/tanka/pkg/tanka"
 )
@@ -19,8 +22,13 @@ func evalCmd() *cobra.Command {
 		},
 	}
 
+	getExtCode := extCodeParser(cmd.Flags())
+
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		raw, _, err := tanka.Eval(args[0], nil)
+		raw, err := tanka.Eval(args[0],
+			tanka.WithExtCode(getExtCode()),
+		)
+
 		if err != nil {
 			log.Fatalln(err, nil)
 		}
@@ -34,4 +42,31 @@ func evalCmd() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func extCodeParser(fs *pflag.FlagSet) func() map[string]string {
+	// need to use StringArray instead of StringSlice, because pflag attempts to
+	// parse StringSlice using the csv parser, which breaks when passing objects
+	values := fs.StringArrayP("extCode", "e", nil, "Inject any Jsonnet from the outside (Format: key=<code>)")
+	strs := fs.StringArray("extVar", nil, "Inject a string from the outside (Format: key=value)")
+
+	return func() map[string]string {
+		m := make(map[string]string)
+		for _, s := range *values {
+			split := strings.SplitN(s, "=", 2)
+			if len(split) != 2 {
+				log.Fatalln("extCode argument has wrong format:", s+".", "Expected 'key=<code>'")
+			}
+			m[split[0]] = split[1]
+		}
+
+		for _, s := range *strs {
+			split := strings.SplitN(s, "=", 2)
+			if len(split) != 2 {
+				log.Fatalln("extVar argument has wrong format:", s+".", "Expected 'key=value'")
+			}
+			m[split[0]] = fmt.Sprintf(`"%s"`, split[1])
+		}
+		return m
+	}
 }

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -45,9 +45,12 @@ func applyCmd() *cobra.Command {
 	vars := workflowFlags(cmd.Flags())
 	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	getExtCode := extCodeParser(cmd.Flags())
+
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		err := tanka.Apply(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
+			tanka.WithExtCode(getExtCode()),
 			tanka.WithApplyForce(*force),
 			tanka.WithApplyAutoApprove(*autoApprove),
 		)
@@ -79,9 +82,12 @@ func diffCmd() *cobra.Command {
 		summarize    = cmd.Flags().BoolP("summarize", "s", false, "quick summary of the differences, hides file contents")
 	)
 
+	getExtCode := extCodeParser(cmd.Flags())
+
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		changes, err := tanka.Diff(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
+			tanka.WithExtCode(getExtCode()),
 			tanka.WithDiffStrategy(*diffStrategy),
 			tanka.WithDiffSummarize(*summarize),
 		)
@@ -118,6 +124,7 @@ func showCmd() *cobra.Command {
 	}
 	vars := workflowFlags(cmd.Flags())
 	allowRedirect := cmd.Flags().Bool("dangerous-allow-redirect", false, "allow redirecting output to a file or a pipe.")
+	getExtCode := extCodeParser(cmd.Flags())
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if !interactive && !*allowRedirect {
 			fmt.Fprintln(os.Stderr, "Redirection of the output of tk show is discouraged and disabled by default. Run tk show --dangerous-allow-redirect to enable.")
@@ -125,6 +132,7 @@ func showCmd() *cobra.Command {
 		}
 
 		pretty, err := tanka.Show(args[0],
+			tanka.WithExtCode(getExtCode()),
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
 		)
 		if err != nil {

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -24,6 +24,9 @@ type options struct {
 	// io.Writer to write warnings and notices to
 	wWarn io.Writer
 
+	// `std.extVar`
+	extCode map[string]string
+
 	// target regular expressions to limit the working set
 	targets []*regexp.Regexp
 
@@ -43,6 +46,13 @@ type Modifier func(*options)
 func WithWarnWriter(w io.Writer) Modifier {
 	return func(opts *options) {
 		opts.wWarn = w
+	}
+}
+
+// WithExtCode allows to pass external variables (jsonnet code) to the VM
+func WithExtCode(code map[string]string) Modifier {
+	return func(opts *options) {
+		opts.extCode = code
 	}
 }
 


### PR DESCRIPTION
Adds two flags for working with extVars:

- `-e` / `--extCode`: Allows to bind any Jsonnet value (anything) to the
  extVar. This flag is superior to `--extVar`, because it also handles
  ints, bools, objects and arrays. **Strings need to be quoted**.

- `--extVar`: Only strings, but takes them unqouted. Added for
compatibility reasons to `jsonnet`.

Fixes #168 and Closes #171 