### PR TITLE
refactor(kubernetes): Jsonnet testdata

### DIFF
--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -26,46 +26,46 @@ func TestReconcile(t *testing.T) {
 	}{
 		{
 			name: "regular",
-			deep: testDataRegular().deep,
-			flat: mapToList(testDataRegular().flat),
+			deep: testDataRegular().Deep,
+			flat: mapToList(testDataRegular().Flat),
 		},
 		{
 			name: "targets",
-			deep: testDataDeep().deep,
+			deep: testDataDeep().Deep,
 			flat: manifest.List{
-				testDataDeep().flat[".app.web.backend.server.nginx.deployment"],
-				testDataDeep().flat[".app.web.frontend.nodejs.express.service"],
+				testDataDeep().Flat[".app.web.backend.server.grafana.deployment"],
+				testDataDeep().Flat[".app.web.frontend.nodejs.express.service"],
 			},
 			targets: util.MustCompileTargetExps(
-				`deployment/nginx`,
+				`deployment/grafana`,
 				`service/frontend`,
 			),
 		},
 		{
 			name: "targets-regex",
-			deep: testDataDeep().deep,
+			deep: testDataDeep().Deep,
 			flat: manifest.List{
-				testDataDeep().flat[".app.web.backend.server.nginx.deployment"],
-				testDataDeep().flat[".app.web.frontend.nodejs.express.deployment"],
+				testDataDeep().Flat[".app.web.backend.server.grafana.deployment"],
+				testDataDeep().Flat[".app.web.frontend.nodejs.express.deployment"],
 			},
 			targets: util.MustCompileTargetExps(`deployment/.*`),
 		},
 		{
 			name: "targets-caseInsensitive",
-			deep: testDataDeep().deep,
+			deep: testDataDeep().Deep,
 			flat: manifest.List{
-				testDataDeep().flat[".app.web.backend.server.nginx.deployment"],
+				testDataDeep().Flat[".app.web.backend.server.grafana.deployment"],
 			},
 			targets: util.MustCompileTargetExps(
-				`DePlOyMeNt/NgInX`,
+				`DePlOyMeNt/GrAfAnA`,
 			),
 		},
 		{
 			name: "force-namespace",
 			spec: v1alpha1.Spec{Namespace: "tanka"},
-			deep: testDataFlat().deep,
+			deep: testDataFlat().Deep,
 			flat: func() manifest.List {
-				f := testDataFlat().flat["."]
+				f := testDataFlat().Flat["."]
 				f.Metadata()["namespace"] = "tanka"
 				return manifest.List{f}
 			}(),
@@ -74,12 +74,12 @@ func TestReconcile(t *testing.T) {
 			name: "custom-namespace",
 			spec: v1alpha1.Spec{Namespace: "tanka"},
 			deep: func() map[string]interface{} {
-				d := objx.New(testDataFlat().deep)
+				d := objx.New(testDataFlat().Deep)
 				d.Set("metadata.namespace", "custom")
 				return d
 			}(),
 			flat: func() manifest.List {
-				f := testDataFlat().flat["."]
+				f := testDataFlat().Flat["."]
 				f.Metadata()["namespace"] = "custom"
 				return manifest.List{f}
 			}(),
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 func TestReconcileOrder(t *testing.T) {
 	got := make([]manifest.List, 10)
 	for i := 0; i < 10; i++ {
-		r, err := Reconcile(testDataDeep().deep.(map[string]interface{}), v1alpha1.Spec{}, nil)
+		r, err := Reconcile(testDataDeep().Deep.(map[string]interface{}), v1alpha1.Spec{}, nil)
 		require.NoError(t, err)
 		got[i] = r
 	}

--- a/pkg/kubernetes/reconcile.go
+++ b/pkg/kubernetes/reconcile.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -87,17 +86,11 @@ func walkJSON(ptr interface{}, extracted map[string]manifest.Manifest, path trac
 		return walkList(v, extracted, path)
 	}
 
-	// Lists other than []interface{} need to be handled separately
-	s, ok := tryCoerceSlice(ptr)
-	if !ok {
-		// object and list tried, so not a collection.
-		return ErrorPrimitiveReached{
-			path:      path.Base(),
-			key:       path.Name(),
-			primitive: ptr,
-		}
+	return ErrorPrimitiveReached{
+		path:      path.Base(),
+		key:       path.Name(),
+		primitive: ptr,
 	}
-	return walkJSON(s, extracted, path)
 }
 
 func walkList(list []interface{}, extracted map[string]manifest.Manifest, path trace) error {
@@ -137,25 +130,6 @@ func walkObj(obj objx.Map, extracted map[string]manifest.Manifest, path trace) e
 	}
 
 	return nil
-}
-
-// tryCoerceSlice attempts to construct a []interface{} from any other kind of
-// array/slice.
-// If the argument is not a list at all, ok will be false
-func tryCoerceSlice(input interface{}) ([]interface{}, bool) {
-	v := reflect.ValueOf(input)
-	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
-		return nil, false
-	}
-
-	l := v.Len()
-	s := make([]interface{}, l)
-
-	for i := 0; i < l; i++ {
-		s[i] = v.Index(i).Interface()
-	}
-
-	return s, true
 }
 
 type trace []string

--- a/pkg/kubernetes/reconcile_test.go
+++ b/pkg/kubernetes/reconcile_test.go
@@ -24,7 +24,7 @@ func TestExtract(t *testing.T) {
 		{
 			name: "primitive",
 			data: testDataPrimitive(),
-			err:  ErrorPrimitiveReached{path: ".nginx.service", key: "note", primitive: "invalid because apiVersion and kind are missing"},
+			err:  ErrorPrimitiveReached{path: ".service", key: "note", primitive: "invalid because apiVersion and kind are missing"},
 		},
 		{
 			name: "deep",
@@ -35,14 +35,10 @@ func TestExtract(t *testing.T) {
 			data: testDataArray(),
 		},
 		{
-			name: "deep array",
-			data: testDataDeepArray(),
-		},
-		{
 			name: "nil",
 			data: func() testData {
 				d := testDataRegular()
-				d.deep.(map[string]interface{})["disabledObject"] = nil
+				d.Deep.(map[string]interface{})["disabledObject"] = nil
 				return d
 			}(),
 			err: nil, // we expect no error, just the result of testDataRegular
@@ -51,10 +47,10 @@ func TestExtract(t *testing.T) {
 
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			extracted, err := extract(c.data.deep)
+			extracted, err := extract(c.data.Deep)
 
 			require.Equal(t, c.err, err)
-			assert.EqualValues(t, c.data.flat, extracted)
+			assert.EqualValues(t, c.data.Flat, extracted)
 		})
 	}
 }

--- a/pkg/kubernetes/testdata/k8s.libsonnet
+++ b/pkg/kubernetes/testdata/k8s.libsonnet
@@ -1,0 +1,37 @@
+// a very basic ripoff from `k.libsonnet`, because we can't vendor in tests
+
+{
+  deployment(name="grafana", image="grafana/grafana"):: {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: { name: name },
+    spec: {
+      replicas: 1,
+      template: {
+        containers: [{
+            name: name,
+            image: image,
+        }],
+        metadata: { labels: { app: name }}
+      }
+    }
+  },
+  service(name="grafana", image="grafana/grafana"):: {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: { name: name },
+    spec: {
+      selector: { app: name },
+      ports: [{
+        name: name,
+        port: 3000,
+        targetPort: 3000
+      }]
+    }
+  },
+  namespace(name="default"):: {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: { name: name }
+  }
+}

--- a/pkg/kubernetes/testdata/resources.jsonnet
+++ b/pkg/kubernetes/testdata/resources.jsonnet
@@ -1,0 +1,6 @@
+local k = (import "./k8s.libsonnet");
+{
+  deployment: k.deployment(),
+  service: k.service(),
+  namespace: k.namespace(),
+}

--- a/pkg/kubernetes/testdata/tdArray.jsonnet
+++ b/pkg/kubernetes/testdata/tdArray.jsonnet
@@ -1,0 +1,10 @@
+local utils = import "./utils.libsonnet";
+
+local deep = import "./tdDeep.jsonnet";
+local flat = import "./tdFlat.jsonnet";
+
+{
+  deep: [deep.deep, [flat.deep]],
+  flat: utils.indexify(deep.flat, [0]) +
+        utils.indexify(flat.flat, [1, 0])
+}

--- a/pkg/kubernetes/testdata/tdDeep.jsonnet
+++ b/pkg/kubernetes/testdata/tdDeep.jsonnet
@@ -1,0 +1,27 @@
+local backendDeploy = (import "./resources.jsonnet").deployment;
+local namespace = (import "./resources.jsonnet").namespace;
+local frontendService = (import "./k8s.libsonnet").service(name="frontend");
+local frontendDeploy = (import "./k8s.libsonnet").deployment(name="frontend");
+
+{
+  deep: {
+    app: {
+      namespace: namespace,
+      web: {
+        backend: { server: { grafana: {
+            deployment: backendDeploy,
+        }}},
+        frontend: { nodejs: { express: {
+            service: frontendService,
+            deployment: frontendDeploy,
+        }}},
+      }
+    }
+  },
+  flat: {
+    ".app.web.backend.server.grafana.deployment": backendDeploy,
+    ".app.web.frontend.nodejs.express.service": frontendService,
+    ".app.web.frontend.nodejs.express.deployment": frontendDeploy,
+    ".app.namespace": namespace,
+  }
+}

--- a/pkg/kubernetes/testdata/tdFlat.jsonnet
+++ b/pkg/kubernetes/testdata/tdFlat.jsonnet
@@ -1,0 +1,6 @@
+{
+  deep: (import "./resources.jsonnet").deployment,
+  flat: {
+    ".": $.deep
+  }
+}

--- a/pkg/kubernetes/testdata/tdInvalidPrimitive.jsonnet
+++ b/pkg/kubernetes/testdata/tdInvalidPrimitive.jsonnet
@@ -1,0 +1,8 @@
+{
+  deep: {
+    deploy: (import "./resources.jsonnet").deployment,
+    service: {
+      "note": "invalid because apiVersion and kind are missing",
+    }
+  }
+}

--- a/pkg/kubernetes/testdata/tdRegular.jsonnet
+++ b/pkg/kubernetes/testdata/tdRegular.jsonnet
@@ -1,0 +1,13 @@
+local deployment = (import "./resources.jsonnet").deployment;
+local service = (import "./resources.jsonnet").service;
+
+{
+  deep: {
+    deployment: deployment,
+    service: service,
+  },
+  flat: {
+    ".deployment": deployment,
+    ".service": service,
+  }
+}

--- a/pkg/kubernetes/testdata/utils.libsonnet
+++ b/pkg/kubernetes/testdata/utils.libsonnet
@@ -1,0 +1,12 @@
+{
+  mkIndex(arr)::
+    local idxs = [ "[%s]" % i for i in arr];
+    "." +std.join(".", idxs),
+
+  mkKey(k):: if k == "." then "" else k,
+
+  indexify(obj, index):: {
+    [$.mkIndex(index) + $.mkKey(key)]: obj[key],
+    for key in std.objectFields(obj)
+  },
+}


### PR DESCRIPTION
Moves the testdata for `pkg/kubernetes` out of Go, into several `.jsonnet` files for easier composing and reading (idea originally from @lawrencejones).

This also ensures that the data passed to `Extract()` and `Reconcile()` is exactly what would be used in real world. This is especially important because Go is usually typed, but `json.Unmarshal` returns untyped `interface{}` objects.

I also reverted a change from #166 (introducing `reflect`) that seemed required there, but as it turns out, this only happened because our testdata was written in Go instead of Jsonnet. Commit: f09257864c5bd94b3ec6526b72ef511c6403a7c4 /cc @jackatbancast