### PR TITLE
feat(cli): adding possiblity to disable schema validation for kubectl…

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -44,6 +44,7 @@ func applyCmd() *cobra.Command {
 	}
 	vars := workflowFlags(cmd.Flags())
 	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
+	validate := cmd.Flags().Bool("validate", true, "validation of resources (kubectl --validate=false)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	getExtCode := extCodeParser(cmd.Flags())
 
@@ -52,6 +53,7 @@ func applyCmd() *cobra.Command {
 			tanka.WithTargets(stringsToRegexps(vars.targets)...),
 			tanka.WithExtCode(getExtCode()),
 			tanka.WithApplyForce(*force),
+			tanka.WithApplyValidate(*validate),
 			tanka.WithApplyAutoApprove(*autoApprove),
 		)
 		if err != nil {

--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -31,6 +31,10 @@ func (k Kubectl) apply(data manifest.List, opts ApplyOpts) error {
 		argv = append(argv, "--force")
 	}
 
+	if !opts.Validate {
+		argv = append(argv, "--validate=false")
+	}
+
 	cmd := exec.Command("kubectl", argv...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -51,6 +51,9 @@ type ApplyOpts struct {
 	// force allows to ignore checks and force the operation
 	Force bool
 
+	// validate allows to enable/disable kubectl validation
+	Validate bool
+
 	// autoApprove allows to skip the interactive approval
 	AutoApprove bool
 }

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -89,6 +89,13 @@ func WithApplyForce(b bool) Modifier {
 	}
 }
 
+// WithApplyValidate allows to invoke `kubectl apply` with the `--validate=false` flag
+func WithApplyValidate(b bool) Modifier {
+	return func(opts *options) {
+		opts.apply.Validate = b
+	}
+}
+
 // WithApplyAutoApprove allows to skip the interactive approval
 func WithApplyAutoApprove(b bool) Modifier {
 	return func(opts *options) {


### PR DESCRIPTION
… apply

Adding --validate=false to tk apply would invoke kubectl apply with same option
Fixes #115