### PR TITLE
Add `tool targets` command

### DIFF
--- a/pkg/kubernetes/util/diff.go
+++ b/pkg/kubernetes/util/diff.go
@@ -23,6 +23,13 @@ func DiffName(m manifest.Manifest) string {
 	), "/", "-", -1)
 }
 
+func TargetName(m manifest.Manifest) string {
+	return fmt.Sprintf("%s/%s",
+		strings.ToLower(m.Kind()),
+		strings.ToLower(m.Metadata().Name()),
+	)
+}
+
 // Diff computes the differences between the strings `is` and `should` using the
 // UNIX `diff(1)` utility.
 func DiffStr(name, is, should string) (string, error) {

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/grafana/tanka/pkg/kubernetes"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
 // Apply parses the environment at the given directory (a `baseDir`) and applies
@@ -82,4 +83,16 @@ func Eval(dir string, mods ...Modifier) (raw map[string]interface{}, err error) 
 		return nil, err
 	}
 	return r, nil
+}
+
+// Resources parses the environment at the given directory (a `baseDir`) and returns a list of resources (manifests)
+func Resources(baseDir string, mods ...Modifier) (manifest.List, error) {
+	opts := parseModifiers(mods)
+
+	p, err := parse(baseDir, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.Resources, nil
 }


### PR DESCRIPTION
Often when I'm trying to add a `-t` targets command I find myself struggling to get the right target.

This command will list all the targets (manifests) for an environment in a format suitable for ingestion by the `-t` flag

I don't feel great about adding the `Resources` method, or am open to suggestions if this might belong somewhere else.

In general there is a little bit of name confusion around Resources and Manifests and Targets and I struggled a little naming this method.
