### PR TITLE
fix(docs): use namespace "monitoring" in jsonnet.mdx

### DIFF
--- a/docs/docs/tutorial/jsonnet.mdx
+++ b/docs/docs/tutorial/jsonnet.mdx
@@ -294,7 +294,7 @@ cluster.
 >     apiVersion: "v1",
 >     kind: "Namespace",
 >     metadata: {
->       name: "my-namespace"
+>       name: "monitoring"
 >     }
 >   }
 > }


### PR DESCRIPTION
The examples before and after use the namespace "monitoring" instead "my-namespace". Should be the same for consistency.