### PR TITLE
fix(kubernetes): let kubectl handle namespaces

### DIFF
--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
@@ -23,10 +22,7 @@ func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
 }
 
 func (k Kubectl) apply(data manifest.List, opts ApplyOpts) error {
-	argv := []string{"apply",
-		"--context", k.context.Get("name").MustStr(),
-		"-f", "-",
-	}
+	argv := []string{"-f", "-"}
 	if opts.Force {
 		argv = append(argv, "--force")
 	}
@@ -35,7 +31,7 @@ func (k Kubectl) apply(data manifest.List, opts ApplyOpts) error {
 		argv = append(argv, "--validate=false")
 	}
 
-	cmd := exec.Command("kubectl", argv...)
+	cmd := k.ctl("apply", argv...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -22,10 +22,8 @@ func (k Kubectl) DeleteByLabels(namespace string, labels map[string]interface{},
 }
 
 func (k Kubectl) delete(namespace string, sel []string, opts DeleteOpts) error {
-	argv := append([]string{"delete",
-		"-n", namespace,
-		"--context", k.context.Get("name").MustStr(),
-	}, sel...)
+	argv := append([]string{"-n", namespace}, sel...)
+	k.ctl("delete", argv...)
 
 	if opts.Force {
 		argv = append(argv, "--force")

--- a/pkg/kubernetes/client/diff.go
+++ b/pkg/kubernetes/client/diff.go
@@ -54,7 +54,8 @@ func (k Kubectl) DiffServerSide(data manifest.List) (*string, error) {
 
 func separateMissingNamespace(in manifest.List, exists map[string]bool) (ready, missingNamespace manifest.List) {
 	for _, r := range in {
-		if !exists[r.Metadata().Namespace()] {
+		// namespace does not exist, also ignore implicit default ("")
+		if ns := r.Metadata().Namespace(); ns != "" && !exists[ns] {
 			missingNamespace = append(missingNamespace, r)
 			continue
 		}

--- a/pkg/kubernetes/client/diff.go
+++ b/pkg/kubernetes/client/diff.go
@@ -19,11 +19,7 @@ func (k Kubectl) DiffServerSide(data manifest.List) (*string, error) {
 	}
 
 	ready, missing := separateMissingNamespace(data, ns)
-	argv := []string{"diff",
-		"--context", k.context.Get("name").MustStr(),
-		"-f", "-",
-	}
-	cmd := exec.Command("kubectl", argv...)
+	cmd := k.ctl("diff", "-f", "-")
 
 	raw := bytes.Buffer{}
 	cmd.Stdout = &raw

--- a/pkg/kubernetes/client/diff_test.go
+++ b/pkg/kubernetes/client/diff_test.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeparateMissingNamespace(t *testing.T) {
+	cases := []struct {
+		name string
+		td   nsTd
+
+		missing bool
+	}{
+		// default should always exist
+		{
+			name: "default",
+			td: newNsTd(func(m manifest.Metadata) {
+				m["namespace"] = "default"
+			}, []string{}),
+			missing: false,
+		},
+		// implcit default (not specfiying an ns at all) also
+		{
+			name: "implicit-default",
+			td: newNsTd(func(m manifest.Metadata) {
+				delete(m, "namespace")
+			}, []string{}),
+			missing: false,
+		},
+		// custom ns that exists
+		{
+			name: "custom-ns",
+			td: newNsTd(func(m manifest.Metadata) {
+				m["namespace"] = "custom"
+			}, []string{"custom"}),
+			missing: false,
+		},
+		// custom ns that does not exist
+		{
+			name: "missing-ns",
+			td: newNsTd(func(m manifest.Metadata) {
+				m["namespace"] = "missing"
+			}, []string{}),
+			missing: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ready, missing := separateMissingNamespace(manifest.List{c.td.m}, c.td.ns)
+			if c.missing {
+				assert.Lenf(t, ready, 0, "expected manifest to be missing (ready = 0)")
+				assert.Lenf(t, missing, 1, "expected manifest to be missing (missing = 1)")
+			} else {
+				assert.Lenf(t, ready, 1, "expected manifest to be ready (ready = 1)")
+				assert.Lenf(t, missing, 0, "expected manifest to be ready (missing = 0)")
+			}
+		})
+	}
+}
+
+type nsTd struct {
+	m  manifest.Manifest
+	ns map[string]bool
+}
+
+func newNsTd(f func(m manifest.Metadata), ns []string) nsTd {
+	m := manifest.Manifest{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]interface{}{},
+	}
+	if f != nil {
+		f(m.Metadata())
+	}
+
+	nsMap := map[string]bool{
+		"default": true, // you can't get rid of this one ever
+	}
+	for _, n := range ns {
+		nsMap[n] = true
+	}
+
+	return nsTd{
+		m:  m,
+		ns: nsMap,
+	}
+}

--- a/pkg/kubernetes/client/exec.go
+++ b/pkg/kubernetes/client/exec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -28,9 +29,10 @@ func patchKubeconfig(file string, e []string) []string {
 	// prepend namespace patch to $KUBECONFIG
 	env := newEnv(e)
 	if _, ok := env["KUBECONFIG"]; !ok {
-		env["KUBECONFIG"] = "~/.kube/config" // kubectl default
+		env["KUBECONFIG"] = filepath.Join(homeDir(), ".kube", "config") // kubectl default
 	}
 	env["KUBECONFIG"] = fmt.Sprintf("%s:%s", file, env["KUBECONFIG"])
+
 	return env.render()
 }
 
@@ -53,4 +55,13 @@ func (e environment) render() []string {
 	}
 	sort.Strings(s)
 	return s
+}
+
+func homeDir() string {
+	home, err := os.UserHomeDir()
+	// unable to find homedir. Should never happen on the supported os/arch
+	if err != nil {
+		panic("Unable to find your $HOME directory. This should not have ever happened. Please open an issue on https://github.com/grafana/tanka/issues with your OS and ARCH.")
+	}
+	return home
 }

--- a/pkg/kubernetes/client/exec.go
+++ b/pkg/kubernetes/client/exec.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ctl returns an `exec.Cmd` for `kubectl`. It also forces the correct context
+// and injects our patched $KUBECONFIG for the default namespace.
+func (k Kubectl) ctl(action string, args ...string) *exec.Cmd {
+	// prepare the arguments
+	argv := []string{action,
+		"--context", k.context.Get("name").MustStr(),
+	}
+	argv = append(argv, args...)
+
+	// prepare the cmd
+	cmd := exec.Command("kubectl", argv...)
+
+	// prepend namespace patch to $KUBECONFIG
+	env := newEnv()
+	if _, ok := env["KUBECONFIG"]; !ok {
+		env["KUBECONFIG"] = "~/.kube/config"
+	}
+	env["KUBECONFIG"] = fmt.Sprintf("%s:%s", k.nsPatch, env["KUBECONFIG"])
+	cmd.Env = env.render()
+
+	return cmd
+}
+
+// environment is a helper type for manipulating os.Environ() more easily
+type environment map[string]string
+
+func newEnv() environment {
+	env := make(environment)
+	for _, s := range os.Environ() {
+		kv := strings.SplitN(s, "=", 2)
+		env[kv[0]] = kv[1]
+	}
+	return env
+}
+
+func (e environment) render() []string {
+	s := make([]string, 0, len(e))
+	for k, v := range e {
+		s = append(s, fmt.Sprintf("%s=%s", k, v))
+	}
+	return s
+}

--- a/pkg/kubernetes/client/exec.go
+++ b/pkg/kubernetes/client/exec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 )
 
@@ -18,24 +19,27 @@ func (k Kubectl) ctl(action string, args ...string) *exec.Cmd {
 
 	// prepare the cmd
 	cmd := exec.Command("kubectl", argv...)
-
-	// prepend namespace patch to $KUBECONFIG
-	env := newEnv()
-	if _, ok := env["KUBECONFIG"]; !ok {
-		env["KUBECONFIG"] = "~/.kube/config"
-	}
-	env["KUBECONFIG"] = fmt.Sprintf("%s:%s", k.nsPatch, env["KUBECONFIG"])
-	cmd.Env = env.render()
+	cmd.Env = patchKubeconfig(k.nsPatch, os.Environ())
 
 	return cmd
+}
+
+func patchKubeconfig(file string, e []string) []string {
+	// prepend namespace patch to $KUBECONFIG
+	env := newEnv(e)
+	if _, ok := env["KUBECONFIG"]; !ok {
+		env["KUBECONFIG"] = "~/.kube/config" // kubectl default
+	}
+	env["KUBECONFIG"] = fmt.Sprintf("%s:%s", file, env["KUBECONFIG"])
+	return env.render()
 }
 
 // environment is a helper type for manipulating os.Environ() more easily
 type environment map[string]string
 
-func newEnv() environment {
+func newEnv(e []string) environment {
 	env := make(environment)
-	for _, s := range os.Environ() {
+	for _, s := range e {
 		kv := strings.SplitN(s, "=", 2)
 		env[kv[0]] = kv[1]
 	}
@@ -47,5 +51,6 @@ func (e environment) render() []string {
 	for k, v := range e {
 		s = append(s, fmt.Sprintf("%s=%s", k, v))
 	}
+	sort.Strings(s)
 	return s
 }

--- a/pkg/kubernetes/client/exec_test.go
+++ b/pkg/kubernetes/client/exec_test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +20,9 @@ func TestPatchKubeconfig(t *testing.T) {
 		{
 			name: "none",
 			env:  []string{},
-			want: []string{"KUBECONFIG=" + patchFile + ":~/.kube/config"},
+			want: []string{
+				fmt.Sprintf("KUBECONFIG=%s:%s", patchFile, filepath.Join(homeDir(), ".kube", "config")),
+			},
 		},
 		{
 			name: "custom",

--- a/pkg/kubernetes/client/exec_test.go
+++ b/pkg/kubernetes/client/exec_test.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const patchFile = "/tmp/tk-nsPatch.yaml"
+
+func TestPatchKubeconfig(t *testing.T) {
+
+	cases := []struct {
+		name string
+		env  []string
+		want []string
+	}{
+		{
+			name: "none",
+			env:  []string{},
+			want: []string{"KUBECONFIG=" + patchFile + ":~/.kube/config"},
+		},
+		{
+			name: "custom",
+			env:  []string{"KUBECONFIG=/home/user/.config/kube"},
+			want: []string{"KUBECONFIG=" + patchFile + ":/home/user/.config/kube"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := patchKubeconfig(patchFile, c.env)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}

--- a/pkg/kubernetes/client/get.go
+++ b/pkg/kubernetes/client/get.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
@@ -41,12 +40,11 @@ func (k Kubectl) GetByLabels(namespace string, labels map[string]interface{}) (m
 }
 
 func (k Kubectl) get(namespace string, sel []string) (manifest.Manifest, error) {
-	argv := append([]string{"get",
+	argv := append([]string{
 		"-o", "json",
 		"-n", namespace,
-		"--context", k.context.Get("name").MustStr(),
 	}, sel...)
-	cmd := exec.Command("kubectl", argv...)
+	cmd := k.ctl("get", argv...)
 
 	var sout, serr bytes.Buffer
 	cmd.Stdout = &sout

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
-	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
@@ -51,29 +49,6 @@ func (k Kubectl) Info() (*Info, error) {
 		Context: k.context,
 		Cluster: k.cluster,
 	}, nil
-}
-
-func (k Kubectl) ctl(action string, args ...string) *exec.Cmd {
-	// prepare the arguments
-	argv := []string{action,
-		"--context", k.context.Get("name").MustStr(),
-	}
-	argv = append(argv, args...)
-
-	// prepare the cmd
-	cmd := exec.Command("kubectl", argv...)
-
-	// add the nsPatch file to $KUBECONFIG
-	env := os.Environ()
-	for i, s := range env {
-		// TODO: handle empty $KUBECONFIG
-		if strings.HasPrefix(s, "KUBECONFIG=") {
-			env[i] = fmt.Sprintf("KUBECONFIG=%s:%s", k.nsPatch, strings.TrimPrefix(s, "KUBECONFIG="))
-		}
-	}
-	cmd.Env = env
-
-	return cmd
 }
 
 // Version returns the version of kubectl and the Kubernetes api server

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -33,7 +33,7 @@ type Differ func(manifest.List) (*string, error)
 // New creates a new Kubernetes with an initialized client
 func New(s v1alpha1.Spec) (*Kubernetes, error) {
 	// setup client
-	ctl, err := client.New(s.APIServer)
+	ctl, err := client.New(s.APIServer, s.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -59,30 +58,6 @@ func TestReconcile(t *testing.T) {
 			targets: util.MustCompileTargetExps(
 				`DePlOyMeNt/GrAfAnA`,
 			),
-		},
-		{
-			name: "force-namespace",
-			spec: v1alpha1.Spec{Namespace: "tanka"},
-			deep: testDataFlat().Deep,
-			flat: func() manifest.List {
-				f := testDataFlat().Flat["."]
-				f.Metadata()["namespace"] = "tanka"
-				return manifest.List{f}
-			}(),
-		},
-		{
-			name: "custom-namespace",
-			spec: v1alpha1.Spec{Namespace: "tanka"},
-			deep: func() map[string]interface{} {
-				d := objx.New(testDataFlat().Deep)
-				d.Set("metadata.namespace", "custom")
-				return d
-			}(),
-			flat: func() manifest.List {
-				f := testDataFlat().Flat["."]
-				f.Metadata()["namespace"] = "custom"
-				return manifest.List{f}
-			}(),
 		},
 	}
 

--- a/pkg/kubernetes/reconcile.go
+++ b/pkg/kubernetes/reconcile.go
@@ -29,10 +29,6 @@ func Reconcile(raw map[string]interface{}, spec v1alpha1.Spec, targets []*regexp
 
 	out := make(manifest.List, 0, len(extracted))
 	for _, m := range extracted {
-		if spec.Namespace != "" && !m.Metadata().HasNamespace() {
-			m.Metadata()["namespace"] = spec.Namespace
-		}
-
 		out = append(out, m)
 	}
 


### PR DESCRIPTION
Instead of naively setting the default namespaces on objects that don't
have one, we now overlay `$KUBECONFIG` with a patch to set the default
namespace on the context, so that `kubectl` will do the job for us.

`kubectl` does this far more intelligent than we did, especially it does
not inject the namespace on objects that don't take one.

Fixes #190 

There is one `TODO` left in injecting the patch into `$KUBECONFIG`: https://github.com/grafana/tanka/blob/0257f10a151d100ee7d645106ff76a8b71a4eae7/pkg/kubernetes/client/kubectl.go#L68-L72