### PR TITLE
fix(cli): paging issues with colored diff

### DIFF
--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -26,11 +26,11 @@ func pageln(i ...interface{}) {
 	pager := os.Getenv("PAGER")
 	var args []string
 	if pager == "" || pager == "less" {
-		// --raw-control-chars  Honors colors from diff.
+		// --RAW-CONTROL-CHARS  Honors colors from diff. Must be in all caps, otherwise display issues occur.
 		// --quit-if-one-screen Closer to the git experience.
 		// --no-init            Don't clear the screen when exiting.
 		pager = "less"
-		args = []string{"--raw-control-chars", "--quit-if-one-screen", "--no-init"}
+		args = []string{"--RAW-CONTROL-CHARS", "--quit-if-one-screen", "--no-init"}
 	}
 
 	// invoke pager


### PR DESCRIPTION
**NOTE**: **Do not merge** until #202 is merged; for this to work correctly it depends on color sequences being applied per line rather than per diff chunk, which is introduced in #202. 

The `less` command has two flags: `--raw-control-chars` and `--RAW-CONTROL-CHARS`, each of which keeps ASCII control characters present in the paginated output. The former flag was being used previously, and the man page warns about various display problems occurring when using that flag.

On the other hand, `--RAW-CONTROL-CHARS` only keeps color escape sequences, and the man page notes that appearance will be maintained correctly in most cases. In my local testing, this appears to be true and colorized output in less will now work as expected.

Fixes #82.