### PR TITLE
fix(kubernetes): handle kubectl-diff exit 1

### DIFF
--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -31,7 +31,7 @@ type Client interface {
 	// Info returns known informational data about the client. Best effort based,
 	// fields of `Info` that cannot be stocked with valuable data, e.g.
 	// due to an error, shall be left nil.
-	Info() (*Info, error)
+	Info() Info
 }
 
 // Info contains metadata about the client and its environment


### PR DESCRIPTION
Properly handles `exit status 1` as a result from `kubectl diff`,
being aware of differences between `kubectl` versions:

* Before `1.18`:
  * `0`: no error, no diff
  * `1`: error or diff
* After 1.18 (https://github.com/kubernetes/kubernetes/pull/87437):
  * `0`: no error, no diff
  * `1`: diff
  * `>1`: error

Fixes #204 
Fixes #205