### PR TITLE
feat(cli): Exporting

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"text/template"
+
+	"github.com/grafana/tanka/pkg/tanka"
+	"github.com/spf13/cobra"
+)
+
+func exportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export <environment> <outputDir>",
+		Short: "write each resources as a YAML file",
+		Args:  cobra.ExactArgs(2),
+		Annotations: map[string]string{
+			"args": "baseDir",
+		},
+	}
+	vars := workflowFlags(cmd.Flags())
+	getExtCode := extCodeParser(cmd.Flags())
+	format := cmd.Flags().String("format", "{{.apiVersion}}.{{.kind}}-{{.metadata.name}}", "https://tanka.dev/exporting#filenames")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		// dir must be empty
+		to := args[1]
+		empty, err := dirEmpty(to)
+		if err != nil {
+			log.Fatalln("Checking target dir:", err)
+		}
+		if !empty {
+			log.Fatalln("Target dir", to, "not empty. Aborting.")
+		}
+
+		// exit early if the template is bad
+		tmpl, err := template.New("").Parse(*format)
+		if err != nil {
+			log.Fatalln("Parsing name format:", err)
+		}
+
+		// get the manifests
+		res, err := tanka.Show(args[0],
+			tanka.WithExtCode(getExtCode()),
+			tanka.WithTargets(stringsToRegexps(vars.targets)...),
+		)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		// write each to a file
+		for _, m := range res {
+			buf := bytes.Buffer{}
+			tmpl.Execute(&buf, m)
+			name := strings.Replace(buf.String(), "/", "-", -1)
+
+			data := m.String()
+			if err := ioutil.WriteFile(filepath.Join(to, name+".yaml"), []byte(data), 0644); err != nil {
+				log.Fatalln("Writing manifest:", err)
+			}
+		}
+	}
+	return cmd
+}
+
+func dirEmpty(dir string) (bool, error) {
+	f, err := os.Open(dir)
+	if os.IsNotExist(err) {
+		return true, os.MkdirAll(dir, os.ModePerm)
+	} else if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -50,6 +50,7 @@ func main() {
 	rootCmd.AddCommand(
 		envCmd(),
 		statusCmd(),
+		exportCmd(),
 	)
 
 	// jsonnet commands

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -129,7 +129,9 @@ func showCmd() *cobra.Command {
 	getExtCode := extCodeParser(cmd.Flags())
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		if !interactive && !*allowRedirect {
-			fmt.Fprintln(os.Stderr, "Redirection of the output of tk show is discouraged and disabled by default. Run tk show --dangerous-allow-redirect to enable.")
+			fmt.Fprintln(os.Stderr, `Redirection of the output of tk show is discouraged and disabled by default.
+If you want to export .yaml files for use with other tools, try 'tk export'.
+Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
 			return
 		}
 
@@ -141,7 +143,7 @@ func showCmd() *cobra.Command {
 			log.Fatalln(err)
 		}
 
-		pageln(pretty)
+		pageln(pretty.String())
 	}
 	return cmd
 }

--- a/docs/docs/exporting.md
+++ b/docs/docs/exporting.md
@@ -1,0 +1,54 @@
+---
+name: "Exporting as YAML"
+route: "/exporting"
+---
+
+# Exporting as YAML
+
+Tanka provides you with a day-to-day workflow for working with Kubernetes clusters:
+
+- `tk show` for quickly checking the YAML representation looks good
+- `tk diff` to ensure your changes will behave like they should
+- `tk apply` makes it happen
+
+However sometimes it can be required to integrate with other tooling that does
+only support `.yaml` files.
+
+For that case, `tk export` can be used:
+
+```bash
+#           <environment>         <outputDir>
+$ tk export environments/promtail promtail
+```
+
+This will create a separate `.yaml` file for each Kubernetes resource included in your Jsonnet.
+
+## Filenames
+
+Tanka by default uses the following pattern:
+
+```bash
+${apiVersion}.${kind}-${metadata.name}.yaml
+
+# examples:
+apps-v1.Deployment-distributor.yaml
+v1.ConfigMap-loki.yaml
+v1.Service-ingester.yaml
+```
+
+If that does not fit your need, you can provide your own pattern using the `--format` flag:
+
+```bash
+tk export environments/promtail promtail --format='{{.metadata.labels.app}}-{{.metadata.name}}-{{.kind}}'
+```
+
+> The syntax is Go `text/template`. See https://golang.org/pkg/text/template/
+> for reference.
+
+This would include the label named `app`, the `name` and `kind` of the resource:
+
+```
+loki-distributor-Deployment
+loki-loki-ConfigMap
+loki-ingester-Service
+```

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/grafana/tanka/pkg/kubernetes"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
 // Apply parses the environment at the given directory (a `baseDir`) and applies
@@ -61,16 +62,17 @@ func Diff(baseDir string, mods ...Modifier) (*string, error) {
 }
 
 // Show parses the environment at the given directory (a `baseDir`) and returns
-// the evaluated jsonnet in yaml form
-func Show(baseDir string, mods ...Modifier) (string, error) {
+// the list of Kubernetes objects.
+// Tip: use the `String()` function on the returned list to get the familiar yaml stream
+func Show(baseDir string, mods ...Modifier) (manifest.List, error) {
 	opts := parseModifiers(mods)
 
 	p, err := parse(baseDir, opts)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return p.Resources.String(), nil
+	return p.Resources, nil
 }
 
 // Eval returns the raw evaluated Jsonnet output (without any transformations)


### PR DESCRIPTION
Adds a new subcommand to Tanka for writing each resource in the `tk
show` output to a separate `.yaml` file

Fixes #206