### PR TITLE
feat(cli): override kubectl path with env-var

### DIFF
--- a/docs/docs/env-vars.md
+++ b/docs/docs/env-vars.md
@@ -5,5 +5,6 @@ route: "/env-vars"
 
 # Environment Variables
 
-Tanka currently makes use of the following environment variables:
-* `TANKA_KUBECTL_PATH` -- path to the `kubectl` tool, defaults to `"kubectl"`.
+#### `TANKA_KUBECTL_PATH`
+**Description**: Path to the `kubectl` tool executable
+**Default**: `$PATH/kubectl`

--- a/docs/docs/env-vars.md
+++ b/docs/docs/env-vars.md
@@ -1,0 +1,9 @@
+---
+name: "Environment variables"
+route: "/env-vars"
+---
+
+# Environment Variables
+
+Tanka currently makes use of the following environment variables:
+* `TANKA_KUBECTL_PATH` -- path to the `kubectl` tool, defaults to `"kubectl"`.

--- a/docs/docs/env-vars.md
+++ b/docs/docs/env-vars.md
@@ -5,6 +5,7 @@ route: "/env-vars"
 
 # Environment Variables
 
-#### `TANKA_KUBECTL_PATH`
-**Description**: Path to the `kubectl` tool executable
+### TANKA_KUBECTL_PATH
+
+**Description**: Path to the `kubectl` tool executable  
 **Default**: `$PATH/kubectl`

--- a/docs/doczrc.js
+++ b/docs/doczrc.js
@@ -40,14 +40,20 @@ export default {
         // "Using libraries",
         // "Creating and structure",
         "Installing and publishing",
-	"Overriding",
+        "Overriding",
       ],
     },
-    "Command-line completion",
-    "Directory structure",
-    "Diff strategies",
+
+    // additional features
     "Output filtering",
-	  
+    "Exporting as YAML",
+    "Command-line completion",
+    "Diff strategies",
+
+    // reference
+    "Directory structure",
+    "Environment variables",
+
     "Frequently asked questions",
     "Known issues",
   ],

--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -62,7 +62,7 @@ func writeNamespacePatch(context objx.Map, namespace string) (string, error) {
 
 // Kubeconfig returns the merged $KUBECONFIG of the host
 func Kubeconfig() (map[string]interface{}, error) {
-	cmd := exec.Command("kubectl", "config", "view", "-o", "json")
+	cmd := exec.Command(KubectlPath(), "config", "view", "-o", "json")
 	cfgJSON := bytes.Buffer{}
 	cmd.Stdout = &cfgJSON
 	cmd.Stderr = os.Stderr
@@ -77,7 +77,7 @@ func Kubeconfig() (map[string]interface{}, error) {
 }
 
 func Contexts() ([]string, error) {
-	cmd := exec.Command("kubectl", "config", "get-contexts", "-o=name")
+	cmd := exec.Command(KubectlPath(), "config", "get-contexts", "-o=name")
 	buf := bytes.Buffer{}
 	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -61,7 +61,7 @@ func writeNamespacePatch(context objx.Map, namespace string) (string, error) {
 
 // Kubeconfig returns the merged $KUBECONFIG of the host
 func Kubeconfig() (map[string]interface{}, error) {
-	cmd := KubectlCmd("config", "view", "-o", "json")
+	cmd := kubectlCmd("config", "view", "-o", "json")
 	cfgJSON := bytes.Buffer{}
 	cmd.Stdout = &cfgJSON
 	cmd.Stderr = os.Stderr
@@ -76,7 +76,7 @@ func Kubeconfig() (map[string]interface{}, error) {
 }
 
 func Contexts() ([]string, error) {
-	cmd := KubectlCmd("config", "get-contexts", "-o=name")
+	cmd := kubectlCmd("config", "get-contexts", "-o=name")
 	buf := bytes.Buffer{}
 	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -62,7 +61,7 @@ func writeNamespacePatch(context objx.Map, namespace string) (string, error) {
 
 // Kubeconfig returns the merged $KUBECONFIG of the host
 func Kubeconfig() (map[string]interface{}, error) {
-	cmd := exec.Command(KubectlPath(), "config", "view", "-o", "json")
+	cmd := KubectlCmd("config", "view", "-o", "json")
 	cfgJSON := bytes.Buffer{}
 	cmd.Stdout = &cfgJSON
 	cmd.Stderr = os.Stderr
@@ -77,7 +76,7 @@ func Kubeconfig() (map[string]interface{}, error) {
 }
 
 func Contexts() ([]string, error) {
-	cmd := exec.Command(KubectlPath(), "config", "get-contexts", "-o=name")
+	cmd := KubectlCmd("config", "get-contexts", "-o=name")
 	buf := bytes.Buffer{}
 	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -28,7 +28,7 @@ func (k Kubectl) delete(namespace string, sel []string, opts DeleteOpts) error {
 		argv = append(argv, "--force")
 	}
 
-	cmd := KubectlCmd(argv...)
+	cmd := kubectlCmd(argv...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"os"
-	"os/exec"
 )
 
 // Delete removes the specified object from the cluster
@@ -29,7 +28,7 @@ func (k Kubectl) delete(namespace string, sel []string, opts DeleteOpts) error {
 		argv = append(argv, "--force")
 	}
 
-	cmd := exec.Command(KubectlPath(), argv...)
+	cmd := KubectlCmd(argv...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -29,7 +29,7 @@ func (k Kubectl) delete(namespace string, sel []string, opts DeleteOpts) error {
 		argv = append(argv, "--force")
 	}
 
-	cmd := exec.Command("kubectl", argv...)
+	cmd := exec.Command(KubectlPath(), argv...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -22,14 +22,11 @@ func (k Kubectl) DeleteByLabels(namespace string, labels map[string]interface{},
 
 func (k Kubectl) delete(namespace string, sel []string, opts DeleteOpts) error {
 	argv := append([]string{"-n", namespace}, sel...)
-	k.ctl("delete", argv...)
-
 	if opts.Force {
 		argv = append(argv, "--force")
 	}
 
-	cmd := kubectlCmd(argv...)
-
+	cmd := k.ctl("delete", argv...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/pkg/kubernetes/client/exec.go
+++ b/pkg/kubernetes/client/exec.go
@@ -9,16 +9,14 @@ import (
 	"strings"
 )
 
-// KubectlPath returns path to the kubectl binary, allowing to override the
-// default one for e.g. test purposes.
-func KubectlPath() string {
-	path := os.Getenv("TANKA_KUBECTL_PATH")
-
-	if path == "" {
-		path = "kubectl"
+// KubectlCmd returns command a object that will launch kubectl at an appropriate path.
+func KubectlCmd(args ...string) *exec.Cmd {
+	binary := "kubectl"
+	if env := os.Getenv("TANKA_KUBECTL_PATH"); env != "" {
+		binary = env
 	}
 
-	return path
+	return exec.Command(binary, args...)
 }
 
 // ctl returns an `exec.Cmd` for `kubectl`. It also forces the correct context
@@ -31,7 +29,7 @@ func (k Kubectl) ctl(action string, args ...string) *exec.Cmd {
 	argv = append(argv, args...)
 
 	// prepare the cmd
-	cmd := exec.Command(KubectlPath(), argv...)
+	cmd := KubectlCmd(argv...)
 	cmd.Env = patchKubeconfig(k.nsPatch, os.Environ())
 
 	return cmd

--- a/pkg/kubernetes/client/exec.go
+++ b/pkg/kubernetes/client/exec.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-// KubectlCmd returns command a object that will launch kubectl at an appropriate path.
-func KubectlCmd(args ...string) *exec.Cmd {
+// kubectlCmd returns command a object that will launch kubectl at an appropriate path.
+func kubectlCmd(args ...string) *exec.Cmd {
 	binary := "kubectl"
 	if env := os.Getenv("TANKA_KUBECTL_PATH"); env != "" {
 		binary = env
@@ -29,7 +29,7 @@ func (k Kubectl) ctl(action string, args ...string) *exec.Cmd {
 	argv = append(argv, args...)
 
 	// prepare the cmd
-	cmd := KubectlCmd(argv...)
+	cmd := kubectlCmd(argv...)
 	cmd.Env = patchKubeconfig(k.nsPatch, os.Environ())
 
 	return cmd

--- a/pkg/kubernetes/client/exec.go
+++ b/pkg/kubernetes/client/exec.go
@@ -9,6 +9,18 @@ import (
 	"strings"
 )
 
+// KubectlPath returns path to the kubectl binary, allowing to override the
+// default one for e.g. test purposes.
+func KubectlPath() string {
+	path := os.Getenv("TANKA_KUBECTL_PATH")
+
+	if path == "" {
+		path = "kubectl"
+	}
+
+	return path
+}
+
 // ctl returns an `exec.Cmd` for `kubectl`. It also forces the correct context
 // and injects our patched $KUBECONFIG for the default namespace.
 func (k Kubectl) ctl(action string, args ...string) *exec.Cmd {
@@ -19,7 +31,7 @@ func (k Kubectl) ctl(action string, args ...string) *exec.Cmd {
 	argv = append(argv, args...)
 
 	// prepare the cmd
-	cmd := exec.Command("kubectl", argv...)
+	cmd := exec.Command(KubectlPath(), argv...)
 	cmd.Env = patchKubeconfig(k.nsPatch, os.Environ())
 
 	return cmd


### PR DESCRIPTION
Up to now, Tanka was using hard-coded string as a `kubectl` path, making
it hard to do any other tool without playing tricks with $PATH. This
commit allows to use TANKA_KUBECTL_PATH env variable to override the
path to `kubectl` used in Tanka's code.

See also https://github.com/grafana/tanka/issues/220 .