### PR TITLE
fix(kubernetes): ignore diff errs on apply

### DIFF
--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -3,8 +3,6 @@ package tanka
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/grafana/tanka/pkg/cli"
 	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
@@ -29,13 +27,15 @@ func Apply(baseDir string, mods ...Modifier) error {
 	}
 
 	diff, err := kube.Diff(p.Resources, kubernetes.DiffOpts{})
-	if err != nil {
-		return errors.Wrap(err, "diffing")
-	}
-	if diff == nil {
+	switch {
+	case err != nil:
+		// This is not fatal, the diff is not strictly required
+		fmt.Println("Error diffing:", err)
+	case diff == nil:
 		tmp := "Warning: There are no differences. Your apply may not do anything at all."
 		diff = &tmp
 	}
+
 	b := cli.Colordiff(*diff)
 	fmt.Print(b.String())
 


### PR DESCRIPTION
If diff fails, it doesn't mean apply couldn't succeed anyways, so it is wrong to abort in such a case.

Changes that behavior so that the diff error is printed, but still continued to applying.

This does not fix the actual issue (diff failing for complex reasons), but makes Tanka still usable because after the first apply diff will most probably work again.