### PR TITLE
Fix 'tk show' and 'tk diff' in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM alpine
+
+# less with `--RAW-CONTROL-CHARS` is required for tk show/ tk diff
+RUN apk add --no-cache less
+
 COPY tk /usr/local/bin/tk
 ENTRYPOINT ["/usr/local/bin/tk"]
 


### PR DESCRIPTION
Busybox less does not support `--RAW-CONTROL-CHARS`; `tk show` and `tk diff` fail in an unmodified alpine image.

Fixed by installing the full-fledged less.

**Before:**
```sh
> docker run -v `pwd`:/conf -w /conf -it grafana/tanka:latest show environments/dev
less: unrecognized option: RAW-CONTROL-CHARS
BusyBox v1.31.1 () multi-call binary.

Usage: less [-EFIMmNSRh~] [FILE]...
[...]
```
