### PR TITLE
fix(kubernetes): fmt related stack overflow

### DIFF
--- a/pkg/kubernetes/client/errors.go
+++ b/pkg/kubernetes/client/errors.go
@@ -25,12 +25,12 @@ func (e ErrorUnknownResource) Error() string {
 type ErrorNoContext string
 
 func (e ErrorNoContext) Error() string {
-	return fmt.Sprintf("no context named `%s` was found. Please check your $KUBECONFIG", e)
+	return fmt.Sprintf("no context named `%s` was found. Please check your $KUBECONFIG", string(e))
 }
 
 // ErrorNoCluster means that the cluster that was searched for couldn't be found
 type ErrorNoCluster string
 
 func (e ErrorNoCluster) Error() string {
-	return fmt.Sprintf("no cluster that matches the apiServer `%s` was found. Please check your $KUBECONFIG", e)
+	return fmt.Sprintf("no cluster that matches the apiServer `%s` was found. Please check your $KUBECONFIG", string(e))
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver"
-	"github.com/pkg/errors"
 
 	"github.com/grafana/tanka/pkg/kubernetes/client"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
@@ -32,7 +31,7 @@ func New(s v1alpha1.Spec) (*Kubernetes, error) {
 	// setup client
 	ctl, err := client.New(s.APIServer, s.Namespace)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating client")
+		return nil, err
 	}
 
 	// setup diffing


### PR DESCRIPTION
Apparently you can't `%s` `type string` things that implement `Error()`,
as it recurses.

Fixes #238 

/cc @rfratto @malcolmholmes 