### PR TITLE
Fixes for compatibility with windows style path environment variable.

### DIFF
--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -46,6 +46,7 @@ func writeNamespacePatch(context Context, defaultNamespace string) (string, erro
 	if err != nil {
 		return "", err
 	}
+
 	if err = ioutil.WriteFile(f.Name(), out, 0644); err != nil {
 		return "", err
 	}

--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -46,7 +46,6 @@ func writeNamespacePatch(context Context, defaultNamespace string) (string, erro
 	if err != nil {
 		return "", err
 	}
-
 	if err = ioutil.WriteFile(f.Name(), out, 0644); err != nil {
 		return "", err
 	}

--- a/pkg/kubernetes/client/exec.go
+++ b/pkg/kubernetes/client/exec.go
@@ -41,8 +41,7 @@ func patchKubeconfig(file string, e []string) []string {
 	if _, ok := env["KUBECONFIG"]; !ok {
 		env["KUBECONFIG"] = filepath.Join(homeDir(), ".kube", "config") // kubectl default
 	}
-	env["KUBECONFIG"] = fmt.Sprintf("%s:%s", file, env["KUBECONFIG"])
-
+	env["KUBECONFIG"] = fmt.Sprintf("%s%s%s", file, string(os.PathListSeparator), env["KUBECONFIG"])
 	return env.render()
 }
 

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -31,18 +31,18 @@ func New(endpoint, defaultNamespace string) (*Kubectl, error) {
 		return nil, errors.Wrap(err, "finding usable context")
 	}
 
-	// query versions (requires context)
-	k.info.ClientVersion, k.info.ServerVersion, err = k.version()
-	if err != nil {
-		return nil, errors.Wrap(err, "obtaining versions")
-	}
-
 	// set the default namespace by injecting it into the context
 	nsPatch, err := writeNamespacePatch(k.info.Kubeconfig.Context, defaultNamespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating $KUBECONFIG patch for default namespace")
 	}
 	k.nsPatch = nsPatch
+
+	// query versions (requires context)
+	k.info.ClientVersion, k.info.ServerVersion, err = k.version()
+	if err != nil {
+		return nil, errors.Wrap(err, "obtaining versions")
+	}
 
 	return &k, nil
 }


### PR DESCRIPTION
Don't call kubectl at all until after we drop the kubeconfig patch.

And use the correct os specific path separator.