### PR TITLE
Sort kubernetes objects before applying.

### DIFF
--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -2,23 +2,71 @@ package client
 
 import (
 	"os"
+	"sort"
 	"strings"
-
-	funk "github.com/thoas/go-funk"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
+// Order in which install different kinds of Kubernetes objects.
+// Inspired by https://github.com/helm/helm/blob/8c84a0bc0376650bc3d7334eef0c46356c22fa36/pkg/releaseutil/kind_sorter.go
+var kindOrder = []string{
+	"Namespace",
+	"NetworkPolicy",
+	"ResourceQuota",
+	"LimitRange",
+	"PodSecurityPolicy",
+	"PodDisruptionBudget",
+	"ServiceAccount",
+	"Secret",
+	"ConfigMap",
+	"StorageClass",
+	"PersistentVolume",
+	"PersistentVolumeClaim",
+	"CustomResourceDefinition",
+	"ClusterRole",
+	"ClusterRoleList",
+	"ClusterRoleBinding",
+	"ClusterRoleBindingList",
+	"Role",
+	"RoleList",
+	"RoleBinding",
+	"RoleBindingList",
+	"Service",
+	"DaemonSet",
+	"Pod",
+	"ReplicationController",
+	"ReplicaSet",
+	"Deployment",
+	"HorizontalPodAutoscaler",
+	"StatefulSet",
+	"Job",
+	"CronJob",
+	"Ingress",
+	"APIService",
+}
+
 // Apply applies the given yaml to the cluster
 func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
-	// create namespaces first to succeed first try
-	ns := filterNamespace(data)
-	if len(ns) > 0 {
-		if err := k.apply(ns, opts); err != nil {
-			return err
-		}
-	}
+	// sort the manifests into a sane install order
+	sort.SliceStable(data, func(i, j int) bool {
+		var io, jo int
 
+		// anything that is not in kindOrder will get to the end of the install list.
+		for io = 0; io < len(kindOrder); io++ {
+			if data[i].Kind() == kindOrder[io] {
+				break
+			}
+		}
+
+		for jo = 0; jo < len(kindOrder); jo++ {
+			if data[j].Kind() == kindOrder[jo] {
+				break
+			}
+		}
+
+		return io < jo
+	})
 	return k.apply(data, opts)
 }
 
@@ -39,10 +87,4 @@ func (k Kubectl) apply(data manifest.List, opts ApplyOpts) error {
 	cmd.Stdin = strings.NewReader(data.String())
 
 	return cmd.Run()
-}
-
-func filterNamespace(in manifest.List) manifest.List {
-	return manifest.List(funk.Filter(in, func(i manifest.Manifest) bool {
-		return strings.ToLower(i.Kind()) == "namespace"
-	}).([]manifest.Manifest))
 }

--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -7,51 +7,8 @@ import (
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
-// Order in which install different kinds of Kubernetes objects.
-// Inspired by https://github.com/helm/helm/blob/8c84a0bc0376650bc3d7334eef0c46356c22fa36/pkg/releaseutil/kind_sorter.go
-var kindOrder = []string{
-	"Namespace",
-	"NetworkPolicy",
-	"ResourceQuota",
-	"LimitRange",
-	"PodSecurityPolicy",
-	"PodDisruptionBudget",
-	"ServiceAccount",
-	"Secret",
-	"ConfigMap",
-	"StorageClass",
-	"PersistentVolume",
-	"PersistentVolumeClaim",
-	"CustomResourceDefinition",
-	"ClusterRole",
-	"ClusterRoleList",
-	"ClusterRoleBinding",
-	"ClusterRoleBindingList",
-	"Role",
-	"RoleList",
-	"RoleBinding",
-	"RoleBindingList",
-	"Service",
-	"DaemonSet",
-	"Pod",
-	"ReplicationController",
-	"ReplicaSet",
-	"Deployment",
-	"HorizontalPodAutoscaler",
-	"StatefulSet",
-	"Job",
-	"CronJob",
-	"Ingress",
-	"APIService",
-}
-
 // Apply applies the given yaml to the cluster
 func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
-	// Manifests have already been pre-sorted during the Reconcile phase.
-	return k.apply(data, opts)
-}
-
-func (k Kubectl) apply(data manifest.List, opts ApplyOpts) error {
 	argv := []string{"-f", "-"}
 	if opts.Force {
 		argv = append(argv, "--force")

--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
@@ -48,25 +47,7 @@ var kindOrder = []string{
 
 // Apply applies the given yaml to the cluster
 func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
-	// sort the manifests into a sane install order
-	sort.SliceStable(data, func(i, j int) bool {
-		var io, jo int
-
-		// anything that is not in kindOrder will get to the end of the install list.
-		for io = 0; io < len(kindOrder); io++ {
-			if data[i].Kind() == kindOrder[io] {
-				break
-			}
-		}
-
-		for jo = 0; jo < len(kindOrder); jo++ {
-			if data[j].Kind() == kindOrder[jo] {
-				break
-			}
-		}
-
-		return io < jo
-	})
+	// Manifests have already been pre-sorted during the Reconcile phase.
 	return k.apply(data, opts)
 }
 


### PR DESCRIPTION
Instead of just applying namespces before everything else, let's sort
all the objects. There's more inter-dependences between various kinds,
e.g. CRDs need to be applied before the actual custom resources,
StorageClasses before the PVCs, ... .