### PR TITLE
fix(diff): refuse to diff on kubectl 1.18

### DIFF
--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 
 	"github.com/grafana/tanka/pkg/kubernetes/client"
@@ -12,6 +13,13 @@ import (
 
 // Diff takes the desired state and returns the differences from the cluster
 func (k *Kubernetes) Diff(state manifest.List, opts DiffOpts) (*string, error) {
+	// prevent https://github.com/kubernetes/kubernetes/issues/89762 until fixed
+	if k.ctl.Info().ClientVersion.Equal(semver.MustParse("1.18.0")) {
+		return nil, fmt.Errorf(`You seem to be using kubectl 1.18.0, which contains an unfixed issue
+that makes 'kubectl diff' modify resources in your cluster.
+Please downgrade kubectl until https://github.com/kubernetes/kubernetes/issues/89762 is fixed.`)
+	}
+
 	// required for separating
 	namespaces, err := k.ctl.Namespaces()
 	if err != nil {


### PR DESCRIPTION
Kubectl 1.18 includes an unfixed issue that causes diff to apply as well – which
is a very bad thing. To avoid this, we now check and abort on that specific
version, prompting the user to downgrade as no fix is yet available.

https://github.com/kubernetes/kubernetes/issues/89762