### PR TITLE
fix(kubernetes): don't panic on failed diff

### DIFF
--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -37,8 +37,11 @@ func Apply(baseDir string, mods ...Modifier) error {
 		diff = &tmp
 	}
 
-	b := term.Colordiff(*diff)
-	fmt.Print(b.String())
+	// in case of non-fatal error diff may be nil
+	if diff != nil {
+		b := term.Colordiff(*diff)
+		fmt.Print(b.String())
+	}
 
 	return kube.Apply(p.Resources, opts.apply)
 }


### PR DESCRIPTION
We recently made diff errors in apply non-fatal, but accidentally made
them even more fatal because it can now panic.

Added a check to avoid this