### PR TITLE
doc: correct docs/directory-structure.md

### DIFF
--- a/docs/docs/directory-structure.md
+++ b/docs/docs/directory-structure.md
@@ -53,8 +53,8 @@ When talking about directories, Tanka uses the following terms:
 
 | Term      | Description                              | Identifier file                   |
 | --------- | ---------------------------------------- | --------------------------------- |
-| `baseDir` | The root of your project                 | `jsonnetfile.json` or `tkrc.yaml` |
-| `rootDir` | The directory of the current environment | `main.jsonnet`                    |
+| `rootDir` | The root of your project                 | `jsonnetfile.json` or `tkrc.yaml` |
+| `baseDir` | The directory of the current environment | `main.jsonnet`                    |
 
 Regardless what subdirectory of the project you are in, Tanka will always be
 able to identify both directories, by searching for the identifier files in the


### PR DESCRIPTION
In [docs/directory-structure.md#Root-and-Base](https://tanka.dev/directory-structure#root-and-base), `baseDir` and `rootDir` seems to be inverted in the table.