### PR TITLE
fix(make): static on all OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dev:
 
 LDFLAGS := '-s -w -extldflags "-static" -X main.Version=${VERSION}'
 static:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags=${LDFLAGS} ./cmd/tk
+	CGO_ENABLED=0 go build -ldflags=${LDFLAGS} ./cmd/tk
 
 install:
 	CGO_ENABLED=0 go install -ldflags=${LDFLAGS} ./cmd/tk


### PR DESCRIPTION
Included a GOOS=linux, which makes no sense