### PR TITLE
fix(test): use full config instead of spec

### DIFF
--- a/pkg/kubernetes/reconcile_test.go
+++ b/pkg/kubernetes/reconcile_test.go
@@ -179,7 +179,7 @@ func TestReconcileSorting(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res, err := Reconcile(test.raw, v1alpha1.New().Spec, test.targets)
+		res, err := Reconcile(test.raw, *v1alpha1.New(), test.targets)
 
 		require.NoError(t, err)
 		require.Equal(t, test.state, res)


### PR DESCRIPTION
Required for #902 to pass, no idea why that only happened after merge