### PR TITLE
Fix vendor patching example

### DIFF
--- a/docs/docs/libraries/overriding.md
+++ b/docs/docs/libraries/overriding.md
@@ -28,7 +28,7 @@ For example, if `/vendor/foo/bar.libsonnet` contained an error, you could create
 >
 > ```jsonnet
 > // in /lib/foo/bar.libsonnet:
-> import "../vendor/foo/bar.libsonnet" + {
+> (import "../../vendor/foo/bar.libsonnet") + {
 >   foo+: {
 >     bar: "fixed"
 >   }


### PR DESCRIPTION
- use parentheses to evaluate the import path, without which Jsonnet thinks the import is computed
- fix the relative path to the vendored library