### PR TITLE
chore(packaging): windows/amd64 binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ uninstall:
 $(GOX):
 	go get -u github.com/mitchellh/gox
 cross: $(GOX)
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64 arm64 arm" -os="linux" -osarch="darwin/amd64" ./cmd/tk
+	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64 arm64 arm" -os="linux" -osarch="darwin/amd64" -osarch="windows/amd64" ./cmd/tk
 
 # Docker container
 container: static


### PR DESCRIPTION
Adds `windows/amd64` platform, so we also provide `.exe` files for users
interested in Tanka on native Windows.

Everybody please keep in mind this is community support only, Grafana
Labs will not actively develop on Windows and not actively make Tanka
compatible with that platform.

Yet we try not to break it and accept community patches for arising issues.

Fixes #282 