### PR TITLE
fix(spec): Default apiServer URL to https

### DIFF
--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -60,7 +60,7 @@ func initCmd() *cli.Command {
 			}
 		}
 
-		fmt.Println("Directory structure set up! Remember to configure the API endpoint:\n`tk env set environments/default --server=127.0.0.1:6443`")
+		fmt.Println("Directory structure set up! Remember to configure the API endpoint:\n`tk env set environments/default --server=https://127.0.0.1:6443`")
 		if failed {
 			log.Println("Errors occured while initializing the project. Check the above logs for details.")
 		}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/pkg/errors"
 
@@ -55,6 +56,12 @@ func Parse(data []byte, name string) (*v1alpha1.Config, error) {
 	if err := handleDeprecated(config, data); err != nil {
 		return config, err
 	}
+
+	// default apiServer URL to https
+	if !regexp.MustCompile("^.+://").MatchString(config.Spec.APIServer) {
+		config.Spec.APIServer = "https://" + config.Spec.APIServer
+	}
+
 	return config, nil
 }
 


### PR DESCRIPTION
Defaults the apiServer URL scheme to `https://` if unset.

Also fixes the message printed by `tk init` to include the scheme

Fixes #287 