### PR TITLE
fix(jsonnet): import "tk" panic

### DIFF
--- a/pkg/jsonnet/importer.go
+++ b/pkg/jsonnet/importer.go
@@ -83,8 +83,7 @@ func tkLoader(importedFrom, importedPath string) (contents *jsonnet.Contents, fo
 		return nil, "", nil
 	}
 
-	s := jsonnet.MakeContents(tkLibsonnet)
-	return &s, filepath.Join(locationInternal, "tk.libsonnet"), nil
+	return &tkLibsonnet, filepath.Join(locationInternal, "tk.libsonnet"), nil
 }
 
 // newFileLoader returns an importLoader that uses jsonnet.FileImporter to source

--- a/pkg/jsonnet/tk.libsonnet.go
+++ b/pkg/jsonnet/tk.libsonnet.go
@@ -1,7 +1,9 @@
 package jsonnet
 
-const tkLibsonnet = `
+import jsonnet "github.com/google/go-jsonnet"
+
+var tkLibsonnet = jsonnet.MakeContents(`
 {
   env: std.extVar("tanka.dev/environment"),
 }
-`
+`)


### PR DESCRIPTION
`jsonnet.Importer` requires us to return the same `jsonnet.Contents`
each time the same path is imported.

Before, we returned a different `jsonnet.Contents` instance instead,
which the VM noticed and panics.