### PR TITLE
Slightly more flexible `export`

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -30,6 +30,7 @@ func exportCmd() *cli.Command {
 	vars := workflowFlags(cmd.Flags())
 	getExtCode := extCodeParser(cmd.Flags())
 	format := cmd.Flags().String("format", "{{.apiVersion}}.{{.kind}}-{{.metadata.name}}", "https://tanka.dev/exporting#filenames")
+	extension := cmd.Flags().String("extension", "yaml", "File extension")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		// dir must be empty
@@ -66,7 +67,7 @@ func exportCmd() *cli.Command {
 			name := strings.Replace(buf.String(), "/", "-", -1)
 
 			data := m.String()
-			if err := ioutil.WriteFile(filepath.Join(to, name+".yaml"), []byte(data), 0644); err != nil {
+			if err := ioutil.WriteFile(filepath.Join(to, name+"."+*extension), []byte(data), 0644); err != nil {
 				return fmt.Errorf("Writing manifest: %s", err)
 			}
 		}

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -32,6 +32,12 @@ func exportCmd() *cli.Command {
 	format := cmd.Flags().String("format", "{{.apiVersion}}.{{.kind}}-{{.metadata.name}}", "https://tanka.dev/exporting#filenames")
 	extension := cmd.Flags().String("extension", "yaml", "File extension")
 
+	templateFuncMap := template.FuncMap{
+		"lower": func(s string) string {
+			return strings.ToLower(s)
+		},
+	}
+
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		// dir must be empty
 		to := args[1]
@@ -44,7 +50,7 @@ func exportCmd() *cli.Command {
 		}
 
 		// exit early if the template is bad
-		tmpl, err := template.New("").Parse(*format)
+		tmpl, err := template.New("").Funcs(templateFuncMap).Parse(*format)
 		if err != nil {
 			return fmt.Errorf("Parsing name format: %s", err)
 		}

--- a/docs/docs/exporting.md
+++ b/docs/docs/exporting.md
@@ -52,3 +52,19 @@ loki-distributor-Deployment
 loki-loki-ConfigMap
 loki-ingester-Service
 ```
+
+You can optionally use the template function `lower` for lower-casing fields, e.g. in the above example
+
+```bash
+... --format='{{.metadata.labels.app}}-{{.metadata.name}}-{{.kind | lower}}'
+```
+
+would yield
+
+```
+loki-distributor-deployment
+```
+
+etc.
+
+You can also use a different file extension by providing `--extension='yml'`, for example.


### PR DESCRIPTION
Minor improvements for `export` to avoid some post-factum scripting when integrating into our stack.