### PR TITLE
Always use non-symlinked paths when listing imports.

### DIFF
--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -21,6 +21,11 @@ func TransitiveImports(dir string) ([]string, error) {
 		return nil, err
 	}
 
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		return nil, err
+	}
+
 	mainFile := filepath.Join(dir, "main.jsonnet")
 
 	sonnet, err := ioutil.ReadFile(mainFile)


### PR DESCRIPTION
Havin a "canonical" representation of the imports makes the life much
easier when trying to match environment's dependencies against a list of
changed jsonnet/libsonnet files.