### PR TITLE
Remove symlinks also from dependencies.

### DIFF
--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -56,7 +56,15 @@ func TransitiveImports(dir string) ([]string, error) {
 
 	paths := make([]string, 0, len(imports)+1)
 	for k := range imports {
+
+		// Try to resolve any symlinks; use the original path as a last resort
+		p, err := filepath.EvalSymlinks(k)
+		if err == nil {
+			paths = append(paths, p)
+			continue
+		}
 		paths = append(paths, k)
+
 	}
 	paths = append(paths, mainFile)
 

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -2,6 +2,7 @@ package jsonnet
 
 import (
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"sort"
 
@@ -59,11 +60,10 @@ func TransitiveImports(dir string) ([]string, error) {
 
 		// Try to resolve any symlinks; use the original path as a last resort
 		p, err := filepath.EvalSymlinks(k)
-		if err == nil {
-			paths = append(paths, p)
-			continue
+		if err != nil {
+			log.Fatalln("Failed to resolve symlink: ", err)
 		}
-		paths = append(paths, k)
+		paths = append(paths, p)
 
 	}
 	paths = append(paths, mainFile)

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -2,7 +2,6 @@ package jsonnet
 
 import (
 	"io/ioutil"
-	"log"
 	"path/filepath"
 	"sort"
 
@@ -61,7 +60,7 @@ func TransitiveImports(dir string) ([]string, error) {
 		// Try to resolve any symlinks; use the original path as a last resort
 		p, err := filepath.EvalSymlinks(k)
 		if err != nil {
-			log.Fatalln("Failed to resolve symlink: ", err)
+			return nil, errors.Wrap(err, "resolving symlinks")
 		}
 		paths = append(paths, p)
 


### PR DESCRIPTION
The change in https://github.com/grafana/tanka/pull/302 only removed
symlinks from the directory path for `main.jsonnet`; this commit also
modifies the code that iteratoes through all the transitive dependencies
to de-symlink them.