### PR TITLE
Implement `tk delete` functionality.

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -40,6 +40,7 @@ func main() {
 		showCmd(),
 		diffCmd(),
 		pruneCmd(),
+		deleteCmd(),
 	)
 
 	rootCmd.AddCommand(

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -92,7 +92,7 @@ func deleteCmd() *cli.Command {
 	}
 
 	vars := workflowFlags(cmd.Flags())
-	force := cmd.Flags().Bool("force", false, "force applying (kubectl delete --force)")
+	force := cmd.Flags().Bool("force", false, "force deleting (kubectl delete --force)")
 	validate := cmd.Flags().Bool("validate", true, "validation of resources (kubectl --validate=false)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	getExtCode := extCodeParser(cmd.Flags())

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -84,6 +84,35 @@ func pruneCmd() *cli.Command {
 	return cmd
 }
 
+func deleteCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "delete <path>",
+		Short: "delete the environment from the cluster",
+		Args:  workflowArgs,
+	}
+
+	vars := workflowFlags(cmd.Flags())
+	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
+	validate := cmd.Flags().Bool("validate", true, "validation of resources (kubectl --validate=false)")
+	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	getExtCode := extCodeParser(cmd.Flags())
+
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		err := tanka.Delete(args[0],
+			tanka.WithTargets(stringsToRegexps(vars.targets)),
+			tanka.WithExtCode(getExtCode()),
+			tanka.WithApplyForce(*force),
+			tanka.WithApplyValidate(*validate),
+			tanka.WithApplyAutoApprove(*autoApprove),
+		)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return cmd
+}
+
 func diffCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "diff <path>",

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -87,12 +87,12 @@ func pruneCmd() *cli.Command {
 func deleteCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "delete <path>",
-		Short: "delete the environment from the cluster",
+		Short: "delete the environment from cluster",
 		Args:  workflowArgs,
 	}
 
 	vars := workflowFlags(cmd.Flags())
-	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
+	force := cmd.Flags().Bool("force", false, "force applying (kubectl delete --force)")
 	validate := cmd.Flags().Bool("validate", true, "validation of resources (kubectl --validate=false)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	getExtCode := extCodeParser(cmd.Flags())

--- a/pkg/kubernetes/delete.go
+++ b/pkg/kubernetes/delete.go
@@ -8,7 +8,7 @@ import (
 
 type DeleteOpts client.DeleteOpts
 
-func (k *Kubernetes) Delete(state manifest.List, opts DeleteOpts) error {
+func (k *Kubernetes) Delete(state manifest.List, opts ApplyOpts) error {
 	// Sort and reverse the manifests to avoid cascading deletions
 	process.Sort(state)
 	for i := 0; i < len(state)/2; i++ {

--- a/pkg/kubernetes/delete.go
+++ b/pkg/kubernetes/delete.go
@@ -3,11 +3,20 @@ package kubernetes
 import (
 	"github.com/grafana/tanka/pkg/kubernetes/client"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/grafana/tanka/pkg/process"
 )
 
 type DeleteOpts client.DeleteOpts
 
 func (k *Kubernetes) Delete(state manifest.List, opts DeleteOpts) error {
+	// Sort and reverse the manifests to avoid cascading deletions
+	process.Sort(state)
+	for i := 0; i < len(state)/2; i++ {
+		t := state[i]
+		state[i] = state[len(state)-1-i]
+		state[len(state)-1-i] = t
+	}
+
 	for _, m := range state {
 		if err := k.ctl.Delete(m.Metadata().Namespace(), m.Kind(), m.Metadata().Name(), client.DeleteOpts(opts)); err != nil {
 			return err

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -50,5 +50,5 @@ func Prune(baseDir string, mods ...Modifier) error {
 	}
 
 	// delete resources
-	return kube.Delete(orphaned, kubernetes.DeleteOpts(opts.apply))
+	return kube.Delete(orphaned, opts.apply)
 }

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -27,8 +27,12 @@ type options struct {
 
 	// additional options for diff
 	diff kubernetes.DiffOpts
+
 	// additional options for apply
 	apply kubernetes.ApplyOpts
+
+	// additional options for delete
+	delete kubernetes.DeleteOpts
 }
 
 // Modifier allow to influence the behavior of certain `tanka.*` actions. They

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -30,10 +30,6 @@ type options struct {
 
 	// additional options for apply
 	apply kubernetes.ApplyOpts
-
-	// additional options for delete
-	// this is type-aliased to kubernetes.ApplyOpts and will be removed.
-	delete kubernetes.DeleteOpts
 }
 
 // Modifier allow to influence the behavior of certain `tanka.*` actions. They

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -32,6 +32,7 @@ type options struct {
 	apply kubernetes.ApplyOpts
 
 	// additional options for delete
+	// this is type-aliased to kubernetes.ApplyOpts and will be removed.
 	delete kubernetes.DeleteOpts
 }
 

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -110,6 +110,10 @@ func Delete(baseDir string, mods ...Modifier) error {
 	// static differ will never fail and always return something if input is not nil
 	diff, err := kubernetes.StaticDiffer(false)(l.Resources)
 
+	if err != nil {
+		fmt.Println("Error diffing:", err)
+	}
+
 	// in case of non-fatal error diff may be nil
 	if diff != nil {
 		b := term.Colordiff(*diff)
@@ -122,7 +126,7 @@ func Delete(baseDir string, mods ...Modifier) error {
 		return err
 	}
 
-	return kube.Delete(l.Resources, kubernetes.DeleteOpts(opts.apply))
+	return kube.Delete(l.Resources, opts.apply)
 }
 
 // Show parses the environment at the given directory (a `baseDir`) and returns

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -106,16 +106,9 @@ func Delete(baseDir string, mods ...Modifier) error {
 	}
 	defer kube.Close()
 
-	// The list of objects is sorted so that it applies correctly; to delete it, we need to reverse the order.
-	reversed := make(manifest.List, 0, len(l.Resources))
-
-	for i := len(l.Resources) - 1; i >= 0; i-- {
-		reversed = append(reversed, l.Resources[i])
-	}
-
 	// show diff
 	// static differ will never fail and always return something if input is not nil
-	diff, err := kubernetes.StaticDiffer(false)(reversed)
+	diff, err := kubernetes.StaticDiffer(false)(l.Resources)
 
 	// in case of non-fatal error diff may be nil
 	if diff != nil {
@@ -129,7 +122,7 @@ func Delete(baseDir string, mods ...Modifier) error {
 		return err
 	}
 
-	return kube.Delete(reversed, kubernetes.DeleteOpts(opts.apply))
+	return kube.Delete(l.Resources, kubernetes.DeleteOpts(opts.apply))
 }
 
 // Show parses the environment at the given directory (a `baseDir`) and returns

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -90,6 +90,54 @@ func Diff(baseDir string, mods ...Modifier) (*string, error) {
 	return kube.Diff(l.Resources, opts.diff)
 }
 
+// Delete parses the environment at the given directory (a `baseDir`) and deletes
+// the generated objects from the Kubernetes cluster defined in the environment's
+// `spec.json`.
+func Delete(baseDir string, mods ...Modifier) error {
+	opts := parseModifiers(mods)
+
+	l, err := load(baseDir, opts)
+	if err != nil {
+		return err
+	}
+	kube, err := l.connect()
+	if err != nil {
+		return err
+	}
+	defer kube.Close()
+
+	// The list of objects is sorted so that it applies correctly; to delete it, we need to reverse the order.
+	reversed := manifest.List{}
+	for i := len(l.Resources) - 1; i >= 0; i-- {
+		reversed = append(reversed, l.Resources[i])
+	}
+
+	// show diff
+	diff, err := kubernetes.StaticDiffer(false)(reversed)
+	switch {
+	case err != nil:
+		// This is not fatal, the diff is not strictly required
+		fmt.Println("Error diffing:", err)
+	case diff == nil:
+		tmp := "Warning: There are no differences. Your apply may not do anything at all."
+		diff = &tmp
+	}
+
+	// in case of non-fatal error diff may be nil
+	if diff != nil {
+		b := term.Colordiff(*diff)
+		fmt.Print(b.String())
+	}
+
+	// prompt for confirmation
+	if opts.delete.AutoApprove {
+	} else if err := confirmPrompt("Deleting from", l.Env.Spec.Namespace, kube.Info()); err != nil {
+		return err
+	}
+
+	return kube.Delete(reversed, opts.delete)
+}
+
 // Show parses the environment at the given directory (a `baseDir`) and returns
 // the list of Kubernetes objects.
 // Tip: use the `String()` function on the returned list to get the familiar yaml stream


### PR DESCRIPTION
This can be used to tear down a tanka environment. When doing `tk
delete`, tanka will generate all manifests for an environment and remove
them from kubernetes cluster.

This is a safer variant of the one-liner mentioned at https://github.com/grafana/tanka/issues/155