### PR TITLE
Don't attach namespaces to non-namespaced resources

### DIFF
--- a/docs/docs/namespaces.md
+++ b/docs/docs/namespaces.md
@@ -34,7 +34,10 @@ Some resources in Kubernetes are cluster-wide, meaning they don't belong to a si
 Tanka will make an attempt to not add namespaces to *known* cluster-wide types. 
 It does this with a short list of types in [the source code](https://github.com/grafana/tanka/blob/master/pkg/process/namespace.go).
 
-In case this ever becomes a problem, you can **override this** behavior
+Tanka cannot feasably maintain this list for all known custom resource types. In that case, those resources will have namespaces added to their manifests,
+and kubectl should happily apply them as non-namespaced resources.
+
+If this presents a problem for your workflow, you can **override this** behavior
 per-resource, by setting the `tanka.dev/namespaced` annotation to `"false"`
 (must be of `string` type):
 

--- a/docs/docs/namespaces.md
+++ b/docs/docs/namespaces.md
@@ -31,10 +31,8 @@ legit cases where it's handy to have them span multiple namespaces, for example:
 
 Some resources in Kubernetes are cluster-wide, meaning they don't belong to a single namespace at all.
 
-To Tanka these appear as _Scenario 1 (see above)_, so it will set the default
-namespace. In reality however, this is **not a problem**, because `kubectl`
-discards this information silently. We made this design-choice, because it
-simplifies our code a lot.
+Tanka will make an attempt to not add namespaces to *known* cluster-wide types. 
+It does this with a short list of types in [the source code](https://github.com/grafana/tanka/blob/master/pkg/process/namespace.go).
 
 In case this ever becomes a problem, you can **override this** behavior
 per-resource, by setting the `tanka.dev/namespaced` annotation to `"false"`

--- a/docs/docs/namespaces.md
+++ b/docs/docs/namespaces.md
@@ -34,7 +34,7 @@ Some resources in Kubernetes are cluster-wide, meaning they don't belong to a si
 Tanka will make an attempt to not add namespaces to *known* cluster-wide types. 
 It does this with a short list of types in [the source code](https://github.com/grafana/tanka/blob/master/pkg/process/namespace.go).
 
-Tanka cannot feasably maintain this list for all known custom resource types. In that case, those resources will have namespaces added to their manifests,
+Tanka cannot feasably maintain this list for all known custom resource types. In those cases, resources will have namespaces added to their manifests,
 and kubectl should happily apply them as non-namespaced resources.
 
 If this presents a problem for your workflow, you can **override this** behavior

--- a/pkg/process/namespace.go
+++ b/pkg/process/namespace.go
@@ -14,44 +14,33 @@ const (
 // This helps us to know which objects we should NOT apply namespaces to automatically.
 // We can add to this list periodically if new types are added. There is no reason not to add popular CRD types here as well.
 // Alternatively, library authors can add annotations to control namespacing for a type as well.
-var clusterWideKinds = []string{
-	"APIService",
-	"CertificateSigningRequest",
-	"ClusterRole",
-	"ClusterRoleBinding",
-	"ComponentStatus",
-	"CSIDriver",
-	"CSINode",
-	"CustomResourceDefinition",
-	"MutatingWebhookConfiguration",
-	"Namespace",
-	"Node",
-	"NodeMetrics",
-	"PersistentVolume",
-	"PodSecurityPolicy",
-	"PriorityClass",
-	"RuntimeClass",
-	"SelfSubjectAccessReview",
-	"SelfSubjectRulesReview",
-	"StorageClass",
-	"SubjectAccessReview",
-	"TokenReview",
-	"ValidatingWebhookConfiguration",
-	"VolumeAttachment",
+var clusterWideKinds = map[string]bool{
+	"APIService":                     true,
+	"CertificateSigningRequest":      true,
+	"ClusterRole":                    true,
+	"ClusterRoleBinding":             true,
+	"ComponentStatus":                true,
+	"CSIDriver":                      true,
+	"CSINode":                        true,
+	"CustomResourceDefinition":       true,
+	"MutatingWebhookConfiguration":   true,
+	"Namespace":                      true,
+	"Node":                           true,
+	"NodeMetrics":                    true,
+	"PersistentVolume":               true,
+	"PodSecurityPolicy":              true,
+	"PriorityClass":                  true,
+	"RuntimeClass":                   true,
+	"SelfSubjectAccessReview":        true,
+	"SelfSubjectRulesReview":         true,
+	"StorageClass":                   true,
+	"SubjectAccessReview":            true,
+	"TokenReview":                    true,
+	"ValidatingWebhookConfiguration": true,
+	"VolumeAttachment":               true,
 
 	// cert-manager
-	"ClusterIssuer",
-}
-
-// clusterWideMap is a generated lookup table on top of clusterWideKinds
-var clusterWideMap = buildClusterWideMap()
-
-func buildClusterWideMap() map[string]bool {
-	m := make(map[string]bool, len(clusterWideKinds))
-	for _, k := range clusterWideKinds {
-		m[k] = true
-	}
-	return m
+	"ClusterIssuer": true,
 }
 
 // Namespace injects the default namespace of the environment into each
@@ -64,7 +53,7 @@ func Namespace(list manifest.List, def string) manifest.List {
 
 	for i, m := range list {
 		namespaced := true
-		if clusterWideMap[m.Kind()] {
+		if clusterWideKinds[m.Kind()] {
 			namespaced = false
 		}
 		// check for annotation override

--- a/pkg/process/namespace.go
+++ b/pkg/process/namespace.go
@@ -12,8 +12,8 @@ const (
 
 // This is a list of "cluster-wide" resources harvested from `kubectl api-resources --namespaced=false`
 // This helps us to know which objects we should NOT apply namespaces to automatically.
-// We can add to this list periodically if new types are added. There is no reason not to add popular CRD types here as well.
-// Alternatively, library authors can add annotations to control namespacing for a type as well.
+// We can add to this list periodically if new types are added.
+// This only applies to built-in kubernetes types. CRDs will need to be handled with annotations.
 var clusterWideKinds = map[string]bool{
 	"APIService":                     true,
 	"CertificateSigningRequest":      true,
@@ -38,9 +38,6 @@ var clusterWideKinds = map[string]bool{
 	"TokenReview":                    true,
 	"ValidatingWebhookConfiguration": true,
 	"VolumeAttachment":               true,
-
-	// cert-manager
-	"ClusterIssuer": true,
 }
 
 // Namespace injects the default namespace of the environment into each

--- a/pkg/process/namespace.go
+++ b/pkg/process/namespace.go
@@ -10,6 +10,50 @@ const (
 	AnnotationNamespaced = MetadataPrefix + "/namespaced"
 )
 
+// This is a list of "cluster-wide" resources harvested from `kubectl api-resources --namespaced=false`
+// This helps us to know which objects we should NOT apply namespaces to automatically.
+// We can add to this list periodically if new types are added. There is no reason not to add popular CRD types here as well.
+// Alternatively, library authors can add annotations to control namespacing for a type as well.
+var clusterWideKinds = []string{
+	"APIService",
+	"CertificateSigningRequest",
+	"ClusterRole",
+	"ClusterRoleBinding",
+	"ComponentStatus",
+	"CSIDriver",
+	"CSINode",
+	"CustomResourceDefinition",
+	"MutatingWebhookConfiguration",
+	"Namespace",
+	"Node",
+	"NodeMetrics",
+	"PersistentVolume",
+	"PodSecurityPolicy",
+	"PriorityClass",
+	"RuntimeClass",
+	"SelfSubjectAccessReview",
+	"SelfSubjectRulesReview",
+	"StorageClass",
+	"SubjectAccessReview",
+	"TokenReview",
+	"ValidatingWebhookConfiguration",
+	"VolumeAttachment",
+
+	// cert-manager
+	"ClusterIssuer",
+}
+
+// clusterWideMap is a generated lookup table on top of clusterWideKinds
+var clusterWideMap = buildClusterWideMap()
+
+func buildClusterWideMap() map[string]bool {
+	m := make(map[string]bool, len(clusterWideKinds))
+	for _, k := range clusterWideKinds {
+		m[k] = true
+	}
+	return m
+}
+
 // Namespace injects the default namespace of the environment into each
 // resources, that does not already define one. AnnotationNamespaced can be used
 // to disable this per resource
@@ -20,7 +64,9 @@ func Namespace(list manifest.List, def string) manifest.List {
 
 	for i, m := range list {
 		namespaced := true
-
+		if clusterWideMap[m.Kind()] {
+			namespaced = false
+		}
 		// check for annotation override
 		if s, ok := m.Metadata().Annotations()[AnnotationNamespaced]; ok {
 			namespaced = s == "true"


### PR DESCRIPTION
This is a quick and dirty way to NOT add namespaces to  non-namespaced resource types like ClusterRoles or StorageClasses.

I ran into this when trying to export resources to a folder per namespace, and seeing things like ClusterRoles show up in nested namespaces, which is incorrect. It masked issues like multiple environments defining the same object because of the way it did this.

I implemented it as a simple list in namespace.go. If new types are added to the api we can add them here. It requires a little maintenance potentially, but it isn't world ending if we take too long to add something.