### PR TITLE
Fix issue #329: Windows indefinite loop

### DIFF
--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -67,7 +67,7 @@ func findRoot(start string) (dir string, err error) {
   // root path based on os
 	var stop string
 	if runtime.GOOS == "windows" {
-	  stop = "C:\\"
+	   stop = "C:\\"
 	} else {
 		stop = "/"
 	}

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 var (
@@ -63,14 +64,22 @@ func Resolve(workdir string) (path []string, base, root string, err error) {
 // - tkrc.yaml is considered first, for a jb-independent way of marking the root
 // - if it is not present (default), jsonnetfile.json is used.
 func findRoot(start string) (dir string, err error) {
+  // root path based on os
+	var stop string
+	if runtime.GOOS == "windows" {
+	    stop = "C:\\"
+	} else {
+		stop = "/"
+	}
+
 	// try tkrc.yaml first
-	root, err := FindParentFile("tkrc.yaml", start, "/")
+	root, err := FindParentFile("tkrc.yaml", start, stop)
 	if err == nil {
 		return root, nil
 	}
 
 	// otherwise use jsonnetfile.json
-	root, err = FindParentFile("jsonnetfile.json", start, "/")
+	root, err = FindParentFile("jsonnetfile.json", start, stop)
 	if err != nil {
 		if _, ok := err.(ErrorFileNotFound); ok {
 			return "", ErrorNoRoot

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -67,7 +67,7 @@ func findRoot(start string) (dir string, err error) {
   // root path based on os
 	var stop string
 	if runtime.GOOS == "windows" {
-	  stop = "C:\\"
+	  stop = filepath.VolumeName(start) + "\\"
 	} else {
 		stop = "/"
 	}

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -64,12 +64,10 @@ func Resolve(workdir string) (path []string, base, root string, err error) {
 // - tkrc.yaml is considered first, for a jb-independent way of marking the root
 // - if it is not present (default), jsonnetfile.json is used.
 func findRoot(start string) (dir string, err error) {
-  // root path based on os
-	var stop string
+	// root path based on os
+	stop := "/"
 	if runtime.GOOS == "windows" {
-	  stop = filepath.VolumeName(start) + "\\"
-	} else {
-		stop = "/"
+		stop = filepath.VolumeName(start) + "\\"
 	}
 
 	// try tkrc.yaml first

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -67,7 +67,7 @@ func findRoot(start string) (dir string, err error) {
   // root path based on os
 	var stop string
 	if runtime.GOOS == "windows" {
-	   stop = "C:\\"
+	  stop = "C:\\"
 	} else {
 		stop = "/"
 	}

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -67,7 +67,7 @@ func findRoot(start string) (dir string, err error) {
   // root path based on os
 	var stop string
 	if runtime.GOOS == "windows" {
-	    stop = "C:\\"
+	  stop = "C:\\"
 	} else {
 		stop = "/"
 	}


### PR DESCRIPTION
Problem: Indefinite loop in function findRoot

Root cause: Root path only consider linux "/"

Solution: Detect os at runtime and decide root path. Windows "C:\\", others "/"

Fixes #329