### PR TITLE
feat(cli): mainfile argument

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -25,6 +25,7 @@ func evalCmd() *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		raw, err := tanka.Eval(args[0],
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithMainfile("main.jsonnet"),
 		)
 
 		if err != nil {

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -24,12 +24,14 @@ const (
 )
 
 type workflowFlagVars struct {
-	targets []string
+	targets  []string
+	mainfile string
 }
 
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
 	fs.StringSliceVarP(&v.targets, "target", "t", nil, "only use the specified objects (Format: <type>/<name>)")
+	fs.StringVarP(&v.mainfile, "mainfile", "m", "main.jsonnet", "entrypoint into the evaluation")
 	return &v
 }
 
@@ -49,6 +51,7 @@ func applyCmd() *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		err := tanka.Apply(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
+			tanka.WithMainfile(vars.mainfile),
 			tanka.WithExtCode(getExtCode()),
 			tanka.WithApplyForce(*force),
 			tanka.WithApplyValidate(*validate),
@@ -135,6 +138,7 @@ func diffCmd() *cli.Command {
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		changes, err := tanka.Diff(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
+			tanka.WithMainfile(vars.mainfile),
 			tanka.WithExtCode(getExtCode()),
 			tanka.WithDiffStrategy(*diffStrategy),
 			tanka.WithDiffSummarize(*summarize),
@@ -181,6 +185,7 @@ Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
 
 		pretty, err := tanka.Show(args[0],
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithMainfile(vars.mainfile),
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
 		)
 		if err != nil {

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -56,7 +56,7 @@ func (p *loaded) connect() (*kubernetes.Kubernetes, error) {
 
 // load runs all processing stages described at the Processed type
 func load(dir string, opts *options) (*loaded, error) {
-	raw, env, err := eval(dir, opts.extCode)
+	raw, env, err := eval(dir, opts.mainfile, opts.extCode)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func load(dir string, opts *options) (*loaded, error) {
 
 // eval runs all processing stages describe at the Processed type apart from
 // post-processing, thus returning the raw Jsonnet result.
-func eval(dir string, extCode map[string]string) (raw map[string]interface{}, env *v1alpha1.Config, err error) {
+func eval(dir string, mainFile string, extCode map[string]string) (raw map[string]interface{}, env *v1alpha1.Config, err error) {
 	_, baseDir, rootDir, err := jpath.Resolve(dir)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "resolving jpath")
@@ -85,7 +85,7 @@ func eval(dir string, extCode map[string]string) (raw map[string]interface{}, en
 		return nil, nil, err
 	}
 
-	raw, err = evalJsonnet(baseDir, env, extCode)
+	raw, err = evalJsonnet(baseDir, mainFile, env, extCode)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "evaluating jsonnet")
 	}
@@ -119,7 +119,7 @@ func parseSpec(baseDir, rootDir string) (*v1alpha1.Config, error) {
 
 // evalJsonnet evaluates the jsonnet environment at the given directory starting with
 // `main.jsonnet`
-func evalJsonnet(baseDir string, env *v1alpha1.Config, extCode map[string]string) (map[string]interface{}, error) {
+func evalJsonnet(baseDir string, mainFile string, env *v1alpha1.Config, extCode map[string]string) (map[string]interface{}, error) {
 	jsonEnv, err := json.Marshal(env)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling environment config")
@@ -133,7 +133,7 @@ func evalJsonnet(baseDir string, env *v1alpha1.Config, extCode map[string]string
 	}
 
 	raw, err := jsonnet.EvaluateFile(
-		filepath.Join(baseDir, "main.jsonnet"),
+		filepath.Join(baseDir, mainFile),
 		ext...,
 	)
 	if err != nil {

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -25,6 +25,9 @@ type options struct {
 	// target regular expressions to limit the working set
 	targets process.Matchers
 
+	// main file path into evaluation
+	mainfile string
+
 	// additional options for diff
 	diff kubernetes.DiffOpts
 
@@ -88,5 +91,12 @@ func WithApplyValidate(b bool) Modifier {
 func WithApplyAutoApprove(b bool) Modifier {
 	return func(opts *options) {
 		opts.apply.AutoApprove = b
+	}
+}
+
+// WithMainfile allows to pass the entrypoint into evaluation
+func WithMainfile(main string) Modifier {
+	return func(opts *options) {
+		opts.mainfile = main
 	}
 }

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -147,7 +147,7 @@ func Show(baseDir string, mods ...Modifier) (manifest.List, error) {
 func Eval(dir string, mods ...Modifier) (raw map[string]interface{}, err error) {
 	opts := parseModifiers(mods)
 
-	r, _, err := eval(dir, opts.extCode)
+	r, _, err := eval(dir, opts.mainfile, opts.extCode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, `main.jsonnet` is a starting point to jsonnet compilation.  Sometimes, I would like to have many starting points in an environment (for partial sync/diff). For example, I manage addons with tanka. Because these addons have many resources, some operations like diff/apply is not fast. 

```
$tk diff -h
differences between the configuration and the cluster

Usage:
  tk diff <path> [flags]

Flags:
   --diff-strategy string   force the diff-strategy to use. Automatically chosen if not set.
  -e, --extCode stringArray    Inject any Jsonnet from the outside (Format: key=<code>)
      --extVar stringArray     Inject a string from the outside (Format: key=value)
  -h, --help                   help for diff
  -m, --mainfile string        entrypoint into the evaluation (default "main.jsonnet")
  -s, --summarize              quick summary of the differences, hides file contents
  -t, --target strings         only use the specified objects (Format: <type>/<name>)
```

```
$ls
certs.jsonnet    config.libsonnet ingress.jsonnet  main.jsonnet     spec.json
cluster.jsonnet  datadog.jsonnet  logging.jsonnet  service.jsonnet
$tk apply -m cluster.jsonnet .
```
 

 
 