### PR TITLE
fix(k8s): consistent types in manifest.Manifest

### DIFF
--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -220,7 +220,7 @@ func (m Metadata) UID() string {
 
 // Labels of the manifest
 func (m Metadata) Labels() map[string]interface{} {
-	return safeMSI(m, "annotations")
+	return safeMSI(m, "labels")
 }
 
 // Annotations of the manifest

--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -219,37 +219,22 @@ func (m Metadata) UID() string {
 }
 
 // Labels of the manifest
-func (m Metadata) Labels() map[string]string {
-	return safeStringMap(m, "labels")
+func (m Metadata) Labels() map[string]interface{} {
+	return safeMSI(m, "annotations")
 }
 
 // Annotations of the manifest
-func (m Metadata) Annotations() map[string]string {
-	return safeStringMap(m, "annotations")
+func (m Metadata) Annotations() map[string]interface{} {
+	return safeMSI(m, "annotations")
 }
 
-// safeStringMap safely returns a string map:
-// - returns if map[string]string
-// - converts if map[string]interface{}
-// - zeroes if anything else
-func safeStringMap(m map[string]interface{}, key string) map[string]string {
+func safeMSI(m map[string]interface{}, key string) map[string]interface{} {
 	switch t := m[key].(type) {
-	case map[string]string:
-		return t
 	case map[string]interface{}:
-		mss := make(map[string]string)
-		for k, v := range t {
-			s, ok := v.(string)
-			if !ok {
-				continue
-			}
-			mss[k] = s
-		}
-		m[key] = mss
-		return m[key].(map[string]string)
+		return t
 	default:
-		m[key] = make(map[string]string)
-		return m[key].(map[string]string)
+		m[key] = make(map[string]interface{})
+		return m[key].(map[string]interface{})
 	}
 }
 


### PR DESCRIPTION
The manifest.Manifest is a `map[string]interface{}`, which sticks to what `json.Unmarshal` returns, meaning it only includes concrete values, `[]interface{}` and `map[string]interface{}`.

In a v0.10 change I accidentally broke that, without realizing it: https://github.com/grafana/tanka/blob/a6d5fde5aac69dc4d66bb57d5a501e52ba60fada/pkg/kubernetes/manifest/manifest.go#L248

Up to #312, this didn't create any issues. Now however, because we called `Annotations` on all objects, types weren't like they should have been.

This caused subsetdiff to miss annotations, not computing the subset on them at all.

Fixes #318