### PR TITLE
feat(cli): support negative filters

### DIFF
--- a/docs/docs/targets.md
+++ b/docs/docs/targets.md
@@ -78,3 +78,14 @@ apiVersion: apps/v1
 kind: Deployment
 # ...
 ```
+
+## Excluding
+
+Sometimes it may be desirably to exclude a single object, instead of including all others.
+
+To do so, prepend the regular expression with an exclamation mark (`!`), like so:
+
+```bash
+# filter out all Deployments
+$ tk show . -t '!deployment/.*'
+```

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -65,6 +65,15 @@ func TestProcess(t *testing.T) {
 			),
 		},
 		{
+			name: "targets-negative",
+			deep: testDataDeep().Deep,
+			flat: manifest.List{
+				testDataDeep().Flat[".app.web.frontend.nodejs.express.service"],
+				testDataDeep().Flat[".app.namespace"],
+			},
+			targets: MustStrExps(`!deployment/.*`),
+		},
+		{
 			name: "unwrap-list",
 			deep: loadFixture("list").Deep,
 			flat: manifest.List{


### PR DESCRIPTION
Output filtering (`-t`) now supports excluding objects, by prepending an
exlamation mark (`!`) before the regular expression

Fixes #324 