### PR TITLE
feat(jsonnet): top level arguments

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -33,7 +33,7 @@ func exportCmd() *cli.Command {
 	}
 
 	vars := workflowFlags(cmd.Flags())
-	getExtCode := extCodeParser(cmd.Flags())
+	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
 	format := cmd.Flags().String("format", "{{.apiVersion}}.{{.kind}}-{{.metadata.name}}", "https://tanka.dev/exporting#filenames")
 	extension := cmd.Flags().String("extension", "yaml", "File extension")
 	merge := cmd.Flags().Bool("merge", false, "Allow merging with existing directory")
@@ -68,6 +68,7 @@ func exportCmd() *cli.Command {
 		// get the manifests
 		res, err := tanka.Show(args[0],
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithTLACode(getTLACode()),
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
 		)
 		if err != nil {

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -44,12 +44,14 @@ func applyCmd() *cli.Command {
 	force := cmd.Flags().Bool("force", false, "force applying (kubectl apply --force)")
 	validate := cmd.Flags().Bool("validate", true, "validation of resources (kubectl --validate=false)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
-	getExtCode := extCodeParser(cmd.Flags())
+
+	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		err := tanka.Apply(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithTLACode(getTLACode()),
 			tanka.WithApplyForce(*force),
 			tanka.WithApplyValidate(*validate),
 			tanka.WithApplyAutoApprove(*autoApprove),
@@ -69,13 +71,14 @@ func pruneCmd() *cli.Command {
 		Args:  workflowArgs,
 	}
 
-	getExtCode := extCodeParser(cmd.Flags())
+	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	force := cmd.Flags().Bool("force", false, "force deleting (kubectl delete --force)")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		return tanka.Prune(args[0],
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithTLACode(getTLACode()),
 			tanka.WithApplyAutoApprove(*autoApprove),
 			tanka.WithApplyForce(*force),
 		)
@@ -95,12 +98,13 @@ func deleteCmd() *cli.Command {
 	force := cmd.Flags().Bool("force", false, "force deleting (kubectl delete --force)")
 	validate := cmd.Flags().Bool("validate", true, "validation of resources (kubectl --validate=false)")
 	autoApprove := cmd.Flags().Bool("dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
-	getExtCode := extCodeParser(cmd.Flags())
+	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		err := tanka.Delete(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithTLACode(getTLACode()),
 			tanka.WithApplyForce(*force),
 			tanka.WithApplyValidate(*validate),
 			tanka.WithApplyAutoApprove(*autoApprove),
@@ -130,12 +134,13 @@ func diffCmd() *cli.Command {
 		summarize    = cmd.Flags().BoolP("summarize", "s", false, "quick summary of the differences, hides file contents")
 	)
 
-	getExtCode := extCodeParser(cmd.Flags())
+	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		changes, err := tanka.Diff(args[0],
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithTLACode(getTLACode()),
 			tanka.WithDiffStrategy(*diffStrategy),
 			tanka.WithDiffSummarize(*summarize),
 		)
@@ -170,7 +175,7 @@ func showCmd() *cli.Command {
 	}
 	vars := workflowFlags(cmd.Flags())
 	allowRedirect := cmd.Flags().Bool("dangerous-allow-redirect", false, "allow redirecting output to a file or a pipe.")
-	getExtCode := extCodeParser(cmd.Flags())
+	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		if !interactive && !*allowRedirect {
 			fmt.Fprintln(os.Stderr, `Redirection of the output of tk show is discouraged and disabled by default.
@@ -181,6 +186,7 @@ Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
 
 		pretty, err := tanka.Show(args[0],
 			tanka.WithExtCode(getExtCode()),
+			tanka.WithTLACode(getTLACode()),
 			tanka.WithTargets(stringsToRegexps(vars.targets)),
 		)
 		if err != nil {

--- a/docs/docs/jsonnet/injecting-values.md
+++ b/docs/docs/jsonnet/injecting-values.md
@@ -23,7 +23,7 @@ Jsonnet is a superset of JSON, it treats any JSON as valid Jsonnet. Because many
 systems can be told to output their data in JSON format, this provides a pretty
 good interface between those.
 
-For example, your deployment pipeline could acquire secrets from systems such as
+For example, your build tooling like `make` could acquire secrets from systems such as
 [Vault](https://www.vaultproject.io/), etc. and write that into `secrets.json`.
 
 ```jsonnet

--- a/docs/docs/jsonnet/injecting-values.md
+++ b/docs/docs/jsonnet/injecting-values.md
@@ -1,0 +1,89 @@
+---
+name: "Injecting Values"
+route: "/jsonnet/injecting-values"
+menu: "Writing Jsonnet"
+---
+
+# Injecting Values
+
+Sometimes it might be required to pass externally acquired data into Jsonnet.
+
+There are three ways of doing so:
+
+1. [JSON files](#json-files)
+2. [External variables](#external-variables)
+3. [Top level arguments](#top-level-arguments)
+
+## JSON files
+
+Jsonnet is a superset of JSON, it treats any JSON as valid Jsonnet. Because many
+systems can be told to output their data in JSON format, this provides a pretty
+good interface between those.
+
+For example, your deployment pipeline could acquire secrets from systems such as
+[Vault](https://www.vaultproject.io/), etc. and write that into `secrets.json`.
+
+```jsonnet
+local secrets = import "secrets.json";
+
+{
+  foo: secrets.myPassword,
+}
+```
+
+## External variables
+
+Another way of passing values from the outside are external variables, which are specified like so:
+
+```bash
+# strings
+$ tk show . --ext-str hello=world
+
+# any Jsonnet snippet
+$ tk show . --ext-str foo=4 --ext-str bar='[ 1, 3 ]'
+```
+
+They can be accessed using `std.extVar` and the name given to them on the command line:
+
+```jsonnet
+{
+  foo: std.extVar('foo'), // 4, integer
+  bar: std.extVar('bar'), // [ 1, 3 ], array
+}
+```
+
+> **Warning**: It's not possible to detect what extVars are available, and it's
+> not possible to set default values.  
+> Try to use [**Top Level Arguments**](#top-level-arguments) instead, to avoid surprising behaviour
+
+## Top Level Arguments
+
+To avoid the magic and possibly surprising nature of external variables, Top
+Level Arguments can be used.
+
+Usually with Tanka, your `main.jsonnet` holds an object at the top level (most
+outer type in the generated JSON):
+
+```jsonnet
+// main.jsonnet
+{
+  /* your resources */
+}
+```
+
+Another type of Jsonnet that naturally accepts parameters is the `function`.
+When the Jsonnet compiler finds a function at the top level, it invokes it and
+allows passing parameter values from the command line:
+
+```jsonnet
+// function returns the final object, supporting parameters and default values
+function(who, msg="Hello %s!") {
+  hello: msg % who
+}
+```
+
+Here, `who` needs a value while `msg` has a default. This can be invoked like so:
+
+```bash
+$ tk show . --tla-str who=John
+```

--- a/docs/docs/jsonnet/injecting-values.md
+++ b/docs/docs/jsonnet/injecting-values.md
@@ -14,6 +14,9 @@ There are three ways of doing so:
 2. [External variables](#external-variables)
 3. [Top level arguments](#top-level-arguments)
 
+Also check out the [official Jsonnet docs on this
+topic](https://jsonnet.org/ref/language.html#passing-data-to-jsonnet).
+
 ## JSON files
 
 Jsonnet is a superset of JSON, it treats any JSON as valid Jsonnet. Because many
@@ -31,6 +34,10 @@ local secrets = import "secrets.json";
 }
 ```
 
+> **Note**: Using `import` with JSON treats it as Jsonnet, so make sure to not
+> use it with untrusted code.  
+> A safer, but more verbose, alternative is `std.parseJson(importstr 'path_to_json.json')`
+
 ## External variables
 
 Another way of passing values from the outside are external variables, which are specified like so:
@@ -40,7 +47,7 @@ Another way of passing values from the outside are external variables, which are
 $ tk show . --ext-str hello=world
 
 # any Jsonnet snippet
-$ tk show . --ext-str foo=4 --ext-str bar='[ 1, 3 ]'
+$ tk show . --ext-code foo=4 --ext-code bar='[ 1, 3 ]'
 ```
 
 They can be accessed using `std.extVar` and the name given to them on the command line:
@@ -52,14 +59,12 @@ They can be accessed using `std.extVar` and the name given to them on the comman
 }
 ```
 
-> **Warning**: It's not possible to detect what extVars are available, and it's
-> not possible to set default values.  
-> Try to use [**Top Level Arguments**](#top-level-arguments) instead, to avoid surprising behaviour
+> **Warning**: External variables are directly accessible in all parts of the
+> configuration, which can make it difficult to track where they are used and
+> what effect they have on the final result.
+> Try to use [Top Level Arguments](#top-level-arguments) instead.
 
 ## Top Level Arguments
-
-To avoid the magic and possibly surprising nature of external variables, Top
-Level Arguments can be used.
 
 Usually with Tanka, your `main.jsonnet` holds an object at the top level (most
 outer type in the generated JSON):
@@ -76,7 +81,7 @@ When the Jsonnet compiler finds a function at the top level, it invokes it and
 allows passing parameter values from the command line:
 
 ```jsonnet
-// function returns the final object, supporting parameters and default values
+// Actual output (object) returned by function, which is taking parameters and default values
 function(who, msg="Hello %s!") {
   hello: msg % who
 }

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -55,3 +55,11 @@ func WithExtCode(key, code string) Modifier {
 		return nil
 	}
 }
+
+// WithTLA allows to set the given code as a top level argument
+func WithTLA(key, code string) Modifier {
+	return func(vm *jsonnet.VM) error {
+		vm.TLACode(key, code)
+		return nil
+	}
+}

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -21,6 +21,7 @@ func parseModifiers(mods []Modifier) *options {
 type options struct {
 	// `std.extVar`
 	extCode map[string]string
+	tlaCode map[string]string
 
 	// target regular expressions to limit the working set
 	targets process.Matchers
@@ -39,6 +40,12 @@ type Modifier func(*options)
 
 // WithExtCode allows to pass external variables (jsonnet code) to the VM
 func WithExtCode(code map[string]string) Modifier {
+	return func(opts *options) {
+		opts.extCode = code
+	}
+}
+
+func WithTLACode(code map[string]string) Modifier {
 	return func(opts *options) {
 		opts.extCode = code
 	}


### PR DESCRIPTION
Exposes the TLA functionality of Jsonnet.

BREAKING: Changes the extVar flags to match those of the `jsonnet` CLI

/cc @sbarzowski, would be super cool if you could give the docs added by this PR a quick look if they are complete and correct