### PR TITLE
fix(readme): build status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cloud.drone.io/grafana/tanka">
-    <img src="https://img.shields.io/drone/build/grafana/tanka?style=flat-square">
+    <img src="https://img.shields.io/drone/build/grafana/tanka?style=flat-square&server=https%3A%2F%2Fdrone.grafana.net">
   </a>
   <a href="https://github.com/grafana/tanka/releases">
     <img src="https://img.shields.io/github/release/grafana/tanka?style=flat-square" />


### PR DESCRIPTION
Makes it point to Grafana Drone instead of Drone Cloud which is no longer used by us