### PR TITLE
Using jbBinary variable instead of hardcoded jb

### DIFF
--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -89,7 +89,7 @@ func installK8sLib() error {
 		return err
 	}
 
-	cmd := exec.Command("jb", append([]string{"install"}, initialPackages...)...)
+	cmd := exec.Command(jbBinary, append([]string{"install"}, initialPackages...)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
A new environmental variable was added called `TANKA_JB_PATH` however it's not actually being used to install the packages due to `"jb"` still being hardcoded.