### PR TITLE
feat(cli): fallback to PredictDirs

### DIFF
--- a/cmd/tk/args.go
+++ b/cmd/tk/args.go
@@ -7,10 +7,11 @@ import (
 
 var workflowArgs = cli.Args{
 	Validator: cli.ValidateExact(1),
-	Predictor: cli.PredictFunc(func(complete.Args) []string {
+	Predictor: cli.PredictFunc(func(args complete.Args) []string {
 		if dirs := findBaseDirs(); len(dirs) != 0 {
 			return dirs
 		}
-		return []string{""}
+
+		return complete.PredictDirs("*").Predict(args)
 	}),
 }


### PR DESCRIPTION
When environment completion is not available the projectRoot is not
reliably detected, tk now suggests any directory instead of an empty
set.

Fixes #352 

@ghostsquad