### PR TITLE
Add default labels and annotations from spec.json

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.2-0.20200818193711-d2fcc899bdc2 h1:CZtx9gNen+kr3PuC/JQff3n1pJbgpy7Wr3hzjnupqdw=
 github.com/google/go-cmp v0.5.2-0.20200818193711-d2fcc899bdc2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-jsonnet v0.15.1-0.20200331184325-4f4aa80dd785 h1:+dlQ7fPoeAqO0U9V+94golo/rW1/V2Pn+v8aPp3ljRM=
 github.com/google/go-jsonnet v0.15.1-0.20200331184325-4f4aa80dd785/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -41,6 +41,9 @@ func Process(raw interface{}, cfg v1alpha1.Config, exprs Matchers) (manifest.Lis
 	// tanka.dev/** labels
 	out = Label(out, cfg)
 
+	// arbitrary annotations from spec
+	out = Annotate(out, cfg)
+
 	// Perhaps filter for kind/name expressions
 	if len(exprs) > 0 {
 		out = Filter(out, exprs)
@@ -62,6 +65,19 @@ func Label(list manifest.List, cfg v1alpha1.Config) manifest.List {
 		list[i] = m
 	}
 
+	return list
+}
+
+func Annotate(list manifest.List, cfg v1alpha1.Config) manifest.List {
+	for i, m := range list {
+		for k, v := range cfg.Spec.Annotations {
+			annotations := m.Metadata().Annotations()
+			if _, ok := annotations[k]; !ok {
+				annotations[k] = v
+			}
+		}
+		list[i] = m
+	}
 	return list
 }
 

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -41,8 +41,8 @@ func Process(raw interface{}, cfg v1alpha1.Config, exprs Matchers) (manifest.Lis
 	// tanka.dev/** labels
 	out = Label(out, cfg)
 
-	// arbitrary annotations from spec
-	out = Annotate(out, cfg)
+	// arbitrary labels and annotations from spec
+	out = ApplyDefaults(out, cfg)
 
 	// Perhaps filter for kind/name expressions
 	if len(exprs) > 0 {
@@ -68,14 +68,22 @@ func Label(list manifest.List, cfg v1alpha1.Config) manifest.List {
 	return list
 }
 
-func Annotate(list manifest.List, cfg v1alpha1.Config) manifest.List {
+func ApplyDefaults(list manifest.List, cfg v1alpha1.Config) manifest.List {
 	for i, m := range list {
-		for k, v := range cfg.Spec.Annotations {
+		for k, v := range cfg.Spec.ResourceDefaults.Annotations {
 			annotations := m.Metadata().Annotations()
 			if _, ok := annotations[k]; !ok {
 				annotations[k] = v
 			}
 		}
+
+		for k, v := range cfg.Spec.ResourceDefaults.Labels {
+			labels := m.Metadata().Labels()
+			if _, ok := labels[k]; !ok {
+				labels[k] = v
+			}
+		}
+
 		list[i] = m
 	}
 	return list

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -42,7 +42,7 @@ func Process(raw interface{}, cfg v1alpha1.Config, exprs Matchers) (manifest.Lis
 	out = Label(out, cfg)
 
 	// arbitrary labels and annotations from spec
-	out = ApplyDefaults(out, cfg)
+	out = ResourceDefaults(out, cfg)
 
 	// Perhaps filter for kind/name expressions
 	if len(exprs) > 0 {
@@ -68,7 +68,7 @@ func Label(list manifest.List, cfg v1alpha1.Config) manifest.List {
 	return list
 }
 
-func ApplyDefaults(list manifest.List, cfg v1alpha1.Config) manifest.List {
+func ResourceDefaults(list manifest.List, cfg v1alpha1.Config) manifest.List {
 	for i, m := range list {
 		for k, v := range cfg.Spec.ResourceDefaults.Annotations {
 			annotations := m.Metadata().Annotations()

--- a/pkg/process/resourceDefaults_test.go
+++ b/pkg/process/resourceDefaults_test.go
@@ -82,7 +82,7 @@ func TestResourceDefaults(t *testing.T) {
 				expected.Labels()[k] = v
 			}
 
-			result := ApplyDefaults(manifest.List{before}, cfg)
+			result := ResourceDefaults(manifest.List{before}, cfg)
 			actual := result[0]
 			if diff := cmp.Diff(expected, actual.Metadata()); diff != "" {
 				t.Error(diff)

--- a/pkg/process/resourceDefaults_test.go
+++ b/pkg/process/resourceDefaults_test.go
@@ -1,0 +1,92 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+)
+
+func TestResourceDefaults(t *testing.T) {
+	cases := []struct {
+		name                string
+		beforeAnnotations   map[string]string
+		beforeLabels        map[string]string
+		specAnnotations     map[string]string
+		specLabels          map[string]string
+		expectedAnnotations map[string]string
+		expectedLabels      map[string]string
+	}{
+		// resource without a namespace: set it
+		{
+			name: "No change",
+		},
+		{
+			name:                "Add annotation",
+			specAnnotations:     map[string]string{"a": "b"},
+			expectedAnnotations: map[string]string{"a": "b"},
+		},
+		{
+			name:           "Add Label",
+			specLabels:     map[string]string{"a": "b"},
+			expectedLabels: map[string]string{"a": "b"},
+		},
+		{
+			name:                "Add leaves existing",
+			beforeAnnotations:   map[string]string{"1": "2"},
+			beforeLabels:        map[string]string{"1": "2"},
+			specAnnotations:     map[string]string{"a": "b"},
+			specLabels:          map[string]string{"a": "b"},
+			expectedAnnotations: map[string]string{"a": "b", "1": "2"},
+			expectedLabels:      map[string]string{"a": "b", "1": "2"},
+		},
+		{
+			name:                "Existing overrides spec",
+			beforeAnnotations:   map[string]string{"a": "c", "1": "2"},
+			beforeLabels:        map[string]string{"a": "c", "1": "2"},
+			specAnnotations:     map[string]string{"a": "b"},
+			specLabels:          map[string]string{"a": "b"},
+			expectedAnnotations: map[string]string{"a": "c", "1": "2"},
+			expectedLabels:      map[string]string{"a": "c", "1": "2"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := v1alpha1.Config{
+				Spec: v1alpha1.Spec{
+					ResourceDefaults: v1alpha1.ResourceDefaults{
+						Annotations: c.specAnnotations,
+						Labels:      c.specLabels,
+					},
+				},
+			}
+
+			before := manifest.Manifest{
+				"kind": "Deployment",
+			}
+			for k, v := range c.beforeAnnotations {
+				before.Metadata().Annotations()[k] = v
+			}
+			for k, v := range c.beforeLabels {
+				before.Metadata().Labels()[k] = v
+			}
+
+			expected := manifest.Metadata{}
+			for k, v := range c.expectedAnnotations {
+				expected.Annotations()[k] = v
+			}
+			for k, v := range c.expectedLabels {
+				expected.Labels()[k] = v
+			}
+
+			result := ApplyDefaults(manifest.List{before}, cfg)
+			actual := result[0]
+			if diff := cmp.Diff(expected, actual.Metadata()); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/pkg/spec/v1alpha1/config.go
+++ b/pkg/spec/v1alpha1/config.go
@@ -50,8 +50,9 @@ func (m Metadata) NameLabel() string {
 
 // Spec defines Kubernetes properties
 type Spec struct {
-	APIServer    string `json:"apiServer"`
-	Namespace    string `json:"namespace"`
-	DiffStrategy string `json:"diffStrategy,omitempty"`
-	InjectLabels bool   `json:"injectLabels,omitempty"`
+	APIServer    string            `json:"apiServer"`
+	Namespace    string            `json:"namespace"`
+	DiffStrategy string            `json:"diffStrategy,omitempty"`
+	InjectLabels bool              `json:"injectLabels,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
 }

--- a/pkg/spec/v1alpha1/config.go
+++ b/pkg/spec/v1alpha1/config.go
@@ -50,9 +50,15 @@ func (m Metadata) NameLabel() string {
 
 // Spec defines Kubernetes properties
 type Spec struct {
-	APIServer    string            `json:"apiServer"`
-	Namespace    string            `json:"namespace"`
-	DiffStrategy string            `json:"diffStrategy,omitempty"`
-	InjectLabels bool              `json:"injectLabels,omitempty"`
-	Annotations  map[string]string `json:"annotations,omitempty"`
+	APIServer        string           `json:"apiServer"`
+	Namespace        string           `json:"namespace"`
+	DiffStrategy     string           `json:"diffStrategy,omitempty"`
+	InjectLabels     bool             `json:"injectLabels,omitempty"`
+	ResourceDefaults ResourceDefaults `json:"resourceDefaults,omitempty"`
+}
+
+// ResourceDefaults should be inserted in any manifests that tanka processes.
+type ResourceDefaults struct {
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }

--- a/pkg/spec/v1alpha1/config.go
+++ b/pkg/spec/v1alpha1/config.go
@@ -57,7 +57,7 @@ type Spec struct {
 	ResourceDefaults ResourceDefaults `json:"resourceDefaults,omitempty"`
 }
 
-// ResourceDefaults should be inserted in any manifests that tanka processes.
+// ResourceDefaults will be inserted in any manifests that tanka processes.
 type ResourceDefaults struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`


### PR DESCRIPTION
Implements #365 

This allows you to have in your spec.json:

```
"spec": {
  "resourceDefaults": {
    "labels": {"foo":"bar"},
    "annotations": {"whatever/foo": "anything_at_all"},
  }
}
```

and those will be applied to EVERY resource in the environment.

It will not overwrite any labels or annotations explicitly defined in your manifests.