### PR TITLE
feat(tool/charts): untar

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -46,6 +46,7 @@ func (e ExecHelm) Pull(chart, version string, opts PullOpts) error {
 		"--version", version,
 		"--destination", opts.Destination,
 		"--repository-config", repoFile,
+		"--untar",
 	)
 
 	return cmd.Run()


### PR DESCRIPTION
Now automatically untars the downloaded Chart artifact, so git can
handle it better.

Is there a use-case for not doing this? Should it be configurable?