### PR TITLE
feat(helm): Require Charts to be locally available

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	jsonnet "github.com/google/go-jsonnet"
@@ -18,9 +19,14 @@ import (
 
 // TemplateOpts defines additional parameters that can be passed to the
 // Helm.Template action
+// TODO: Isolate between Helm.Template and NativeFunc
 type TemplateOpts struct {
-	Values map[string]interface{}
-	Flags  []string
+	// general
+	Values map[string]interface{} `json:"values"`
+	Flags  []string               `json:"flags"`
+
+	// native func related
+	CalledFrom string `json:"calledFrom"`
 }
 
 func confToArgs(conf TemplateOpts) ([]string, []string, error) {
@@ -93,11 +99,15 @@ func (h ExecHelm) Template(name, chart string, opts TemplateOpts) (manifest.List
 }
 
 // NativeFunc returns a jsonnet native function that provides the same
-// functionality as `Helm.Template` of this package
+// functionality as `Helm.Template` of this package. Charts are required to be
+// present on the local filesystem, at a relative location to the file that
+// calls `helm.template()` / `std.native('helmTemplate')`. This guarantees
+// hermeticity
 func NativeFunc() *jsonnet.NativeFunction {
 	return &jsonnet.NativeFunction{
 		Name: "helmTemplate",
-		// Lines up with `helm template [NAME] [CHART] [flags]` except 'conf' is a bit more elaborate
+		// Similar to `helm template [NAME] [CHART] [flags]` except 'conf' is a
+		// bit more elaborate and chart is a local path
 		Params: ast.Identifiers{"name", "chart", "conf"},
 		Func: func(data []interface{}) (interface{}, error) {
 			name, ok := data[0].(string)
@@ -105,7 +115,7 @@ func NativeFunc() *jsonnet.NativeFunction {
 				return nil, fmt.Errorf("First argument 'name' must be of 'string' type, got '%T' instead", data[0])
 			}
 
-			chart, ok := data[1].(string)
+			chartpath, ok := data[1].(string)
 			if !ok {
 				return nil, fmt.Errorf("Second argument 'chart' must be of 'string' type, got '%T' instead", data[1])
 			}
@@ -118,6 +128,20 @@ func NativeFunc() *jsonnet.NativeFunction {
 			var conf TemplateOpts
 			if err := json.Unmarshal(c, &conf); err != nil {
 				return "", err
+			}
+
+			// Charts are only allowed at relative paths. Use conf.CalledFrom to find the callers directory
+			if conf.CalledFrom == "" {
+				// TODO: rephrase and move lengthy explanation to website
+				return nil, fmt.Errorf("helmTemplate: 'conf.calledFrom' is unset or empty.\nHowever, Tanka must know where helmTemplate was called from, to resolve the Helm Chart relative to that.\n")
+			}
+			callerDir := filepath.Dir(conf.CalledFrom)
+
+			// resolve the Chart relative to the caller
+			chart := filepath.Join(callerDir, chartpath)
+			if _, err := os.Stat(chart); err != nil {
+				// TODO: add website link for explanation
+				return nil, fmt.Errorf("helmTemplate: Failed to find a Chart at '%s': %s", chart, err)
 			}
 
 			// TODO: Define Template on the Helm interface instead


### PR DESCRIPTION
As proposed by [this design doc](https://docs.google.com/document/d/171F0cm_VliMStmHe6oy5pAbuXihr-7Cb5yD-vmwqpP8/edit#heading=h.jw0tqbslwqja), this modifies the `helmTemplate` native function in a way that it expects a relative path instead of the `repo/name` identifier for Charts.

Before, this feature relied on the system wide Helm cache, which is independent from the Tanka project and not controlled by git. This does not play well with our aim for hermeticity and strong reproducibility at all.

To overcome this, `helmTemplate` resolves the chart **relative to the calling file**. This suggests to keep Helm Charts as close to the consuming source code as possible.

Using the calling file as a fixpoint is also the only way I came up with that is independent from the current working directory Tanka was invoked in, which is important as `tk show` must continue to not only work from the project root, but also inside any nested folder.

Depends on #368, will be rebased once merged