### PR TITLE
Revise diff error message to encourage upgrading kubectl beyond 1.18.0

### DIFF
--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -17,7 +17,7 @@ func (k *Kubernetes) Diff(state manifest.List, opts DiffOpts) (*string, error) {
 	if k.ctl.Info().ClientVersion.Equal(semver.MustParse("1.18.0")) {
 		return nil, fmt.Errorf(`You seem to be using kubectl 1.18.0, which contains an unfixed issue
 that makes 'kubectl diff' modify resources in your cluster.
-Please downgrade kubectl until https://github.com/kubernetes/kubernetes/issues/89762 is fixed.`)
+Please upgrade kubectl to at least version 1.18.1.`)
 	}
 
 	// required for separating


### PR DESCRIPTION
I've changed the message to encourage users to upgrade to a kubectl version with the fix merged. I felt like encouraging either a downgrade or upgrade may be confusing to users who I assume are running 1.18.X to match up with their cluster versions.  

Closes #328 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>