### PR TITLE
Improve user control of paging

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -36,7 +36,10 @@ func evalCmd() *cli.Command {
 			return err
 		}
 
-		pageln(string(out))
+		if err := pageln(string(out)); err != nil {
+			return err
+		}
+
 		return nil
 	}
 

--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -16,7 +16,7 @@ func pageln(i ...interface{}) error {
 
 // fPageln invokes the systems pager with the supplied data.
 // If the PAGER environment variable is empty, no pager is used.
-// If the PAGER environment variable is unset, use less with posix flags.
+// If the PAGER environment variable is unset, use GNU less with convenience flags.
 func fPageln(r io.Reader) error {
 	pager, ok := os.LookupEnv("PAGER")
 	if !ok {

--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -32,8 +32,9 @@ func fPageln(r io.Reader) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		err := cmd.Run()
-		if err == nil {
+		if err := cmd.Run(); err != nil {
+			// Fallthrough on failure so that the contents of the reader are copied to stdout.
+		} else {
 			return nil
 		}
 	}

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -153,12 +153,8 @@ func diffCmd() *cli.Command {
 			os.Exit(ExitStatusClean)
 		}
 
-		if interactive {
-			r := term.Colordiff(*changes)
-			fPageln(r)
-		} else {
-			fmt.Println(*changes)
-		}
+		r := term.Colordiff(*changes)
+		fPageln(r)
 
 		os.Exit(ExitStatusDiff)
 		return nil

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -154,7 +154,9 @@ func diffCmd() *cli.Command {
 		}
 
 		r := term.Colordiff(*changes)
-		fPageln(r)
+		if err := fPageln(r); err != nil {
+			return err
+		}
 
 		os.Exit(ExitStatusDiff)
 		return nil
@@ -189,7 +191,10 @@ Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
 			return err
 		}
 
-		pageln(pretty.String())
+		if err := pageln(pretty.String()); err != nil {
+			return err
+		}
+
 		return nil
 	}
 	return cmd

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -191,11 +191,7 @@ Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
 			return err
 		}
 
-		if err := pageln(pretty.String()); err != nil {
-			return err
-		}
-
-		return nil
+		return pageln(pretty.String())
 	}
 	return cmd
 }


### PR DESCRIPTION
This allows users to avoid a pager by emptying out the `PAGER` environment variable (setting `PAGER=""`), only defaulting to `less` with posix flags (not supported by busybox `less`) if `PAGER` is unset.

Closes #293 