### PR TITLE
refactor: Jsonnet parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-clix/cli v0.1.1
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.2-0.20200818193711-d2fcc899bdc2
-	github.com/google/go-jsonnet v0.15.1-0.20200331184325-4f4aa80dd785
+	github.com/google/go-jsonnet v0.16.1-0.20200908152747-b70cbd441a39
 	github.com/karrick/godirwalk v1.15.5
 	github.com/pkg/errors v0.8.1
 	github.com/posener/complete v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/google/go-cmp v0.5.2-0.20200818193711-d2fcc899bdc2 h1:CZtx9gNen+kr3Pu
 github.com/google/go-cmp v0.5.2-0.20200818193711-d2fcc899bdc2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-jsonnet v0.15.1-0.20200331184325-4f4aa80dd785 h1:+dlQ7fPoeAqO0U9V+94golo/rW1/V2Pn+v8aPp3ljRM=
 github.com/google/go-jsonnet v0.15.1-0.20200331184325-4f4aa80dd785/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
+github.com/google/go-jsonnet v0.16.1-0.20200908152747-b70cbd441a39 h1:noLRnY1ESguFGDPxXvIcESe2rG63f+ZSbSGYfVa6iHo=
+github.com/google/go-jsonnet v0.16.1-0.20200908152747-b70cbd441a39/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/jsonnet/jpath/jpath_test.go
+++ b/pkg/jsonnet/jpath/jpath_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestResolvePrecedence(t *testing.T) {
-	s, err := jsonnet.EvaluateFile(filepath.Join("./testdata/precedence/environments/default/main.jsonnet"))
+	s, err := jsonnet.EvaluateFile(filepath.Join("./testdata/precedence/environments/default/main.jsonnet"), jsonnet.Opts{})
 	require.NoError(t, err)
 
 	want := map[string]string{

--- a/pkg/process/data_test.go
+++ b/pkg/process/data_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/grafana/tanka/pkg/jsonnet"
@@ -18,12 +17,12 @@ type testData struct {
 
 func loadFixture(name string) testData {
 	filename := "./testdata/td" + strings.Title(name) + ".jsonnet"
-	raw, err := ioutil.ReadFile(filename)
-	if err != nil {
-		panic(fmt.Sprint("loading fixture:", err))
-	}
 
-	data, err := jsonnet.Evaluate(filename, string(raw), []string{"./testdata"})
+	vm := jsonnet.MakeVM(jsonnet.Opts{
+		ImportPaths: []string{"./testdata"},
+	})
+
+	data, err := vm.EvaluateFile(filename)
 	if err != nil {
 		panic(fmt.Sprint("loading fixture:", err))
 	}

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -1,9 +1,11 @@
 package tanka
 
 import (
+	"testing"
+
+	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestEvalJsonnet(t *testing.T) {
@@ -33,8 +35,7 @@ func TestEvalJsonnet(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		m := make(map[string]string)
-		data, e := evalJsonnet(test.baseDir, v1alpha1.New(), m)
+		data, e := evalJsonnet(test.baseDir, v1alpha1.New(), jsonnet.Opts{})
 		assert.NoError(t, e)
 		assert.Equal(t, test.expected, data)
 	}

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -5,6 +5,7 @@
 package tanka
 
 import (
+	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/process"
 )
@@ -20,8 +21,7 @@ func parseModifiers(mods []Modifier) *options {
 
 type options struct {
 	// `std.extVar`
-	extCode map[string]string
-	tlaCode map[string]string
+	jsonnet jsonnet.Opts
 
 	// target regular expressions to limit the working set
 	targets process.Matchers
@@ -41,13 +41,13 @@ type Modifier func(*options)
 // WithExtCode allows to pass external variables (jsonnet code) to the VM
 func WithExtCode(code map[string]string) Modifier {
 	return func(opts *options) {
-		opts.extCode = code
+		opts.jsonnet.ExtCode = code
 	}
 }
 
 func WithTLACode(code map[string]string) Modifier {
 	return func(opts *options) {
-		opts.extCode = code
+		opts.jsonnet.TLACode = code
 	}
 }
 

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -147,7 +147,7 @@ func Show(baseDir string, mods ...Modifier) (manifest.List, error) {
 func Eval(dir string, mods ...Modifier) (raw interface{}, err error) {
 	opts := parseModifiers(mods)
 
-	r, _, err := eval(dir, opts.extCode)
+	r, _, err := eval(dir, opts.jsonnet)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
4a2d018b4cbab1a78b8c3fc20f4c5f7ffe0bad36: Switches from `vm.EvaluateSnippet` to the new `vm.EvaluateFile` and `vm.EvaluateAnonymousSnippet` function classes, which were introduced in https://github.com/google/go-jsonnet/pull/447.

Our `pkg/jsonnet` now has three primary methods:
- `MakeVM(opts)`, which creates a Tanka specific VM, including import paths, native funcs, TLA, extVars, etc
- `EvaluateFile(file, opts)`, which uses above VM to render a file found by the importer
- `Evaluate(filename, snippet, opts)`, which uses above VM to render a piece of code that is not actually on the local file system, but injected from somewhere else

The latter two functions do not much on their own, but stay closer to the current api, where a consumer does not need to know about the VM at all

916b6c30ae8e1a8b8121453cfbfecf7acb27d6a3: Fixes the TLA feature. Apparently, we only collected top level arguments, but accidentally passed these as extVars to the VM. Oops

The refactoring already properly exposed this functionality, in this commit I only changed the "wiring" away from boilerplate function modifiers to "just" passing the struct, which seems to be more fool proof in the long run (as observed here)