### PR TITLE
refactor(api): use structs

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -32,11 +32,12 @@ func exportCmd() *cli.Command {
 		Args:  args,
 	}
 
-	vars := workflowFlags(cmd.Flags())
-	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
 	format := cmd.Flags().String("format", "{{.apiVersion}}.{{.kind}}-{{.metadata.name}}", "https://tanka.dev/exporting#filenames")
 	extension := cmd.Flags().String("extension", "yaml", "File extension")
 	merge := cmd.Flags().Bool("merge", false, "Allow merging with existing directory")
+
+	vars := workflowFlags(cmd.Flags())
+	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	templateFuncMap := template.FuncMap{
 		"lower": func(s string) string {
@@ -66,11 +67,10 @@ func exportCmd() *cli.Command {
 		}
 
 		// get the manifests
-		res, err := tanka.Show(args[0],
-			tanka.WithExtCode(getExtCode()),
-			tanka.WithTLACode(getTLACode()),
-			tanka.WithTargets(stringsToRegexps(vars.targets)),
-		)
+		res, err := tanka.Show(args[0], tanka.Opts{
+			JsonnetOpts: getJsonnetOpts(),
+			Filters:     stringsToRegexps(vars.targets),
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -19,13 +19,12 @@ func evalCmd() *cli.Command {
 		Args:  workflowArgs,
 	}
 
-	getExtCode, getTLACode := cliCodeParser(cmd.Flags())
+	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		raw, err := tanka.Eval(args[0],
-			tanka.WithExtCode(getExtCode()),
-			tanka.WithTLACode(getTLACode()),
-		)
+		raw, err := tanka.Eval(args[0], tanka.Opts{
+			JsonnetOpts: getJsonnetOpts(),
+		})
 
 		if err != nil {
 			return err
@@ -41,6 +40,17 @@ func evalCmd() *cli.Command {
 	}
 
 	return cmd
+}
+
+func jsonnetFlags(fs *pflag.FlagSet) func() tanka.JsonnetOpts {
+	getExtCode, getTLACode := cliCodeParser(fs)
+
+	return func() tanka.JsonnetOpts {
+		return tanka.JsonnetOpts{
+			ExtCode: getExtCode(),
+			TLACode: getTLACode(),
+		}
+	}
 }
 
 func cliCodeParser(fs *pflag.FlagSet) (func() map[string]string, func() map[string]string) {

--- a/cmd/tk/status.go
+++ b/cmd/tk/status.go
@@ -18,8 +18,13 @@ func statusCmd() *cli.Command {
 		Short: "display an overview of the environment, including contents and metadata.",
 		Args:  workflowArgs,
 	}
+
+	getJsonnetOpts := jsonnetFlags(cmd.Flags())
+
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		status, err := tanka.Status(args[0])
+		status, err := tanka.Status(args[0], tanka.Opts{
+			JsonnetOpts: getJsonnetOpts(),
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/kubernetes/delete.go
+++ b/pkg/kubernetes/delete.go
@@ -8,7 +8,7 @@ import (
 
 type DeleteOpts client.DeleteOpts
 
-func (k *Kubernetes) Delete(state manifest.List, opts ApplyOpts) error {
+func (k *Kubernetes) Delete(state manifest.List, opts DeleteOpts) error {
 	// Sort and reverse the manifests to avoid cascading deletions
 	process.Sort(state)
 	for i := 0; i < len(state)/2; i++ {

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -55,13 +55,13 @@ func (p *loaded) connect() (*kubernetes.Kubernetes, error) {
 }
 
 // load runs all processing stages described at the Processed type
-func load(dir string, opts *options) (*loaded, error) {
-	raw, env, err := eval(dir, opts.extCode)
+func load(dir string, opts Opts) (*loaded, error) {
+	raw, env, err := eval(dir, opts.ExtCode)
 	if err != nil {
 		return nil, err
 	}
 
-	rec, err := process.Process(raw, *env, opts.targets)
+	rec, err := process.Process(raw, *env, opts.Filters)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -1,9 +1,10 @@
 package tanka
 
 import (
+	"testing"
+
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestEvalJsonnet(t *testing.T) {

--- a/pkg/tanka/status.go
+++ b/pkg/tanka/status.go
@@ -16,9 +16,7 @@ type Info struct {
 }
 
 // Status returns information about the particular environment
-func Status(baseDir string, mods ...Modifier) (*Info, error) {
-	opts := parseModifiers(mods)
-
+func Status(baseDir string, opts Opts) (*Info, error) {
 	r, err := load(baseDir, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -5,95 +5,22 @@
 package tanka
 
 import (
-	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/process"
 )
 
-// parseModifiers parses all modifiers into an options struct
-func parseModifiers(mods []Modifier) *options {
-	o := &options{}
-	for _, mod := range mods {
-		mod(o)
-	}
-	return o
+// Opts specify general, optional properties that apply to all actions
+type Opts struct {
+	JsonnetOpts
+
+	// Filters are used to optionally select a subset of the resources
+	Filters process.Matchers
 }
 
-type options struct {
-	// `std.extVar`
-	extCode map[string]string
-	tlaCode map[string]string
+// JsonnetOpts specify additional properties for the Jsonnet VM
+type JsonnetOpts struct {
+	// ExtCode are values available using `std.extVar`
+	ExtCode map[string]string
 
-	// target regular expressions to limit the working set
-	targets process.Matchers
-
-	// additional options for diff
-	diff kubernetes.DiffOpts
-
-	// additional options for apply
-	apply kubernetes.ApplyOpts
-}
-
-// Modifier allow to influence the behavior of certain `tanka.*` actions. They
-// are roughly equivalent to flags on the command line. See the `tanka.With*`
-// functions for available options.
-type Modifier func(*options)
-
-// WithExtCode allows to pass external variables (jsonnet code) to the VM
-func WithExtCode(code map[string]string) Modifier {
-	return func(opts *options) {
-		opts.extCode = code
-	}
-}
-
-func WithTLACode(code map[string]string) Modifier {
-	return func(opts *options) {
-		opts.extCode = code
-	}
-}
-
-// WithTargets allows to submit regular expressions to limit the working set of
-// objects (https://tanka.dev/output-filtering/).
-func WithTargets(t process.Matchers) Modifier {
-	return func(opts *options) {
-		opts.targets = t
-	}
-}
-
-// WithDiffStrategy allows to set the used diff strategy.
-// An empty string is ignored.
-func WithDiffStrategy(ds string) Modifier {
-	return func(opts *options) {
-		if ds != "" {
-			opts.diff.Strategy = ds
-		}
-	}
-}
-
-// WithDiffSummarize enables summary mode, which invokes `diffstat(1)` on the
-// set of changes to create an overview
-func WithDiffSummarize(b bool) Modifier {
-	return func(opts *options) {
-		opts.diff.Summarize = b
-	}
-}
-
-// WithApplyForce allows to invoke `kubectl apply` with the `--force` flag
-func WithApplyForce(b bool) Modifier {
-	return func(opts *options) {
-		opts.apply.Force = b
-	}
-}
-
-// WithApplyValidate allows to invoke `kubectl apply` with the `--validate=false` flag
-func WithApplyValidate(b bool) Modifier {
-	return func(opts *options) {
-		opts.apply.Validate = b
-	}
-}
-
-// WithApplyAutoApprove allows to skip the interactive approval
-func WithApplyAutoApprove(b bool) Modifier {
-	return func(opts *options) {
-		opts.apply.AutoApprove = b
-	}
+	// TLACode are values set onto top level arguments
+	TLACode map[string]string
 }

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -11,13 +11,26 @@ import (
 	"github.com/grafana/tanka/pkg/term"
 )
 
+// ApplyOpts specify additional properties for the Apply action
+type ApplyOpts struct {
+	Opts
+
+	// AutoApprove skips the interactive approval
+	AutoApprove bool
+	// DiffStrategy to use for printing the diff before approval
+	DiffStrategy string
+
+	// Force ignores any warnings kubectl might have
+	Force bool
+	// Validate set to false ignores invalid Kubernetes schemas
+	Validate bool
+}
+
 // Apply parses the environment at the given directory (a `baseDir`) and applies
 // the evaluated jsonnet to the Kubernetes cluster defined in the environments
 // `spec.json`.
-func Apply(baseDir string, mods ...Modifier) error {
-	opts := parseModifiers(mods)
-
-	l, err := load(baseDir, opts)
+func Apply(baseDir string, opts ApplyOpts) error {
+	l, err := load(baseDir, opts.Opts)
 	if err != nil {
 		return err
 	}
@@ -28,7 +41,7 @@ func Apply(baseDir string, mods ...Modifier) error {
 	defer kube.Close()
 
 	// show diff
-	diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{Strategy: opts.diff.Strategy})
+	diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{Strategy: opts.DiffStrategy})
 	switch {
 	case err != nil:
 		// This is not fatal, the diff is not strictly required
@@ -45,12 +58,15 @@ func Apply(baseDir string, mods ...Modifier) error {
 	}
 
 	// prompt for confirmation
-	if opts.apply.AutoApprove {
+	if opts.AutoApprove {
 	} else if err := confirmPrompt("Applying to", l.Env.Spec.Namespace, kube.Info()); err != nil {
 		return err
 	}
 
-	return kube.Apply(l.Resources, opts.apply)
+	return kube.Apply(l.Resources, kubernetes.ApplyOpts{
+		Force:    opts.Force,
+		Validate: opts.Validate,
+	})
 }
 
 // confirmPrompt asks the user for confirmation before apply
@@ -68,16 +84,24 @@ func confirmPrompt(action, namespace string, info client.Info) error {
 	)
 }
 
+// DiffOpts specify additional properties for the Diff action
+type DiffOpts struct {
+	Opts
+
+	// Strategy must be one of "native" or "subset"
+	Strategy string
+	// Summarize prints a summary, instead of the actual diff
+	Summarize bool
+}
+
 // Diff parses the environment at the given directory (a `baseDir`) and returns
 // the differences from the live cluster state in `diff(1)` format. If the
 // `WithDiffSummarize` modifier is used, a histogram created using `diffstat(1)`
 // is returned instead.
 // The cluster information is retrieved from the environments `spec.json`.
 // NOTE: This function requires on `diff(1)`, `kubectl(1)` and perhaps `diffstat(1)`
-func Diff(baseDir string, mods ...Modifier) (*string, error) {
-	opts := parseModifiers(mods)
-
-	l, err := load(baseDir, opts)
+func Diff(baseDir string, opts DiffOpts) (*string, error) {
+	l, err := load(baseDir, opts.Opts)
 	if err != nil {
 		return nil, err
 	}
@@ -87,16 +111,30 @@ func Diff(baseDir string, mods ...Modifier) (*string, error) {
 	}
 	defer kube.Close()
 
-	return kube.Diff(l.Resources, opts.diff)
+	return kube.Diff(l.Resources, kubernetes.DiffOpts{
+		Summarize: opts.Summarize,
+		Strategy:  opts.Strategy,
+	})
+}
+
+// DeleteOpts specify additional properties for the Delete operation
+type DeleteOpts struct {
+	Opts
+
+	// AutoApprove skips the interactive approval
+	AutoApprove bool
+
+	// Force ignores any warnings kubectl might have
+	Force bool
+	// Validate set to false ignores invalid Kubernetes schemas
+	Validate bool
 }
 
 // Delete parses the environment at the given directory (a `baseDir`) and deletes
 // the generated objects from the Kubernetes cluster defined in the environment's
 // `spec.json`.
-func Delete(baseDir string, mods ...Modifier) error {
-	opts := parseModifiers(mods)
-
-	l, err := load(baseDir, opts)
+func Delete(baseDir string, opts DeleteOpts) error {
+	l, err := load(baseDir, opts.Opts)
 	if err != nil {
 		return err
 	}
@@ -121,20 +159,21 @@ func Delete(baseDir string, mods ...Modifier) error {
 	}
 
 	// prompt for confirmation
-	if opts.apply.AutoApprove {
+	if opts.AutoApprove {
 	} else if err := confirmPrompt("Deleting from", l.Env.Spec.Namespace, kube.Info()); err != nil {
 		return err
 	}
 
-	return kube.Delete(l.Resources, opts.apply)
+	return kube.Delete(l.Resources, kubernetes.DeleteOpts{
+		Force:    opts.Force,
+		Validate: opts.Validate,
+	})
 }
 
 // Show parses the environment at the given directory (a `baseDir`) and returns
 // the list of Kubernetes objects.
 // Tip: use the `String()` function on the returned list to get the familiar yaml stream
-func Show(baseDir string, mods ...Modifier) (manifest.List, error) {
-	opts := parseModifiers(mods)
-
+func Show(baseDir string, opts Opts) (manifest.List, error) {
 	l, err := load(baseDir, opts)
 	if err != nil {
 		return nil, err
@@ -144,10 +183,8 @@ func Show(baseDir string, mods ...Modifier) (manifest.List, error) {
 }
 
 // Eval returns the raw evaluated Jsonnet output (without any transformations)
-func Eval(dir string, mods ...Modifier) (raw interface{}, err error) {
-	opts := parseModifiers(mods)
-
-	r, _, err := eval(dir, opts.extCode)
+func Eval(dir string, opts Opts) (raw interface{}, err error) {
+	r, _, err := eval(dir, opts.JsonnetOpts.ExtCode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refactors our API away from the Modifier pattern to plain old struct arguments.

- This requires less boilerplate. No longer a Setter must be created for each possible field
- Logical separation: Using struct embedding, fields can be properly grouped and scoped for their respective action, etc. This also requires less copying around in memory
- Stricter checking: Every action got its own composed struct type, so only those fields can be set that actually make sense.

Not quite sure who to assign for review on this. This is intended as a refactor in the strict sense, being a no-op