### PR TITLE
tk prune: Add the Summarize flag

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -67,6 +67,7 @@ func pruneCmd() *cli.Command {
 	var opts tanka.PruneOpts
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	cmd.Flags().BoolVarP(&opts.Summarize, "summarize", "s", false, "print summary of the differences, not the actual contents")
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {


### PR DESCRIPTION
When using this flag (in either its long or short versions),
the output will be simplified and list the Kubernetes Kind
and the object Name.

Signed-off-by: Javier Palomo <javier.palomo@grafana.com>

Addresses https://github.com/grafana/tanka/issues/383

---

An example output will be:

```
➜  prom-grafana git:(tk-prune-summarize) ✗ tk prune -s environments/prom-grafana/dev
fetching UID's .. done 99.460194ms
fetching previously created resources .. done 1.772459157s
Pruning Service/grafana
Pruning Deployment/grafana
Pruning from namespace 'prom-grafana-dev' of cluster 'minikube' at 'https://X.Y.X.Y:8443' using context 'minikube'.
Please type 'yes' to confirm:
```

Test it out by:

Adding `injectLabels` to the spec as per https://tanka.dev/garbage-collection

```diff
diff --git a/examples/prom-grafana/environments/prom-grafana/dev/spec.json b/examples/prom-grafana/environments/prom-grafana/dev/spec.json
index 6595e3f..ad537b9 100644
--- a/examples/prom-grafana/environments/prom-grafana/dev/spec.json
+++ b/examples/prom-grafana/environments/prom-grafana/dev/spec.json
@@ -5,6 +5,7 @@
     "name": "dev"
   },
   "spec": {
+    "injectLabels": true,
     "apiServer": "",
     "namespace": "prom-grafana-dev"
   }
```

Applying the changes:

```
tk apply environments/prom-grafana/dev
```

Removing the Grafana block from the prom-gram library:

```diff
diff --git a/examples/prom-grafana/lib/prom-grafana/prom-grafana.libsonnet b/examples/prom-grafana/lib/prom-grafana/prom-grafana.libsonnet
index 07a7ee3..c670905 100644
--- a/examples/prom-grafana/lib/prom-grafana/prom-grafana.libsonnet
+++ b/examples/prom-grafana/lib/prom-grafana/prom-grafana.libsonnet
@@ -21,15 +21,6 @@
       service: $.util.serviceFor(self.deployment),
     },

-    grafana: {
-      deployment: deployment.new(
-        name=c.grafana.name, replicas=1,
-        containers=[
-          container.new(c.grafana.name, $._images.promgrafana.grafana)
-          + container.withPorts([port.new("ui", c.grafana.port)]),
-        ],
-      ),
-      service: $.util.serviceFor(self.deployment) + service.mixin.spec.withType("NodePort"),
-    },
+
   }
 }
```