### PR TITLE
doc: helm.template()

### DIFF
--- a/docs/docs/completion.md
+++ b/docs/docs/completion.md
@@ -1,6 +1,7 @@
 ---
 name: "Command-line completion"
 route: "/completion"
+menu: "References"
 ---
 
 # Command-line Completion

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -1,6 +1,7 @@
 ---
 name: "Configuration Reference"
 route: "/config"
+menu: "References"
 ---
 
 # Configuration Reference

--- a/docs/docs/diff-strategy.md
+++ b/docs/docs/diff-strategy.md
@@ -1,6 +1,7 @@
 ---
 name: "Diff strategies"
 route: "/diff-strategy"
+menu: "References"
 ---
 
 # Diff Strategies

--- a/docs/docs/directory-structure.md
+++ b/docs/docs/directory-structure.md
@@ -1,6 +1,7 @@
 ---
 name: Directory structure
 route: /directory-structure
+menu: "References"
 ---
 
 # Directory structure

--- a/docs/docs/env-vars.md
+++ b/docs/docs/env-vars.md
@@ -1,6 +1,7 @@
 ---
 name: "Environment variables"
 route: "/env-vars"
+menu: "References"
 ---
 
 # Environment Variables

--- a/docs/docs/env-vars.md
+++ b/docs/docs/env-vars.md
@@ -8,7 +8,7 @@ menu: "References"
 
 ### TANKA_JB_PATH
 
-**Description**: Path to the `jb` tool executable
+**Description**: Path to the `jb` tool executable  
 **Default**: `$PATH/jb`
 
 ### TANKA_KUBECTL_PATH
@@ -23,5 +23,5 @@ menu: "References"
 
 ### TANKA_HELM_PATH
 
-**Description**: Path to the `helm` executable
+**Description**: Path to the `helm` executable  
 **Default**: `$PATH/helm`

--- a/docs/docs/exporting.md
+++ b/docs/docs/exporting.md
@@ -1,6 +1,7 @@
 ---
 name: "Exporting as YAML"
 route: "/exporting"
+menu: Advanced features
 ---
 
 # Exporting as YAML

--- a/docs/docs/garbage-collection.md
+++ b/docs/docs/garbage-collection.md
@@ -1,6 +1,7 @@
 ---
 name: "Garbage collection"
 route: "/garbage-collection"
+menu: Advanced features
 ---
 
 # Garbage collection

--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -60,8 +60,8 @@ a regular Jsonnet object that looks roughly like so:
 
 ## Vendoring Helm Charts
 
-A core concept of Grafana Tanka is purity, which it **always yields the same
-resources**, regardless of surroundings. This is the case, when the project is
+Tanka, like Jsonnet, is hermetic. It **always yields the same
+resources** when the project is
 strictly self-contained.
 
 Helm however keeps Charts and repository configuration somewhere around
@@ -78,8 +78,8 @@ Where to actually put them inside the project is up to you, but keep in mind you
 need to refer to them using relative paths.
 
 We recommend always writing libraries that wrap the actual Helm Chart, so the
-consumer does not need to be aware of it. Whether you put these into `lib/` or
-publish them on GitHub (`vendor/`) is up to you.
+consumer does not need to be aware of it. Whether you put these into your local `lib/` directory or
+publish and vendor them into the `vendor/` directory  is up to you.
 
 A library usually looks like this:
 
@@ -98,7 +98,7 @@ When adopting Helm inside it, we recommend vendoring at the top level, as such:
 ```
 
 This way, you can refer to the charts as `./charts/<someChart>` from inside
-`main.libsonnet`. By keeping the Chart as close to the consumer as possible, the
+`main.libsonnet`. By keeping the chart as close to the consumer as possible, the
 library is kept portable.
 
 ### Charttool
@@ -112,11 +112,11 @@ Tanka ships a special utility at `tk tool charts`, which automates `helm pull`:
 # Create a chartfile.yaml in the current directory, e.g. in lib/myLibrary
 $ tk tool charts init
 
-# Install the MySQL Chart at version 1.6.7 from the stable repository
+$ # Install the MySQL chart at version 1.6.7 from the stable repository
 $ tk tool charts add stable/mysql@1.6.7
 ```
 
-**Adding Charts:** To add a Chart, use the following:
+**Adding charts:** To add a chart, use the following:
 
 ```bash
 $ tk tool charts add <repo>/<name>@<version>
@@ -159,11 +159,11 @@ helmTemplate: Failed to find a Chart at 'stable/grafana': No such file or direct
 helmTemplate: Failed to find a Chart at '/home/user/stuff/tanka/environments/default/grafana': No such file or directory.
 ```
 
-Tanka failed to locate your Helm Chart on the filesystem. It looked at the
+Tanka failed to locate your Helm chart on the filesystem. It looked at the
 relative path you provided in `helm.template()`, starting from the directory of
 the file you called `helm.template()` from.
 
-Please check there is actually a valid Helm Chart at this place. Referring to
+Please check there is actually a valid Helm chart at this place. Referring to
 charts as `<repo>/<name>` is disallowed by design.
 
 ### Two resources share the same name

--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -10,7 +10,7 @@ The [Helm](https://helm.sh) project is the biggest ecosystem of high quality,
 well maintained application definitions for Kubernetes.
 
 Even though Grafana Tanka uses the [Jsonnet language](/jsonnet/overview) for
-resource definition in the first place, you still have access to most of Helm.
+resource definition, you can still consume Helm resources, as described below.
 
 > **Warning:** Keep in mind this feature is considered EXPERIMENTAL
 
@@ -44,7 +44,7 @@ path](#vendoring-helm-charts), in this case `./charts/grafana`.
 
 <br />
 
-Once called, the `$.grafana` key holds the individual resources of Helm Chart as
+Once invoked, the `$.grafana` key holds the individual resources of Helm Chart as
 a regular Jsonnet object that looks roughly like so:
 
 ```jsonnet
@@ -58,6 +58,8 @@ a regular Jsonnet object that looks roughly like so:
 }
 ```
 
+Above can be [manipulated](/tutorial/environments#patching) in the same way as any other Jsonnet data.
+
 ## Vendoring Helm Charts
 
 Tanka, like Jsonnet, is hermetic. It **always yields the same
@@ -67,7 +69,7 @@ strictly self-contained.
 Helm however keeps Charts and repository configuration somewhere around
 `~/.config/helm`, which violates above requirement.
 
-As such, we decided to only allow Helm Charts that can be found **inside the
+To comply with this requirement, Tanka expects Helm Charts to be found **inside the
 bounds of a project**. This means, you MUST put your Charts **somewhere next to
 the file that calls `helm.template()`**, so that it can be referred to using a
 relative path.
@@ -103,10 +105,11 @@ library is kept portable.
 
 ### Charttool
 
-Helm does not make vendoring incredibly easy. `helm pull` provides the required
-plumbing, but it does not record its actions in a reproducible manner.
+Helm does not make vendoring incredibly easy by itself. `helm pull` provides the
+required plumbing, but it does not record its actions in a reproducible manner.
 
-Tanka ships a special utility at `tk tool charts`, which automates `helm pull`:
+Therefore, Tanka ships a special utility at `tk tool charts`, which automates
+`helm pull`:
 
 ```bash
 # Create a chartfile.yaml in the current directory, e.g. in lib/myLibrary

--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -142,6 +142,19 @@ repositories:
 
 ## Troubleshooting
 
+### Helm executable missing
+
+Helm support in Tanka requires the `helm` binary installed on your system and
+available on the `$PATH`. If Helm is not installed, you will see this error message:
+
+```
+evaluating jsonnet: RUNTIME ERROR: Expanding Helm Chart: exec: "helm": executable file not found in $PATH
+```
+
+To solve this, you need to [install Helm](https://helm.sh/docs/intro/install/).
+If you cannot install it system-wide, you can point Tanka at your executable
+using [`TANKA_HELM_PATH`](/env-vars#tanka_helm_path)
+
 ### opts.calledFrom unset
 
 This occurs, when Tanka was not told where it `helm.template()` was invoked

--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -1,0 +1,186 @@
+---
+name: "Helm support"
+route: "/helm"
+menu: Advanced features
+---
+
+# Helm Support
+
+The [Helm](https://helm.sh) project is the biggest ecosystem of high quality,
+well maintained application definitions for Kubernetes.
+
+Even though Grafana Tanka uses the [Jsonnet language](/jsonnet/overview) for
+resource definition in the first place, you still have access to most of Helm.
+
+> **Warning:** Keep in mind this feature is considered EXPERIMENTAL
+
+## Consuming Helm Charts from Jsonnet
+
+Helm support is provided using the
+[`github.com/grafana/jsonnet-libs/helm-util`](https://github.com/grafana/jsonnet-libs/tree/master/helm-util)
+library.  
+The following example shows how to extract the individual resources of the
+[`grafana`](https://hub.helm.sh/charts/grafana/grafana) Helm Chart:
+
+```jsonnet
+local helm = (import "github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet").new(std.thisFile);
+
+{
+  grafana: helm.template("grafana", "./charts/grafana", {
+    namespace: "monitoring",
+    values: {
+      persistence: { enabled: true }
+    }
+  })
+}
+```
+
+The Chart itself is required to be [vendored at a relative
+path](#vendoring-helm-charts), in this case `./charts/grafana`.
+
+> **Important:** You MUST include the `.new(std.thisFile)` part in the import.
+> This is what tells Tanka where you actually call `helm.template()` from, so it
+> can find your vendored Charts.
+
+<br />
+
+Once called, the `$.grafana` key holds the individual resources of Helm Chart as
+a regular Jsonnet object that looks roughly like so:
+
+```jsonnet
+{
+  cluster_role_binding_grafana_clusterrolebinding: {/* ... */},
+  cluster_role_grafana_clusterrole: {/* ... */},
+  config_map_grafana: {/* ... */},
+  config_map_grafana_test: {/* ... */},
+  deployment_grafana: {/* ... */},
+  // ...
+}
+```
+
+## Vendoring Helm Charts
+
+A core concept of Grafana Tanka is purity, which it **always yields the same
+resources**, regardless of surroundings. This is the case, when the project is
+strictly self-contained.
+
+Helm however keeps Charts and repository configuration somewhere around
+`~/.config/helm`, which violates above requirement.
+
+As such, we decided to only allow Helm Charts that can be found **inside the
+bounds of a project**. This means, you MUST put your Charts **somewhere next to
+the file that calls `helm.template()`**, so that it can be referred to using a
+relative path.
+
+### Vendor Location
+
+Where to actually put them inside the project is up to you, but keep in mind you
+need to refer to them using relative paths.
+
+We recommend always writing libraries that wrap the actual Helm Chart, so the
+consumer does not need to be aware of it. Whether you put these into `lib/` or
+publish them on GitHub (`vendor/`) is up to you.
+
+A library usually looks like this:
+
+```
+  /jsonnetfile.json
+  /main.libsonnet
+```
+
+When adopting Helm inside it, we recommend vendoring at the top level, as such:
+
+```diff
+  /jsonnetfile.json
+  /main.libsonnet
++ /charts
++ /charts/<someChart>
+```
+
+This way, you can refer to the charts as `./charts/<someChart>` from inside
+`main.libsonnet`. By keeping the Chart as close to the consumer as possible, the
+library is kept portable.
+
+### Charttool
+
+Helm does not make vendoring incredibly easy. `helm pull` provides the required
+plumbing, but it does not record its actions in a reproducible manner.
+
+Tanka ships a special utility at `tk tool charts`, which automates `helm pull`:
+
+```bash
+# Create a chartfile.yaml in the current directory, e.g. in lib/myLibrary
+$ tk tool charts init
+
+# Install the MySQL Chart at version 1.6.7 from the stable repository
+$ tk tool charts add stable/mysql@1.6.7
+```
+
+**Adding Charts:** To add a Chart, use the following:
+
+```bash
+$ tk tool charts add <repo>/<name>@<version>
+```
+
+This will also call `tk tool charts vendor`, so that the `charts/` directory is updated.
+
+<br />
+
+**Adding Repositories:**
+By default, the `stable` repository is automatically set up for you. If you wish
+to add another repository, you currently need modify `chartfile.yaml` directly
+to add it:
+
+```diff
+version: 1
+repositories:
+  - name: stable
+    url: https://kubernetes-charts.storage.googleapis.com
++ - name: grafana
++   url: https://https://grafana.github.io/helm-charts
+```
+
+## Troubleshooting
+
+### opts.calledFrom unset
+
+This occurs, when Tanka was not told where it `helm.template()` was invoked
+from. This most likely means you didn't call `new(std.thisFile)` when importing `helm-util`:
+
+```jsonnet
+local helm = (import "github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet").new(std.thisFile);
+                                                                                 ↑ This is important
+```
+
+### Failed to find Chart
+
+```
+helmTemplate: Failed to find a Chart at 'stable/grafana': No such file or directory.
+helmTemplate: Failed to find a Chart at '/home/user/stuff/tanka/environments/default/grafana': No such file or directory.
+```
+
+Tanka failed to locate your Helm Chart on the filesystem. It looked at the
+relative path you provided in `helm.template()`, starting from the directory of
+the file you called `helm.template()` from.
+
+Please check there is actually a valid Helm Chart at this place. Referring to
+charts as `<repo>/<name>` is disallowed by design.
+
+### Two resources share the same name
+
+To make customization easier, `helm.template()` returns the resources not as the
+list it receives from Helm, but instead converts this into an object.
+
+For the indexing key it uses `kind_name` by default. In some rare cases, this
+might not be enough to distinguish between two resources, namely when the same
+resource exists in two namespaces.
+
+To handle this, pass a custom name format, e.g. to also include the namespace:
+
+```jsonnet
+custom: helm.template("foo", "./charts/foo", {
+  nameFormat: "{{ print .namespace "_" .kind "_" .metadata.name | snakecase }}"
+})
+```
+
+The literal default format used is `{{ print .kind "_" .metadata.name | snakecase }}`

--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -79,7 +79,7 @@ need to refer to them using relative paths.
 
 We recommend always writing libraries that wrap the actual Helm Chart, so the
 consumer does not need to be aware of it. Whether you put these into your local `lib/` directory or
-publish and vendor them into the `vendor/` directory  is up to you.
+publish and vendor them into the `vendor/` directory is up to you.
 
 A library usually looks like this:
 
@@ -191,8 +191,8 @@ resource exists in two namespaces.
 To handle this, pass a custom name format, e.g. to also include the namespace:
 
 ```jsonnet
-custom: helm.template("foo", "./charts/foo", {
-  nameFormat: "{{ print .namespace "_" .kind "_" .metadata.name | snakecase }}"
+custom: helm.template('foo', './charts/foo', {
+  nameFormat: '{{ print .namespace "_" .kind "_" .metadata.name | snakecase }}'
 })
 ```
 

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -16,6 +16,8 @@ Tanka is distributed as a single binary called `tk`. It already includes the Jso
 - `diff`: To compute differences, standard UNIX `diff(1)` is required.
 - (recommended) `jb`: [#Jsonnet Bundler](#jsonnet-bundler), the Jsonnet package
   manager
+- (recommended) `helm`: [Helm](https://helm.sh), required for [Helm
+  support](/helm)
 
 <br />
 <PlatformInstall elems={Tanka} def="macOS" />

--- a/docs/docs/namespaces.md
+++ b/docs/docs/namespaces.md
@@ -1,6 +1,7 @@
 ---
 name: Namespaces
 route: /namespaces
+menu: "References"
 ---
 
 # Namespaces
@@ -31,7 +32,7 @@ legit cases where it's handy to have them span multiple namespaces, for example:
 
 Some resources in Kubernetes are cluster-wide, meaning they don't belong to a single namespace at all.
 
-Tanka will make an attempt to not add namespaces to *known* cluster-wide types. 
+Tanka will make an attempt to not add namespaces to _known_ cluster-wide types.
 It does this with a short list of types in [the source code](https://github.com/grafana/tanka/blob/master/pkg/process/namespace.go).
 
 Tanka cannot feasibly maintain this list for all known custom resource types. In those cases, resources will have namespaces added to their manifests,

--- a/docs/docs/targets.md
+++ b/docs/docs/targets.md
@@ -1,6 +1,7 @@
 ---
 name: "Output filtering"
 route: "/output-filtering"
+menu: Advanced features
 ---
 
 # Output Filtering

--- a/docs/doczrc.js
+++ b/docs/doczrc.js
@@ -45,7 +45,12 @@ export default {
     },
     {
       name: "Advanced features",
-      menu: ["Garbage collection", "Output filtering", "Exporting as YAML"],
+      menu: [
+        "Garbage collection",
+        "Helm support",
+        "Output filtering",
+        "Exporting as YAML",
+      ],
     },
     {
       name: "References",

--- a/docs/doczrc.js
+++ b/docs/doczrc.js
@@ -43,19 +43,21 @@ export default {
         "Overriding",
       ],
     },
-
-    // additional features
-    "Output filtering",
-    "Exporting as YAML",
-    "Garbage collection",
-    "Command-line completion",
-    "Diff strategies",
-    "Namespaces",
-
-    // reference
-    "Configuration Reference",
-    "Directory structure",
-    "Environment variables",
+    {
+      name: "Advanced features",
+      menu: ["Garbage collection", "Output filtering", "Exporting as YAML"],
+    },
+    {
+      name: "References",
+      menu: [
+        "Configuration Reference",
+        "Directory structure",
+        "Environment variables",
+        "Command-line completion",
+        "Diff strategies",
+        "Namespaces",
+      ],
+    },
 
     "Frequently asked questions",
     "Known issues",

--- a/pkg/helm/jsonnet.go
+++ b/pkg/helm/jsonnet.go
@@ -61,7 +61,7 @@ func NativeFunc(h Helm) *jsonnet.NativeFunction {
 			callerDir := filepath.Dir(opts.CalledFrom)
 			chart := filepath.Join(callerDir, chartpath)
 			if _, err := os.Stat(chart); err != nil {
-				return nil, fmt.Errorf("helmTemplate: Failed to find a Chart at '%s': %s. See https://tanka.dev/helm#failed-to-find-chart", chart, err)
+				return nil, fmt.Errorf("helmTemplate: Failed to find a chart at '%s': %s. See https://tanka.dev/helm#failed-to-find-chart", chart, err)
 			}
 
 			// render resources
@@ -93,7 +93,7 @@ func parseOpts(data interface{}) (*JsonnetOpts, error) {
 
 	// Charts are only allowed at relative paths. Use conf.CalledFrom to find the callers directory
 	if opts.CalledFrom == "" {
-		return nil, fmt.Errorf("helmTemplate: 'opts.calledFrom' is unset or empty.\nTanka needs this to find your Charts. See https://tanka.dev/helm#optscalledfrom-unset\n")
+		return nil, fmt.Errorf("helmTemplate: 'opts.calledFrom' is unset or empty.\nTanka needs this to find your charts. See https://tanka.dev/helm#optscalledfrom-unset\n")
 	}
 
 	return &opts, nil

--- a/pkg/helm/jsonnet.go
+++ b/pkg/helm/jsonnet.go
@@ -61,8 +61,7 @@ func NativeFunc(h Helm) *jsonnet.NativeFunction {
 			callerDir := filepath.Dir(opts.CalledFrom)
 			chart := filepath.Join(callerDir, chartpath)
 			if _, err := os.Stat(chart); err != nil {
-				// TODO: add website link for explanation
-				return nil, fmt.Errorf("helmTemplate: Failed to find a Chart at '%s': %s", chart, err)
+				return nil, fmt.Errorf("helmTemplate: Failed to find a Chart at '%s': %s. See https://tanka.dev/helm#failed-to-find-chart", chart, err)
 			}
 
 			// render resources
@@ -94,8 +93,7 @@ func parseOpts(data interface{}) (*JsonnetOpts, error) {
 
 	// Charts are only allowed at relative paths. Use conf.CalledFrom to find the callers directory
 	if opts.CalledFrom == "" {
-		// TODO: rephrase and move lengthy explanation to website
-		return nil, fmt.Errorf("helmTemplate: 'opts.calledFrom' is unset or empty.\nTanka must know where helmTemplate was called from to resolve the Helm Chart relative to that.\n")
+		return nil, fmt.Errorf("helmTemplate: 'opts.calledFrom' is unset or empty.\nTanka needs this to find your Charts. See https://tanka.dev/helm#optscalledfrom-unset\n")
 	}
 
 	return &opts, nil
@@ -138,6 +136,5 @@ type ErrorDuplicateName struct {
 }
 
 func (e ErrorDuplicateName) Error() string {
-	// TODO: explain on website
-	return fmt.Sprintf("Two resources share the same name '%s'. Please adapt the name template '%s'", e.name, e.format)
+	return fmt.Sprintf("Two resources share the same name '%s'. Please adapt the name template '%s'. See https://tanka.dev/helm#two-resources-share-the-same-name", e.name, e.format)
 }


### PR DESCRIPTION
Adds docs for the upcoming Helm support:

- Reorganizes the "loose" docs pages into categories
- Adds Helm support to "Advanced features"

Also needs https://github.com/grafana/jsonnet-libs/pull/332

I've tagged a lot of people here. If you got time, please read those and think of a less involved user. Is it clear how to use this feature?