### PR TITLE
feat: allow other entrypoints

### DIFF
--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -41,7 +41,7 @@ func jpathCmd() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("Resolving JPATH: %s", err)
 			}
-			entrypoint, err := jpath.GetEntrypoint(base)
+			entrypoint, err := jpath.Entrypoint(base)
 			if err != nil {
 				return fmt.Errorf("Resolving JPATH: %s", err)
 			}

--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -41,8 +41,11 @@ func jpathCmd() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("Resolving JPATH: %s", err)
 			}
-
-			fmt.Println("main:", filepath.Join(base, "main.jsonnet"))
+			entrypoint, err := jpath.GetEntrypoint(base)
+			if err != nil {
+				return fmt.Errorf("Resolving JPATH: %s", err)
+			}
+			fmt.Println("main:", entrypoint)
 			fmt.Println("rootDir:", root)
 			fmt.Println("baseDir:", base)
 			fmt.Println("jpath:", path)

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -1,8 +1,6 @@
 package jsonnet
 
 import (
-	"path/filepath"
-
 	jsonnet "github.com/google/go-jsonnet"
 	"github.com/pkg/errors"
 
@@ -60,7 +58,7 @@ func MakeVM(opts Opts) *jsonnet.VM {
 // result in JSON form. It disregards opts.ImportPaths in favor of automatically
 // resolving these according to the specified file.
 func EvaluateFile(jsonnetFile string, opts Opts) (string, error) {
-	jpath, _, _, err := jpath.Resolve(filepath.Dir(jsonnetFile))
+	jpath, _, _, err := jpath.Resolve(jsonnetFile)
 	if err != nil {
 		return "", errors.Wrap(err, "resolving import paths")
 	}
@@ -72,7 +70,7 @@ func EvaluateFile(jsonnetFile string, opts Opts) (string, error) {
 
 // Evaluate renders the given jsonnet into a string
 func Evaluate(filename, data string, opts Opts) (string, error) {
-	jpath, _, _, err := jpath.Resolve(filepath.Dir(filename))
+	jpath, _, _, err := jpath.Resolve(filename)
 	if err != nil {
 		return "", errors.Wrap(err, "resolving import paths")
 	}

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -69,12 +69,12 @@ func EvaluateFile(jsonnetFile string, opts Opts) (string, error) {
 }
 
 // Evaluate renders the given jsonnet into a string
-func Evaluate(filename, data string, opts Opts) (string, error) {
-	jpath, _, _, err := jpath.Resolve(filename)
+func Evaluate(path, data string, opts Opts) (string, error) {
+	jpath, _, _, err := jpath.Resolve(path)
 	if err != nil {
 		return "", errors.Wrap(err, "resolving import paths")
 	}
 	opts.ImportPaths = jpath
 	vm := MakeVM(opts)
-	return vm.EvaluateAnonymousSnippet(filename, data)
+	return vm.EvaluateAnonymousSnippet(path, data)
 }

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -26,7 +26,10 @@ func TransitiveImports(dir string) ([]string, error) {
 		return nil, err
 	}
 
-	mainFile := filepath.Join(dir, "main.jsonnet")
+	mainFile, err := jpath.GetEntrypoint(dir)
+	if err != nil {
+		return nil, err
+	}
 
 	sonnet, err := ioutil.ReadFile(mainFile)
 	if err != nil {
@@ -44,13 +47,13 @@ func TransitiveImports(dir string) ([]string, error) {
 		vm.NativeFunction(nf)
 	}
 
-	node, err := jsonnet.SnippetToAST("main.jsonnet", string(sonnet))
+	node, err := jsonnet.SnippetToAST(filepath.Base(mainFile), string(sonnet))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating Jsonnet AST")
 	}
 
 	imports := make(map[string]bool)
-	if err = importRecursive(imports, vm, node, "main.jsonnet"); err != nil {
+	if err = importRecursive(imports, vm, node, filepath.Base(mainFile)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -26,7 +26,7 @@ func TransitiveImports(dir string) ([]string, error) {
 		return nil, err
 	}
 
-	mainFile, err := jpath.GetEntrypoint(dir)
+	mainFile, err := jpath.Entrypoint(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -26,12 +26,12 @@ func TransitiveImports(dir string) ([]string, error) {
 		return nil, err
 	}
 
-	mainFile, err := jpath.Entrypoint(dir)
+	entrypoint, err := jpath.Entrypoint(dir)
 	if err != nil {
 		return nil, err
 	}
 
-	sonnet, err := ioutil.ReadFile(mainFile)
+	sonnet, err := ioutil.ReadFile(entrypoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening file")
 	}
@@ -47,13 +47,13 @@ func TransitiveImports(dir string) ([]string, error) {
 		vm.NativeFunction(nf)
 	}
 
-	node, err := jsonnet.SnippetToAST(filepath.Base(mainFile), string(sonnet))
+	node, err := jsonnet.SnippetToAST(filepath.Base(entrypoint), string(sonnet))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating Jsonnet AST")
 	}
 
 	imports := make(map[string]bool)
-	if err = importRecursive(imports, vm, node, filepath.Base(mainFile)); err != nil {
+	if err = importRecursive(imports, vm, node, filepath.Base(entrypoint)); err != nil {
 		return nil, err
 	}
 
@@ -68,7 +68,7 @@ func TransitiveImports(dir string) ([]string, error) {
 		paths = append(paths, p)
 
 	}
-	paths = append(paths, mainFile)
+	paths = append(paths, entrypoint)
 
 	for i := range paths {
 		paths[i], _ = filepath.Rel(rootDir, paths[i])

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -38,7 +38,7 @@ func Resolve(workdir string) (path []string, base, root string, err error) {
 		return nil, "", "", err
 	}
 
-	entrypoint, err := GetEntrypoint(workdir)
+	entrypoint, err := Entrypoint(workdir)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -119,7 +119,7 @@ func dirContainsFile(files []os.FileInfo, filename string) bool {
 	return false
 }
 
-func GetEntrypoint(dir string) (string, error) {
+func Entrypoint(dir string) (string, error) {
 	filename := "main.jsonnet"
 	stat, err := os.Stat(dir)
 	if err != nil {

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 )
 
+const DEFAULT_ENTRYPOINT = "main.jsonnet"
+
 var (
 	// ErrorNoRoot means no rootDir was found in the parents
 	ErrorNoRoot = errors.New("could not locate a tkrc.yaml or jsonnetfile.json in the parent directories, which is required to identify the project root.\nRefer to https://tanka.dev/directory-structure for more information")
@@ -120,7 +122,7 @@ func dirContainsFile(files []os.FileInfo, filename string) bool {
 }
 
 func Entrypoint(dir string) (string, error) {
-	filename := "main.jsonnet"
+	filename := DEFAULT_ENTRYPOINT
 	stat, err := os.Stat(dir)
 	if err != nil {
 		return "", err

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -40,7 +40,7 @@ func Resolve(path string) (jpath []string, base, root string, err error) {
 		return nil, "", "", err
 	}
 
-	root, err = findRoot(filepath.Dir(entrypoint))
+	root, err = FindRoot(filepath.Dir(entrypoint))
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -129,8 +129,7 @@ func parseSpec(baseDir, rootDir string) (*v1alpha1.Config, error) {
 	return config, nil
 }
 
-// evalJsonnet evaluates the jsonnet environment at the given directory starting with
-// `main.jsonnet`
+// evalJsonnet evaluates the jsonnet environment at the given directory
 func evalJsonnet(baseDir string, env *v1alpha1.Config, opts jsonnet.Opts) (interface{}, error) {
 	// make env spec accessible from Jsonnet
 	jsonEnv, err := json.Marshal(env)
@@ -141,7 +140,11 @@ func evalJsonnet(baseDir string, env *v1alpha1.Config, opts jsonnet.Opts) (inter
 
 	// evaluate Jsonnet
 	var raw string
-	mainFile := filepath.Join(baseDir, "main.jsonnet")
+	mainFile, err := jpath.GetEntrypoint(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
 	if opts.EvalPattern != "" {
 		evalScript := fmt.Sprintf("(import '%s').%s", mainFile, opts.EvalPattern)
 		raw, err = jsonnet.Evaluate(mainFile, evalScript, opts)

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -87,17 +87,12 @@ func load(dir string, opts Opts) (*loaded, error) {
 // eval runs all processing stages describe at the Processed type apart from
 // post-processing, thus returning the raw Jsonnet result.
 func eval(dir string, opts jsonnet.Opts) (raw interface{}, env *v1alpha1.Config, err error) {
-	_, baseDir, rootDir, err := jpath.Resolve(dir)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "resolving jpath")
-	}
-
-	env, err = parseSpec(baseDir, rootDir)
+	env, err = parseSpec(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	raw, err = evalJsonnet(baseDir, env, opts)
+	raw, err = evalJsonnet(dir, env, opts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "evaluating jsonnet")
 	}
@@ -107,7 +102,12 @@ func eval(dir string, opts jsonnet.Opts) (raw interface{}, env *v1alpha1.Config,
 
 // parseEnv parses the `spec.json` of the environment and returns a
 // *kubernetes.Kubernetes from it
-func parseSpec(baseDir, rootDir string) (*v1alpha1.Config, error) {
+func parseSpec(dir string) (*v1alpha1.Config, error) {
+	_, baseDir, rootDir, err := jpath.Resolve(dir)
+	if err != nil {
+		return nil, errors.Wrap(err, "resolving jpath")
+	}
+
 	// name of the environment: relative path from rootDir
 	name, _ := filepath.Rel(rootDir, baseDir)
 

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -140,7 +140,7 @@ func evalJsonnet(baseDir string, env *v1alpha1.Config, opts jsonnet.Opts) (inter
 
 	// evaluate Jsonnet
 	var raw string
-	mainFile, err := jpath.GetEntrypoint(baseDir)
+	mainFile, err := jpath.Entrypoint(baseDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The change allows the user to run tanka with alternative entrypoints, not limiting to `main.jsonnet` anymore.

This opens the door to using `tk eval` for purposes outside of the Tanka/K8s Environments paradigm. For example, one can
write a library with a `test.jsonnet` and run `tk eval test.jsonnet` in that library. Caveat: it needs to have a
`tkrc.yaml` or `jsonnetfile.json` so Tanka can resolve the JPATH. It also works for `tk export` and `tk show`, beware
that it will add `default` namespace to kubernetes objects, even though a `spec.json` might not exist.

This change is backwards compatible and still defaults to main.jsonnet if no file is given, `tk diff` will still want a
spec.json to connect to a cluster.

Feel free to give feedback/pushback on the idea here too.


I've done a grep on `main.jsonnet` in the codebase to set this up, but there are many other valid references to
`main.jsonnet` left that don't need replacing.