### PR TITLE
Environment name set in spec.json is ignored

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -50,6 +51,10 @@ func Parse(data []byte, name string) (*v1alpha1.Config, error) {
 		return nil, errors.Wrap(err, "parsing spec.json")
 	}
 
+	// only allow explicit metadata.name when matching generated value
+	if config.Metadata.Name != "" && config.Metadata.Name != name {
+		return nil, fmt.Errorf("invalid metadata.name, must match generated %q", name)
+	}
 	// set the name field
 	config.Metadata.Name = name
 

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -43,20 +43,29 @@ func TestEvalJsonnet(t *testing.T) {
 
 func TestEval(t *testing.T) {
 	cases := []struct {
-		baseDir  string
-		expected interface{}
+		baseDir       string
+		expectedError string
+		expected      interface{}
 	}{
 		{
-			baseDir: "./testdata/cases/env/",
+			baseDir:       "./testdata/cases/env-mismatch",
+			expectedError: `reading spec.json: invalid metadata.name, must match generated "cases/env-mismatch"`,
+		},
+		{
+			baseDir: "./testdata/cases/env",
 			expected: map[string]interface{}{
-				"tkName": "custom-name",
+				"tkName": "cases/env",
 			},
 		},
 	}
 
 	for _, test := range cases {
 		raw, _, e := eval(test.baseDir, jsonnet.Opts{})
-		assert.NoError(t, e)
-		assert.Equal(t, test.expected, raw)
+		if test.expectedError != "" {
+			assert.Equal(t, test.expectedError, e.Error())
+		} else {
+			assert.NoError(t, e)
+			assert.Equal(t, test.expected, raw)
+		}
 	}
 }

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -40,3 +40,23 @@ func TestEvalJsonnet(t *testing.T) {
 		assert.Equal(t, test.expected, data)
 	}
 }
+
+func TestEval(t *testing.T) {
+	cases := []struct {
+		baseDir  string
+		expected interface{}
+	}{
+		{
+			baseDir: "./testdata/cases/env/",
+			expected: map[string]interface{}{
+				"tkName": "custom-name",
+			},
+		},
+	}
+
+	for _, test := range cases {
+		raw, _, e := eval(test.baseDir, jsonnet.Opts{})
+		assert.NoError(t, e)
+		assert.Equal(t, test.expected, raw)
+	}
+}

--- a/pkg/tanka/testdata/cases/env-mismatch/main.jsonnet
+++ b/pkg/tanka/testdata/cases/env-mismatch/main.jsonnet
@@ -1,0 +1,5 @@
+local tk = (import "tk");
+
+{
+  tkName: tk.env.metadata.name,
+}

--- a/pkg/tanka/testdata/cases/env-mismatch/spec.json
+++ b/pkg/tanka/testdata/cases/env-mismatch/spec.json
@@ -2,6 +2,6 @@
   "apiVersion": "v1alpha1",
   "kind": "Environment",
   "metadata": {
-    "name": "cases/env"
+    "name": "mismatched-name"
   }
 }

--- a/pkg/tanka/testdata/cases/env/main.jsonnet
+++ b/pkg/tanka/testdata/cases/env/main.jsonnet
@@ -1,0 +1,5 @@
+local tk = (import "tk");
+
+{
+  tkName: tk.env.metadata.name,
+}

--- a/pkg/tanka/testdata/cases/env/spec.json
+++ b/pkg/tanka/testdata/cases/env/spec.json
@@ -1,0 +1,7 @@
+{
+  "apiVersion": "v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "custom-name"
+  }
+}


### PR DESCRIPTION
Currently `tk.env.metadata.name` is always set to the default generated value, regardless of whether `metadata.name` is set in `spec.json` or not.

This patch
* adds a test case for the expected behaviour and
* does not override the value loaded from `spec.json`.

I found a somewhat relevant mention in https://github.com/grafana/tanka/pull/163 and a link to #131, but that may be slightly different issue. As an alternative solution tk could instead throw an error when the name is set in `spec.json` if you believe the generated value is best. This would also be better for backwards compatibility if there are already users unknowingly using the default value while having a different name specified in `spec.json`.

/kind bug