### PR TITLE
Fix dependencies path from generate files

### DIFF
--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -85,7 +85,7 @@ func installK8sLib() error {
 		"github.com/grafana/jsonnet-libs/ksonnet-util",
 	}
 
-	if err := writeNewFile("lib/k.libsonnet", "import 'ksonnet.beta.4/k.libsonnet'\n"); err != nil {
+	if err := writeNewFile("lib/k.libsonnet", "import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet'\n"); err != nil {
 		return err
 	}
 

--- a/docs/docs/directory-structure.md
+++ b/docs/docs/directory-structure.md
@@ -16,13 +16,20 @@ Tanka uses the following directories and special files:
 ├── jsonnetfile.json # direct dependencies
 ├── jsonnetfile.lock.json # all dependencies with exact versions
 ├── lib # libraries for this project only
-│   └── k.libsonnet # alias file for vendor/ksonnet.beta.4/k.libsonnet
+│   └── k.libsonnet # alias file for vendor/github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet
 └── vendor # external libraries installed using jb
-    ├── ksonnet.beta.4 # kubernetes library
-    │   ├── k8s.libsonnet
-    │   └── k.libsonnet
-    └── ksonnet-util # Grafana Labs' usability extensions to k.libsonnet
-        └── kausal.libsonnet
+    ├── github.com
+    │   ├── grafana
+    │   │   └── jsonnet-libs
+    │   │       └── ksonnet-util # Grafana Labs' usability extensions to k.libsonnet
+    │   │           └── kausal.libsonnet
+    │   └── ksonnet
+    │       └── ksonnet-lib
+    │           └── ksonnet.beta.4 # kubernetes library
+    │               ├── k8s.libsonnet
+    │               └── k.libsonnet
+    ├── ksonnet.beta.4 -> github.com/ksonnet/ksonnet-lib/ksonnet.beta.4
+    └── ksonnet-util -> github.com/grafana/jsonnet-libs/ksonnet-util
 ```
 
 ## Environments

--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -24,12 +24,12 @@ more explicit approach and requires you to install them using `jb`:
 
 ```bash
 $ jb install github.com/ksonnet/ksonnet-lib/ksonnet.beta.4
-$ echo 'import "ksonnet.beta.4/k.libsonnet"' > lib/k.libsonnet
+$ echo "import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet'" > lib/k.libsonnet
 ```
 
 This does 2 things:
 
-1) It installs the ksonnet library (in `vendor/ksonnet.beta.4`).
+1) It installs the ksonnet library (in `vendor/github.com/ksonnet/ksonnet-lib/ksonnet.beta.4`).
 If you need a specific version, take a look at
 https://github.com/ksonnet/ksonnet-lib. When a pre-compiled version is
 available, install it using `jb`, otherwise compile it yourself and place it

--- a/docs/docs/tutorial/k-lib.mdx
+++ b/docs/docs/tutorial/k-lib.mdx
@@ -51,11 +51,18 @@ This created the following files in `/vendor`:
 
 ```bash
 vendor
-├── ksonnet.beta.4
-│   ├── k.libsonnet # human friendly wrapper (this is what we use in our code)
-│   └── k8s.libsonnet # literally the entire API as a library. Very huge file
-└── ksonnet-util
-    └── kausal.libsonnet # Grafana's wrapper
+├── github.com
+│   ├── grafana
+│   │   └── jsonnet-libs
+│   │       └── ksonnet-util
+│   │           └── kausal.libsonnet # Grafana's wrapper
+│   └── ksonnet
+│       └── ksonnet-lib
+│           └── ksonnet.beta.4
+│               ├── k8s.libsonnet # literally the entire API as a library. Very huge file
+│               └── k.libsonnet # human friendly wrapper (this is what we use in our code)
+├── ksonnet.beta.4 -> github.com/ksonnet/ksonnet-lib/ksonnet.beta.4
+└── ksonnet-util -> github.com/grafana/jsonnet-libs/ksonnet-util
 ```
 
 > **Info**: The `vendor/` is the location for external libraries, while `lib/`
@@ -63,7 +70,7 @@ vendor
 > for more information.
 
 #### Aliasing
-Because of how `jb` works, the library can be imported as `ksonnet.beta.4/k.libsonnet`.
+Because of how `jb` works, the library can be imported as `github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet`.
 Most external libraries (including our wrapper) expect it as a simple `k.libsonnet` (without
 the package prefix).
 
@@ -80,7 +87,7 @@ First we need to import it in `main.jsonnet`:
 
 ```diff
 - (import "kubernetes.libsonnet") +
-+ (import "ksonnet-util/kausal.libsonnet") +
++ (import "github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet") +
   (import "grafana.jsonnet") +
   (import "prometheus.jsonnet") +
   { /* ... */ }

--- a/examples/prom-grafana/lib/k.libsonnet
+++ b/examples/prom-grafana/lib/k.libsonnet
@@ -1,1 +1,1 @@
-import "ksonnet.beta.4/k.libsonnet"
+import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet'


### PR DESCRIPTION
Hi,

`jb` update how dependencies are vendor: https://github.com/jsonnet-bundler/jsonnet-bundler/issues/6.

Current vendor structure is:
```
vendor
├── github.com
│   ├── grafana
│   │   └── jsonnet-libs
│   │       └── ksonnet-util
│   │           └── kausal.libsonnet
│   └── ksonnet
│       └── ksonnet-lib
│           └── ksonnet.beta.4
│               ├── k8s.libsonnet
│               └── k.libsonnet
├── ksonnet.beta.4 -> github.com/ksonnet/ksonnet-lib/ksonnet.beta.4
└── ksonnet-util -> github.com/grafana/jsonnet-libs/ksonnet-util
```

As `jb` provide command to fix import `jb rewrite`, I suppose that symlink will not be supported in future. So I think it is cleaner if generated files from `tk init` are import files from vendor with full path instead symlinks.

Furthermore, I update docs about directory structure and examples.