### PR TITLE
feat: Tanka version constraint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 dev:
 	go build -ldflags "-X main.Version=dev-${VERSION}" ./cmd/tk
 
-LDFLAGS := '-s -w -extldflags "-static" -X main.Version=${VERSION}'
+LDFLAGS := '-s -w -extldflags "-static" -X github.com/grafana/tanka/pkg/tanka.CURRENT_VERSION=${VERSION}'
 static:
 	CGO_ENABLED=0 go build -ldflags=${LDFLAGS} ./cmd/tk
 

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -13,11 +13,8 @@ import (
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/spec"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+	"github.com/grafana/tanka/pkg/tanka"
 )
-
-// Version is the current version of the tk command.
-// To be overwritten at build time
-var Version = "dev"
 
 // describing variables
 var (
@@ -31,7 +28,7 @@ func main() {
 	rootCmd := &cli.Command{
 		Use:     "tk",
 		Short:   "tanka <3 jsonnet",
-		Version: Version,
+		Version: tanka.CURRENT_VERSION,
 	}
 
 	// workflow commands

--- a/pkg/spec/v1alpha1/config.go
+++ b/pkg/spec/v1alpha1/config.go
@@ -54,7 +54,14 @@ type Spec struct {
 	Namespace        string           `json:"namespace"`
 	DiffStrategy     string           `json:"diffStrategy,omitempty"`
 	InjectLabels     bool             `json:"injectLabels,omitempty"`
-	ResourceDefaults ResourceDefaults `json:"resourceDefaults,omitempty"`
+	ResourceDefaults ResourceDefaults `json:"resourceDefaults"`
+	ExpectVersions   ExpectVersions   `json:"expectVersions"`
+}
+
+// ExpectVersions holds semantic version constraints
+// TODO: extend this to handle more than Tanka
+type ExpectVersions struct {
+	Tanka string `json:"tanka,omitempty"`
 }
 
 // ResourceDefaults will be inserted in any manifests that tanka processes.


### PR DESCRIPTION
Adds `spec.versions.tanka` to validate the current Tanka version against
a SemVer constraint (e.g. `>=0.12`).

This is a struct and not a top level field to allow for extending in the
future, as there are other versions we could validate as well (Helm,
Kubectl, etc)

I realize we put Tanka into feature freeze for the 0.12 release, but I feel like not having this could make the upgrading to the new version harder 