### PR TITLE
switch format verb for status output

### DIFF
--- a/cmd/tk/status.go
+++ b/cmd/tk/status.go
@@ -34,7 +34,7 @@ func statusCmd() *cli.Command {
 		fmt.Println("Cluster:", context.Context.Cluster)
 		fmt.Println("Environment:")
 		for k, v := range structs.Map(status.Env.Spec) {
-			fmt.Printf("  %s: %s\n", k, v)
+			fmt.Printf("  %s: %v\n", k, v)
 		}
 
 		fmt.Println("Resources:")


### PR DESCRIPTION
Currently when running `tk status` the output contains the following:
```
  InjectLabels: %!s(bool=false)
```
This is caused by using the `%s` format verb which only works on string

By specifying `%v`, go will use the default format for the corresponding datatype