### PR TITLE
fix(cli): Environment name at env creation (#397)

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/kubernetes/client"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/grafana/tanka/pkg/term"
@@ -156,8 +157,12 @@ func addEnv(dir string, cfg *v1alpha1.Config) error {
 		}
 	}
 
+	rootDir, err := jpath.FindRoot(path)
+	if err != nil {
+		return err
+	}
 	// the other properties are already set by v1alpha1.New() and pflag.Parse()
-	cfg.Metadata.Name = filepath.Base(path)
+	cfg.Metadata.Name, _ = filepath.Rel(rootDir, path)
 
 	// write spec.json
 	if err := writeJSON(cfg, filepath.Join(path, "spec.json")); err != nil {

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -38,7 +38,7 @@ func Resolve(workdir string) (path []string, base, root string, err error) {
 		return nil, "", "", err
 	}
 
-	root, err = findRoot(workdir)
+	root, err = FindRoot(workdir)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -60,10 +60,10 @@ func Resolve(workdir string) (path []string, base, root string, err error) {
 	}, base, root, nil
 }
 
-// findRoot searches for a rootDir by the following criteria:
+// FindRoot searches for a rootDir by the following criteria:
 // - tkrc.yaml is considered first, for a jb-independent way of marking the root
 // - if it is not present (default), jsonnetfile.json is used.
-func findRoot(start string) (dir string, err error) {
+func FindRoot(start string) (dir string, err error) {
 	// root path based on os
 	stop := "/"
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Environment name is the relative path of an env dir. tk env add is incorrectly
using the base dir name. This PR fixes it.

jpath pkg is used to benefit from the existing implementation. FindRoot function
is made public instead of using Resolve because Resolve does many other things
as well, some of which require files that don't exist at that time.

Signed-off-by: Michal Wasilewski <mwasilewski@gmx.com>