### PR TITLE
Jsonnet Bundler via brew

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -29,4 +29,4 @@ to share and reuse code across the internet, similar to `npm` or `go mod`.
 
 Tanka uses this tool by default, so it's recommended to install it as well:
 
-<PlatformInstall elems={Jb} def="Binary" />
+<PlatformInstall elems={Jb} def="macOS" />

--- a/docs/src/components/install/index.js
+++ b/docs/src/components/install/index.js
@@ -5,6 +5,7 @@ import Arch from "./tk/arch.mdx"
 import Go from "./tk/go.mdx"
 import Binary from "./tk/binary.mdx"
 
+import JbOsx from "./jb/osx.mdx"
 import JbArch from "./jb/arch.mdx"
 import JbGo from "./jb/go.mdx"
 import JbBinary from "./jb/binary.mdx"
@@ -17,8 +18,9 @@ export const Tanka = {
 }
 
 export const Jb = {
-  Binary: <JbBinary />,
+  macOS: <JbOsx />,
   ArchLinux: <JbArch />,
+  Binary: <JbBinary />,
   Go: <JbGo />,
 }
 

--- a/docs/src/components/install/jb/osx.mdx
+++ b/docs/src/components/install/jb/osx.mdx
@@ -1,0 +1,8 @@
+On macOS, Jsonnet Bundler is best installed using [`brew`](https://brew.sh):
+
+```bash
+$ brew install jsonnet-bundler
+```
+
+This downloads the most recent version of Jsonnet Bundler and installs it.  
+Also, Jsonnet Bundler is automatically kept up to date as part of `brew upgrade`.


### PR DESCRIPTION
I am not 100% sure this is all that is needed, but I noticed today while reading your docs that you didn't indicate jb could be installed through brew right along with tanka so I thought I'd take a stab at fixing that. Hope this helps.