### PR TITLE
feat(cli): run commands with tk- prefix on PATH

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	// external commands prefixed with "tk-"
 	rootCmd.AddCommand(
-		prefixCmds("tk-")...,
+		prefixCommands("tk-")...,
 	)
 
 	// Run!

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -54,6 +54,11 @@ func main() {
 		toolCmd(),
 	)
 
+	// external commands prefixed with "tk-"
+	rootCmd.AddCommand(
+		prefixCmds("tk-")...,
+	)
+
 	// Run!
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalln(err)

--- a/cmd/tk/prefix.go
+++ b/cmd/tk/prefix.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/go-clix/cli"
+)
+
+func prefixCmds(prefix string) []*cli.Command {
+	ext_subcommands := map[string]string{}
+	if path, ok := os.LookupEnv("PATH"); ok {
+		paths := strings.Split(path, ":")
+		for _, p := range paths {
+			s, err := os.Stat(p)
+			if err == nil && s.IsDir() {
+				files, err := ioutil.ReadDir(p)
+				if err != nil {
+					panic(err)
+				}
+				for _, file := range files {
+					if strings.HasPrefix(file.Name(), prefix) &&
+						!file.IsDir() &&
+						file.Mode().IsRegular() &&
+						file.Mode().Perm()&0111 != 0 {
+						ext_subcommands[file.Name()] = fmt.Sprintf("%s/%s", p, file.Name())
+					}
+				}
+			}
+		}
+	}
+
+	var cmds []*cli.Command
+	for file, path := range ext_subcommands {
+		cmd := &cli.Command{
+			Use:   fmt.Sprintf("%s --", strings.TrimPrefix(file, prefix)),
+			Short: fmt.Sprintf("external command %s", path),
+			Args:  cli.ArgsAny(),
+		}
+
+		ext_command := exec.Command(path)
+		if ex, err := os.Executable(); err == nil {
+			ext_command.Env = append(os.Environ(), fmt.Sprintf("EXECUTABLE=%s", ex))
+		}
+		ext_command.Stdout = os.Stdout
+		ext_command.Stderr = os.Stderr
+
+		cmd.Run = func(cmd *cli.Command, args []string) error {
+			ext_command.Args = append(ext_command.Args, args...)
+			return ext_command.Run()
+		}
+		cmds = append(cmds, cmd)
+	}
+	if len(cmds) > 0 {
+		return cmds
+	}
+	return nil
+}


### PR DESCRIPTION
In analogy to the git- prefixed commands, this finds all executable on
PATH that look like `tk-<command>` and run them as `tk <command>`.

Implementation example:
```
$ cat /usr/bin/tk-jq
  #!/usr/bin/env sh
  ${EXECUTABLE} eval ${@:2} | jq $1

$ echo "{ tanka: 'cool' }" > main.jsonnet
$ tk jq .tanka main.jsonnet
  "cool"

```

This concept intends to foster extensions that work well with Tanka, for example encrypt/decrypt secrets during runtime, alternative diff tools, integration with third party API clients, ...