### PR TITLE
term: Fix confirmation prompts on windows

### DIFF
--- a/pkg/term/alert.go
+++ b/pkg/term/alert.go
@@ -3,22 +3,42 @@ package term
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/pkg/errors"
 )
 
+var ErrConfirmationFailed = errors.New("aborted by user")
+
 // Confirm asks the user for confirmation
 func Confirm(msg, approval string) error {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println(msg)
-	fmt.Printf("Please type '%s' to confirm: ", approval)
-	read, err := reader.ReadString('\n')
+	return confirmFrom(os.Stdin, os.Stdout, msg, approval)
+}
+
+func confirmFrom(r io.Reader, w io.Writer, msg, approval string) error {
+	reader := bufio.NewScanner(r)
+	_, err := fmt.Fprintln(w, msg)
 	if err != nil {
-		return errors.Wrap(err, "reading from stdin")
+		return errors.Wrap(err, "writing to stdout")
 	}
-	if read != approval+"\n" {
-		return errors.New("aborted by user")
+
+	_, err = fmt.Fprintf(w, "Please type '%s' to confirm: ", approval)
+	if err != nil {
+		return errors.Wrap(err, "writing to stdout")
 	}
+
+	if !reader.Scan() {
+		if err := reader.Err(); err != nil {
+			return errors.Wrap(err, "reading from stdin")
+		}
+
+		return ErrConfirmationFailed
+	}
+
+	if reader.Text() != approval {
+		return ErrConfirmationFailed
+	}
+
 	return nil
 }

--- a/pkg/term/alert_test.go
+++ b/pkg/term/alert_test.go
@@ -1,0 +1,38 @@
+package term
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfirm(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+	}{
+		{name: "linux yes", input: "yes\n", expected: nil},
+		{name: "windows yes", input: "yes\r\n", expected: nil},
+		{name: "linux no", input: "no\n", expected: ErrConfirmationFailed},
+		{name: "windows no", input: "no\r\n", expected: ErrConfirmationFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := strings.NewReader(tt.input)
+			out := &strings.Builder{}
+
+			err := confirmFrom(in, out, "foo", "yes")
+
+			assert.Equal(t, "foo\nPlease type 'yes' to confirm: ", out.String())
+
+			if tt.expected != nil {
+				assert.EqualError(t, err, tt.expected.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes confirmation prompts on windows by scanning for a line of input and comparing that to the desired prompt. `term.Confirm(...)` is refactored slightly to make it easier to test.

Fixes #347

Note that other tests (not those added in this PR) will fail on windows until #411 is merged.

I've also verified this works on windows:

<details>

<summary> With `tk` `v0.12.0` </summary>

```txt
C:\Users\Nathan\projects\grafana-agent-operator\example [master ≡ +0 ~4 -0 !]> tk apply .\environments\default\
diff -u -N C:\Users\Nathan\AppData\Local\Temp\LIVE-097035773/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com C:\Users\Nathan\AppData\Local\Temp\MERGED-483356984/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com
--- C:\Users\Nathan\AppData\Local\Temp\LIVE-097035773/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com       2020-10-27 22:12:54.118744100 -0700
+++ C:\Users\Nathan\AppData\Local\Temp\MERGED-483356984/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com     2020-10-27 22:12:54.142744000 -0700
@@ -46,7 +46,7 @@
         f:storedVersions: {}
     manager: kubectl-client-side-apply
     operation: Update
-    time: "2020-10-28T05:04:03Z"
+    time: "2020-10-28T05:12:51Z"
   name: servicemonitors.monitoring.coreos.com
   resourceVersion: "545577"
   selfLink: /apis/apiextensions.k8s.io/v1/customresourcedefinitions/servicemonitors.monitoring.coreos.com

Applying to namespace 'default' of cluster 'docker-desktop' at 'https://kubernetes.docker.internal:6443' using context 'docker-desktop'.
Please type 'yes' to confirm: yes
aborted by user
```

</details>

<details>

<summary> With `tk` built from this commit </summary>

```txt
C:\Users\Nathan\projects\grafana-agent-operator\example [master ≡ +0 ~4 -0 !]> ..\..\tanka\tk.exe apply .\environments\default\
diff -u -N C:\Users\Nathan\AppData\Local\Temp\LIVE-142144125/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com C:\Users\Nathan\AppData\Local\Temp\MERGED-139668408/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com
--- C:\Users\Nathan\AppData\Local\Temp\LIVE-142144125/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com       2020-10-27 22:04:00.340253300 -0700
+++ C:\Users\Nathan\AppData\Local\Temp\MERGED-139668408/apiextensions.k8s.io.v1.CustomResourceDefinition..servicemonitors.monitoring.coreos.com     2020-10-27 22:04:00.366253100 -0700
@@ -46,7 +46,7 @@
         f:storedVersions: {}
     manager: kubectl-client-side-apply
     operation: Update
-    time: "2020-10-28T05:03:23Z"
+    time: "2020-10-28T05:03:57Z"
   name: servicemonitors.monitoring.coreos.com
   resourceVersion: "545509"
   selfLink: /apis/apiextensions.k8s.io/v1/customresourcedefinitions/servicemonitors.monitoring.coreos.com

Applying to namespace 'default' of cluster 'docker-desktop' at 'https://kubernetes.docker.internal:6443' using context 'docker-desktop'.
Please type 'yes' to confirm: yes
namespace/etcd unchanged
namespace/foo-a unchanged
namespace/foo-b unchanged
namespace/foo-c unchanged
namespace/monitoring unchanged
serviceaccount/grafana-agent-cluster unchanged
configmap/cortex-config unchanged
configmap/dashboards-0 unchanged
configmap/dashboards-1 unchanged
configmap/dashboards-2 unchanged
configmap/dashboards-3 unchanged
configmap/dashboards-4 unchanged
configmap/dashboards-5 unchanged
configmap/dashboards-6 unchanged
configmap/dashboards-7 unchanged
configmap/grafana-agent-cluster unchanged
configmap/grafana-config unchanged
configmap/grafana-dashboard-provisioning unchanged
configmap/grafana-datasources unchanged
persistentvolumeclaim/cortex-data unchanged
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com configured
clusterrole.rbac.authorization.k8s.io/grafana-agent-cluster unchanged
clusterrolebinding.rbac.authorization.k8s.io/grafana-agent-cluster unchanged
service/etcd unchanged
service/example unchanged
service/example unchanged
service/example unchanged
service/cortex unchanged
service/grafana unchanged
service/grafana-agent-cluster unchanged
deployment.apps/etcd unchanged
deployment.apps/example unchanged
deployment.apps/load-generator unchanged
deployment.apps/example unchanged
deployment.apps/load-generator unchanged
deployment.apps/example unchanged
deployment.apps/load-generator unchanged
deployment.apps/cortex unchanged
deployment.apps/grafana unchanged
deployment.apps/grafana-agent-cluster configured
servicemonitor.monitoring.coreos.com/example unchanged
servicemonitor.monitoring.coreos.com/example unchanged
servicemonitor.monitoring.coreos.com/example unchanged
servicemonitor.monitoring.coreos.com/cortex unchanged
```

</details>