### PR TITLE
feat: multiple inline environments

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -77,18 +77,6 @@ func setupConfiguration(baseDir string) *v1alpha1.Environment {
 			if verbose {
 				fmt.Print(err)
 			}
-		// no spec.json is found, try parsing main.jsonnet
-		case spec.ErrNoSpec:
-			_, config, err := tanka.ParseEnv(baseDir, tanka.ParseOpts{Evaluator: tanka.EnvsOnlyEvaluator})
-			if err != nil {
-				switch err.(type) {
-				case tanka.ErrNoEnv:
-					return nil
-				default:
-					log.Fatalf("Reading main.jsonnet: %s", err)
-				}
-			}
-			return config
 		// some other error
 		default:
 			log.Fatalf("Reading spec.json: %s", err)

--- a/cmd/tk/status.go
+++ b/cmd/tk/status.go
@@ -22,29 +22,31 @@ func statusCmd() *cli.Command {
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		status, err := tanka.Status(args[0], tanka.Opts{
+		statusses, err := tanka.Status(args[0], tanka.Opts{
 			JsonnetOpts: getJsonnetOpts(),
 		})
 		if err != nil {
 			return err
 		}
 
-		context := status.Client.Kubeconfig.Context
-		fmt.Println("Context:", context.Name)
-		fmt.Println("Cluster:", context.Context.Cluster)
-		fmt.Println("Environment:")
-		for k, v := range structs.Map(status.Env.Spec) {
-			fmt.Printf("  %s: %v\n", k, v)
-		}
+		for _, status := range statusses {
+			context := status.Client.Kubeconfig.Context
+			fmt.Println("Context:", context.Name)
+			fmt.Println("Cluster:", context.Context.Cluster)
+			fmt.Println("Environment:")
+			for k, v := range structs.Map(status.Env.Spec) {
+				fmt.Printf("  %s: %v\n", k, v)
+			}
 
-		fmt.Println("Resources:")
-		f := "  %s\t%s/%s\n"
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-		fmt.Fprintln(w, "  NAMESPACE\tOBJECTSPEC")
-		for _, r := range status.Resources {
-			fmt.Fprintf(w, f, r.Metadata().Namespace(), r.Kind(), r.Metadata().Name())
+			fmt.Println("Resources:")
+			f := "  %s\t%s/%s\n"
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+			fmt.Fprintln(w, "  NAMESPACE\tOBJECTSPEC")
+			for _, r := range status.Resources {
+				fmt.Fprintf(w, f, r.Metadata().Namespace(), r.Kind(), r.Metadata().Name())
+			}
+			w.Flush()
 		}
-		w.Flush()
 
 		return nil
 	}

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -133,9 +133,11 @@ func diffCmd() *cli.Command {
 			os.Exit(ExitStatusClean)
 		}
 
-		r := term.Colordiff(*changes)
-		if err := fPageln(r); err != nil {
-			return err
+		for _, change := range changes {
+			r := term.Colordiff(*change)
+			if err := fPageln(r); err != nil {
+				return err
+			}
 		}
 
 		os.Exit(ExitStatusDiff)

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -11,7 +11,7 @@ func TestEvalJsonnet(t *testing.T) {
 	cases := []struct {
 		baseDir  string
 		expected interface{}
-		env      *v1alpha1.Environment
+		envs     []*v1alpha1.Environment
 	}{
 		{
 			baseDir: "./testdata/cases/array/",
@@ -25,33 +25,35 @@ func TestEvalJsonnet(t *testing.T) {
 					map[string]interface{}{"testCase": "nestedArray[1][1]"},
 				},
 			},
-			env: nil,
+			envs: nil,
 		},
 		{
 			baseDir: "./testdata/cases/object/",
 			expected: map[string]interface{}{
 				"testCase": "object",
 			},
-			env: nil,
+			envs: nil,
 		},
 		{
 			baseDir: "./testdata/cases/withspecjson/",
 			expected: map[string]interface{}{
 				"testCase": "object",
 			},
-			env: &v1alpha1.Environment{
-				APIVersion: v1alpha1.New().APIVersion,
-				Kind:       v1alpha1.New().Kind,
-				Metadata: v1alpha1.Metadata{
-					Name:   "cases/withspecjson",
-					Labels: v1alpha1.New().Metadata.Labels,
-				},
-				Spec: v1alpha1.Spec{
-					APIServer: "https://localhost",
-					Namespace: "withspec",
-				},
-				Data: map[string]interface{}{
-					"testCase": "object",
+			envs: []*v1alpha1.Environment{
+				{
+					APIVersion: v1alpha1.New().APIVersion,
+					Kind:       v1alpha1.New().Kind,
+					Metadata: v1alpha1.Metadata{
+						Name:   "cases/withspecjson",
+						Labels: v1alpha1.New().Metadata.Labels,
+					},
+					Spec: v1alpha1.Spec{
+						APIServer: "https://localhost",
+						Namespace: "withspec",
+					},
+					Data: map[string]interface{}{
+						"testCase": "object",
+					},
 				},
 			},
 		},
@@ -60,19 +62,21 @@ func TestEvalJsonnet(t *testing.T) {
 			expected: map[string]interface{}{
 				"testCase": "object",
 			},
-			env: &v1alpha1.Environment{
-				APIVersion: v1alpha1.New().APIVersion,
-				Kind:       v1alpha1.New().Kind,
-				Metadata: v1alpha1.Metadata{
-					Name:   "cases/withspecjson",
-					Labels: v1alpha1.New().Metadata.Labels,
-				},
-				Spec: v1alpha1.Spec{
-					APIServer: "https://localhost",
-					Namespace: "withspec",
-				},
-				Data: map[string]interface{}{
-					"testCase": "object",
+			envs: []*v1alpha1.Environment{
+				{
+					APIVersion: v1alpha1.New().APIVersion,
+					Kind:       v1alpha1.New().Kind,
+					Metadata: v1alpha1.Metadata{
+						Name:   "cases/withspecjson",
+						Labels: v1alpha1.New().Metadata.Labels,
+					},
+					Spec: v1alpha1.Spec{
+						APIServer: "https://localhost",
+						Namespace: "withspec",
+					},
+					Data: map[string]interface{}{
+						"testCase": "object",
+					},
 				},
 			},
 		},
@@ -92,32 +96,101 @@ func TestEvalJsonnet(t *testing.T) {
 					"testCase": "object",
 				},
 			},
-			env: &v1alpha1.Environment{
-				APIVersion: v1alpha1.New().APIVersion,
-				Kind:       v1alpha1.New().Kind,
-				Metadata: v1alpha1.Metadata{
-					Name:   "withenv",
-					Labels: v1alpha1.New().Metadata.Labels,
+			envs: []*v1alpha1.Environment{
+				{
+					APIVersion: v1alpha1.New().APIVersion,
+					Kind:       v1alpha1.New().Kind,
+					Metadata: v1alpha1.Metadata{
+						Name:   "withenv",
+						Labels: v1alpha1.New().Metadata.Labels,
+					},
+					Spec: v1alpha1.Spec{
+						APIServer: "https://localhost",
+						Namespace: "withenv",
+					},
+					Data: map[string]interface{}{
+						"testCase": "object",
+					},
 				},
-				Spec: v1alpha1.Spec{
-					APIServer: "https://localhost",
-					Namespace: "withenv",
+			},
+		},
+		{
+			baseDir: "./testdata/cases/withenvs/main.jsonnet",
+			expected: map[string]interface{}{
+				"envs": []interface{}{
+					map[string]interface{}{
+						"apiVersion": v1alpha1.New().APIVersion,
+						"kind":       v1alpha1.New().Kind,
+						"metadata": map[string]interface{}{
+							"name": "withenv1",
+						},
+						"spec": map[string]interface{}{
+							"apiServer": "https://localhost",
+							"namespace": "withenv",
+						},
+						"data": map[string]interface{}{
+							"testCase": "object",
+						},
+					},
+					map[string]interface{}{
+						"apiVersion": v1alpha1.New().APIVersion,
+						"kind":       v1alpha1.New().Kind,
+						"metadata": map[string]interface{}{
+							"name": "withenv2",
+						},
+						"spec": map[string]interface{}{
+							"apiServer": "https://localhost",
+							"namespace": "withenv",
+						},
+						"data": map[string]interface{}{
+							"testCase": "object",
+						},
+					},
 				},
-				Data: map[string]interface{}{
-					"testCase": "object",
+			},
+			envs: []*v1alpha1.Environment{
+				{
+					APIVersion: v1alpha1.New().APIVersion,
+					Kind:       v1alpha1.New().Kind,
+					Metadata: v1alpha1.Metadata{
+						Name:   "withenv1",
+						Labels: v1alpha1.New().Metadata.Labels,
+					},
+					Spec: v1alpha1.Spec{
+						APIServer: "https://localhost",
+						Namespace: "withenv",
+					},
+					Data: map[string]interface{}{
+						"testCase": "object",
+					},
+				},
+				{
+					APIVersion: v1alpha1.New().APIVersion,
+					Kind:       v1alpha1.New().Kind,
+					Metadata: v1alpha1.Metadata{
+						Name:   "withenv2",
+						Labels: v1alpha1.New().Metadata.Labels,
+					},
+					Spec: v1alpha1.Spec{
+						APIServer: "https://localhost",
+						Namespace: "withenv",
+					},
+					Data: map[string]interface{}{
+						"testCase": "object",
+					},
 				},
 			},
 		},
 	}
 
 	for _, test := range cases {
-		data, env, e := ParseEnv(test.baseDir, ParseOpts{})
+		data, envs, e := ParseEnv(test.baseDir, ParseOpts{})
 		if data == nil {
 			assert.NoError(t, e)
 		} else if e != nil {
 			assert.IsType(t, ErrNoEnv{}, e)
 		}
 		assert.Equal(t, test.expected, data)
-		assert.Equal(t, test.env, env)
+		assert.Equal(t, test.envs, envs)
 	}
 }

--- a/pkg/tanka/status.go
+++ b/pkg/tanka/status.go
@@ -16,21 +16,32 @@ type Info struct {
 }
 
 // Status returns information about the particular environment
-func Status(baseDir string, opts Opts) (*Info, error) {
-	r, err := load(baseDir, opts)
-	if err != nil {
-		return nil, err
-	}
-	kube, err := r.connect()
+func Status(path string, opts Opts) ([]*Info, error) {
+	_, envs, err := ParseEnv(path, ParseOpts{JsonnetOpts: opts.JsonnetOpts})
 	if err != nil {
 		return nil, err
 	}
 
-	r.Env.Spec.DiffStrategy = kube.Env.Spec.DiffStrategy
+	infos := make([]*Info, 0)
+	for _, env := range envs {
+		r, err := load(env, opts)
+		if err != nil {
+			return nil, err
+		}
+		kube, err := r.connect()
+		if err != nil {
+			return nil, err
+		}
 
-	return &Info{
-		Env:       r.Env,
-		Resources: r.Resources,
-		Client:    kube.Info(),
-	}, nil
+		r.Env.Spec.DiffStrategy = kube.Env.Spec.DiffStrategy
+
+		info := &Info{
+			Env:       r.Env,
+			Resources: r.Resources,
+			Client:    kube.Info(),
+		}
+
+		infos = append(infos, info)
+	}
+	return infos, nil
 }

--- a/pkg/tanka/testdata/cases/withenvs/main.jsonnet
+++ b/pkg/tanka/testdata/cases/withenvs/main.jsonnet
@@ -1,0 +1,32 @@
+{
+  envs: [
+    {
+      apiVersion: 'tanka.dev/v1alpha1',
+      kind: 'Environment',
+      metadata: {
+        name: 'withenv1',
+      },
+      spec: {
+        apiServer: 'https://localhost',
+        namespace: 'withenv',
+      },
+      data: {
+        testCase: 'object',
+      },
+    },
+    {
+      apiVersion: 'tanka.dev/v1alpha1',
+      kind: 'Environment',
+      metadata: {
+        name: 'withenv2',
+      },
+      spec: {
+        apiServer: 'https://localhost',
+        namespace: 'withenv',
+      },
+      data: {
+        testCase: 'object',
+      },
+    },
+  ],
+}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -1,6 +1,7 @@
 package tanka
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/fatih/color"
@@ -29,44 +30,59 @@ type ApplyOpts struct {
 // Apply parses the environment at the given directory (a `baseDir`) and applies
 // the evaluated jsonnet to the Kubernetes cluster defined in the environments
 // `spec.json`.
-func Apply(baseDir string, opts ApplyOpts) error {
-	l, err := load(baseDir, opts.Opts)
+func Apply(path string, opts ApplyOpts) error {
+	_, envs, err := ParseEnv(path, ParseOpts{JsonnetOpts: opts.JsonnetOpts})
 	if err != nil {
 		return err
 	}
-	kube, err := l.connect()
-	if err != nil {
-		return err
-	}
-	defer kube.Close()
 
-	// show diff
-	diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{Strategy: opts.DiffStrategy})
-	switch {
-	case err != nil:
-		// This is not fatal, the diff is not strictly required
-		fmt.Println("Error diffing:", err)
-	case diff == nil:
-		tmp := "Warning: There are no differences. Your apply may not do anything at all."
-		diff = &tmp
-	}
+	for _, env := range envs {
+		l, err := load(env, opts.Opts)
+		if err != nil {
+			return err
+		}
+		kube, err := l.connect()
+		if err != nil {
+			return err
+		}
+		defer kube.Close()
 
-	// in case of non-fatal error diff may be nil
-	if diff != nil {
-		b := term.Colordiff(*diff)
-		fmt.Print(b.String())
-	}
+		// show diff
+		diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{Strategy: opts.DiffStrategy})
+		switch {
+		case err != nil:
+			// This is not fatal, the diff is not strictly required
+			fmt.Println("Error diffing:", err)
+		case diff == nil:
+			tmp := "Warning: There are no differences. Your apply may not do anything at all."
+			diff = &tmp
+		}
 
-	// prompt for confirmation
-	if opts.AutoApprove {
-	} else if err := confirmPrompt("Applying to", l.Env.Spec.Namespace, kube.Info()); err != nil {
-		return err
-	}
+		// in case of non-fatal error diff may be nil
+		if diff != nil {
+			b := term.Colordiff(*diff)
+			fmt.Print(b.String())
+		}
 
-	return kube.Apply(l.Resources, kubernetes.ApplyOpts{
-		Force:    opts.Force,
-		Validate: opts.Validate,
-	})
+		// prompt for confirmation
+		if opts.AutoApprove {
+		} else if err := confirmPrompt("Applying to", l.Env.Spec.Namespace, kube.Info()); err != nil {
+			if errors.Is(err, term.ErrConfirmationFailed) {
+				fmt.Println(err)
+				continue
+			} else {
+				return err
+			}
+		}
+
+		if err = kube.Apply(l.Resources, kubernetes.ApplyOpts{
+			Force:    opts.Force,
+			Validate: opts.Validate,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // confirmPrompt asks the user for confirmation before apply
@@ -100,21 +116,39 @@ type DiffOpts struct {
 // is returned instead.
 // The cluster information is retrieved from the environments `spec.json`.
 // NOTE: This function requires on `diff(1)`, `kubectl(1)` and perhaps `diffstat(1)`
-func Diff(baseDir string, opts DiffOpts) (*string, error) {
-	l, err := load(baseDir, opts.Opts)
+func Diff(path string, opts DiffOpts) ([]*string, error) {
+	_, envs, err := ParseEnv(path, ParseOpts{JsonnetOpts: opts.JsonnetOpts})
 	if err != nil {
 		return nil, err
 	}
-	kube, err := l.connect()
-	if err != nil {
-		return nil, err
-	}
-	defer kube.Close()
 
-	return kube.Diff(l.Resources, kubernetes.DiffOpts{
-		Summarize: opts.Summarize,
-		Strategy:  opts.Strategy,
-	})
+	diffs := make([]*string, 0)
+	for _, env := range envs {
+		l, err := load(env, opts.Opts)
+		if err != nil {
+			return nil, err
+		}
+		kube, err := l.connect()
+		if err != nil {
+			return nil, err
+		}
+		defer kube.Close()
+
+		diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{
+			Summarize: opts.Summarize,
+			Strategy:  opts.Strategy,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if diff != nil {
+			diffs = append(diffs, diff)
+		}
+	}
+	if len(diffs) == 0 {
+		return nil, nil
+	}
+	return diffs, nil
 }
 
 // DeleteOpts specify additional properties for the Delete operation
@@ -133,53 +167,75 @@ type DeleteOpts struct {
 // Delete parses the environment at the given directory (a `baseDir`) and deletes
 // the generated objects from the Kubernetes cluster defined in the environment's
 // `spec.json`.
-func Delete(baseDir string, opts DeleteOpts) error {
-	l, err := load(baseDir, opts.Opts)
+func Delete(path string, opts DeleteOpts) error {
+	_, envs, err := ParseEnv(path, ParseOpts{JsonnetOpts: opts.JsonnetOpts})
 	if err != nil {
 		return err
 	}
-	kube, err := l.connect()
-	if err != nil {
-		return err
+
+	for _, env := range envs {
+		l, err := load(env, opts.Opts)
+		if err != nil {
+			return err
+		}
+		kube, err := l.connect()
+		if err != nil {
+			return err
+		}
+		defer kube.Close()
+
+		// show diff
+		// static differ will never fail and always return something if input is not nil
+		diff, err := kubernetes.StaticDiffer(false)(l.Resources)
+
+		if err != nil {
+			fmt.Println("Error diffing:", err)
+		}
+
+		// in case of non-fatal error diff may be nil
+		if diff != nil {
+			b := term.Colordiff(*diff)
+			fmt.Print(b.String())
+		}
+
+		// prompt for confirmation
+		if opts.AutoApprove {
+		} else if err := confirmPrompt("Deleting from", l.Env.Spec.Namespace, kube.Info()); err != nil {
+			if errors.Is(err, term.ErrConfirmationFailed) {
+				fmt.Println(err)
+				continue
+			} else {
+				return err
+			}
+		}
+
+		if err = kube.Delete(l.Resources, kubernetes.DeleteOpts{
+			Force:    opts.Force,
+			Validate: opts.Validate,
+		}); err != nil {
+			return err
+		}
 	}
-	defer kube.Close()
-
-	// show diff
-	// static differ will never fail and always return something if input is not nil
-	diff, err := kubernetes.StaticDiffer(false)(l.Resources)
-
-	if err != nil {
-		fmt.Println("Error diffing:", err)
-	}
-
-	// in case of non-fatal error diff may be nil
-	if diff != nil {
-		b := term.Colordiff(*diff)
-		fmt.Print(b.String())
-	}
-
-	// prompt for confirmation
-	if opts.AutoApprove {
-	} else if err := confirmPrompt("Deleting from", l.Env.Spec.Namespace, kube.Info()); err != nil {
-		return err
-	}
-
-	return kube.Delete(l.Resources, kubernetes.DeleteOpts{
-		Force:    opts.Force,
-		Validate: opts.Validate,
-	})
+	return nil
 }
 
 // Show parses the environment at the given directory (a `baseDir`) and returns
 // the list of Kubernetes objects.
 // Tip: use the `String()` function on the returned list to get the familiar yaml stream
-func Show(baseDir string, opts Opts) (manifest.List, error) {
-	l, err := load(baseDir, opts)
+func Show(path string, opts Opts) (manifest.List, error) {
+	_, envs, err := ParseEnv(path, ParseOpts{JsonnetOpts: opts.JsonnetOpts})
 	if err != nil {
 		return nil, err
 	}
-
-	return l.Resources, nil
+	resources := make(manifest.List, 0)
+	for _, env := range envs {
+		l, err := load(env, opts)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, l.Resources...)
+	}
+	return resources, nil
 }
 
 // Eval returns the raw evaluated Jsonnet output (without any transformations)


### PR DESCRIPTION
With inline environments, we are now blocking the ability to handle multiple inline environments in. This PR proposes a solution to that. This also resolves #432.

Example Jsonnet:
```jsonnet
{
  main(namespace, cluster)::
    (import 'main.libsonnet')
    {
      _config+:: {
        namespace: namespace,
        cluster_name: cluster,
      },
    },

  env(cluster, apiServer):: {
    local this = self,
    apiVersion: 'tanka.dev/v1alpha1',
    kind: 'Environment',
    metadata: {
      labels: {
        cluster: cluster,
      },
      name: '%s.%s' % [self.labels.cluster, this.spec.namespace],
    },
    spec: {
      apiServer: apiServer,
      injectLabels: true,
      namespace: 'kube-system',
    },
    data: $.main(self.spec.namespace, cluster),
  },

  envs: {
    dev: $.env('dev-eu', 'https://4.3.2.1'),
    qa: $.env('qa-us', 'https://1.2.3.4'),
  },

  // tk eval -e specs <this file>, get specs without the data
  // tk env should probably do something like this
  specs:: std.mapWithKey(
    function(k, obj)
      obj { data:: {} },
    $.envs
  ),
}
```