### PR TITLE
New URL for stable helm repo

### DIFF
--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -142,7 +142,7 @@ to add it:
 version: 1
 repositories:
   - name: stable
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.helm.sh/stable
 + - name: grafana
 +   url: https://grafana.github.io/helm-charts
 ```

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -162,7 +162,7 @@ func InitChartfile(path string) (*Charts, error) {
 		Version: Version,
 		Repositories: []Repo{{
 			Name: "stable",
-			URL:  "https://kubernetes-charts.storage.googleapis.com",
+			URL:  "https://charts.helm.sh/stable",
 		}},
 		Requires: make(Requirements, 0),
 	}


### PR DESCRIPTION
Using our Helm integration now gives this:

```
WARNING: "kubernetes-charts.storage.googleapis.com" is deprecated for "stable" and will be deleted Nov. 13, 2020.
WARNING: You should switch to "https://charts.helm.sh/stable" via:
WARNING: helm repo add "stable" "https://charts.helm.sh/stable" --force-update
```

This PR does what they say, and prevents the warnings.