### PR TITLE
docs(helm): Fix Grafana Helm Charts URL

### DIFF
--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -144,7 +144,7 @@ repositories:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
 + - name: grafana
-+   url: https://https://grafana.github.io/helm-charts
++   url: https://grafana.github.io/helm-charts
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Fixes the duplicated `https://`. The diff might look weird, because is a diff on a diff block, but is only one line being modified.