### PR TITLE
Adding helm step to docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,18 @@ RUN git clone https://github.com/jsonnet-bundler/jsonnet-bundler &&\
     make static &&\
     mv _output/jb /usr/local/bin/jb
 
+FROM alpine as helm
+RUN apk add --no-cache curl bash openssl
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 &&\
+    chmod 700 get_helm.sh &&\
+    ./get_helm.sh
+
 # assemble final container
 FROM alpine
 RUN apk add --no-cache coreutils diffutils less git openssh-client
 COPY tk /usr/local/bin/tk
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=jb /usr/local/bin/jb /usr/local/bin/jb
+COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/tk"]


### PR DESCRIPTION
:wave: awesome tool! I'm using tanka to do some side projects and I'm setting up some CI/CD pipelines. In the process, I added a helm chart to install redis instances in my k8s cluster and noticed that the tanka docker image doesn't have helm installed. This adds helm to the final built image.

I'm not sure if this is in the scope of this image to be fully honest, or if we want to pin to a specific version of helm inside the image. I'd love some discussion on both of these points if there's any concerns.