### PR TITLE
refactor(api): Evaluators

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-clix/cli"
 
-	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/spec"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
@@ -80,7 +79,7 @@ func setupConfiguration(baseDir string) *v1alpha1.Environment {
 			}
 		// no spec.json is found, try parsing main.jsonnet
 		case spec.ErrNoSpec:
-			_, config, err := tanka.ParseEnv(baseDir, jsonnet.Opts{}, tanka.EnvsOnlyEvaluator)
+			_, config, err := tanka.ParseEnv(baseDir, tanka.ParseOpts{Evaluator: tanka.EnvsOnlyEvaluator})
 			if err != nil {
 				switch err.(type) {
 				case tanka.ErrNoEnv:

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -80,7 +80,7 @@ func setupConfiguration(baseDir string) *v1alpha1.Environment {
 			}
 		// no spec.json is found, try parsing main.jsonnet
 		case spec.ErrNoSpec:
-			config, err := tanka.EvalEnvs(baseDir, jsonnet.Opts{})
+			_, config, err := tanka.ParseEnv(baseDir, jsonnet.Opts{}, tanka.EnvsOnlyEvaluator)
 			if err != nil {
 				switch err.(type) {
 				case tanka.ErrNoEnv:

--- a/pkg/tanka/errors.go
+++ b/pkg/tanka/errors.go
@@ -1,13 +1,9 @@
 package tanka
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
-
-// ErrInvalidEvaluator
-var ErrInvalidEvaluator = errors.New("invalid evaluator type")
 
 // ErrNoEnv means that the given jsonnet has no Environment object
 // This must not be fatal, some operations work without

--- a/pkg/tanka/errors.go
+++ b/pkg/tanka/errors.go
@@ -1,9 +1,13 @@
 package tanka
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrInvalidEvaluator
+var ErrInvalidEvaluator = errors.New("invalid evaluator type")
 
 // ErrNoEnv means that the given jsonnet has no Environment object
 // This must not be fatal, some operations work without

--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -1,0 +1,84 @@
+package tanka
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/grafana/tanka/pkg/jsonnet"
+	"github.com/grafana/tanka/pkg/jsonnet/jpath"
+)
+
+// Evaluator signature for implementing arbitrary Jsonnet evaluators
+type Evaluator func(path string, opts jsonnet.Opts) (string, error)
+
+// DefaultEvaluator evaluates the jsonnet environment at the given file system path
+func DefaultEvaluator(path string, opts jsonnet.Opts) (string, error) {
+	entrypoint, err := jpath.Entrypoint(path)
+	if err != nil {
+		return "", err
+	}
+
+	// evaluate Jsonnet
+	var raw string
+	if opts.EvalPattern != "" {
+		evalScript := fmt.Sprintf("(import '%s').%s", entrypoint, opts.EvalPattern)
+		raw, err = jsonnet.Evaluate(entrypoint, evalScript, opts)
+		if err != nil {
+			return "", errors.Wrap(err, "evaluating jsonnet")
+		}
+	} else {
+		raw, err = jsonnet.EvaluateFile(entrypoint, opts)
+		if err != nil {
+			return "", errors.Wrap(err, "evaluating jsonnet")
+		}
+	}
+	return raw, nil
+}
+
+// EnvsOnlyEvaluator finds the Environment object (without its .data object) at
+// the given file system path intended for use by the `tk env` command
+func EnvsOnlyEvaluator(path string, opts jsonnet.Opts) (string, error) {
+	entrypoint, err := jpath.Entrypoint(path)
+	if err != nil {
+		return "", err
+	}
+
+	// Snippet to find all Environment objects and remove the .data object for faster evaluation
+	noData := `
+local noDataEnv(object) =
+  if std.isObject(object)
+  then
+    if std.objectHas(object, 'apiVersion')
+       && std.objectHas(object, 'kind')
+    then
+      if object.kind == 'Environment'
+      then object { data:: {} }
+      else {}
+    else
+      std.mapWithKey(
+        function(key, obj)
+          noDataEnv(obj),
+        object
+      )
+  else if std.isArray(object)
+  then
+    std.map(
+      function(obj)
+        noDataEnv(obj),
+      object
+    )
+  else {};
+
+noDataEnv(import '%s')
+`
+
+	// evaluate Jsonnet with noData snippet
+	var raw string
+	evalScript := fmt.Sprintf(noData, entrypoint)
+	raw, err = jsonnet.Evaluate(entrypoint, evalScript, opts)
+	if err != nil {
+		return "", errors.Wrap(err, "evaluating jsonnet")
+	}
+	return raw, nil
+}

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -112,7 +112,7 @@ func TestEvalJsonnet(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		data, env, e := eval(test.baseDir, jsonnet.Opts{})
+		data, env, e := ParseEnv(test.baseDir, jsonnet.Opts{}, DefaultEvaluator)
 		if data == nil {
 			assert.NoError(t, e)
 		} else if e != nil {

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -3,7 +3,6 @@ package tanka
 import (
 	"testing"
 
-	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
@@ -112,7 +111,7 @@ func TestEvalJsonnet(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		data, env, e := ParseEnv(test.baseDir, jsonnet.Opts{}, DefaultEvaluator)
+		data, env, e := ParseEnv(test.baseDir, ParseOpts{})
 		if data == nil {
 			assert.NoError(t, e)
 		} else if e != nil {

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/tanka/pkg/process"
 )
 
+type JsonnetOpts = jsonnet.Opts
+
 // Opts specify general, optional properties that apply to all actions
 type Opts struct {
 	JsonnetOpts
@@ -17,4 +19,7 @@ type Opts struct {
 	Filters process.Matchers
 }
 
-type JsonnetOpts = jsonnet.Opts
+type ParseOpts struct {
+	JsonnetOpts
+	Evaluator Evaluator
+}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -184,7 +184,7 @@ func Show(baseDir string, opts Opts) (manifest.List, error) {
 
 // Eval returns the raw evaluated Jsonnet output (without any transformations)
 func Eval(dir string, opts Opts) (raw interface{}, err error) {
-	r, _, err := eval(dir, opts.JsonnetOpts)
+	r, _, err := ParseEnv(dir, opts.JsonnetOpts, DefaultEvaluator)
 	switch err.(type) {
 	case ErrNoEnv, ErrMultipleEnvs:
 		return r, err

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -184,7 +184,7 @@ func Show(baseDir string, opts Opts) (manifest.List, error) {
 
 // Eval returns the raw evaluated Jsonnet output (without any transformations)
 func Eval(dir string, opts Opts) (raw interface{}, err error) {
-	r, _, err := ParseEnv(dir, opts.JsonnetOpts, DefaultEvaluator)
+	r, _, err := ParseEnv(dir, ParseOpts{JsonnetOpts: opts.JsonnetOpts})
 	switch err.(type) {
 	case ErrNoEnv, ErrMultipleEnvs:
 		return r, err


### PR DESCRIPTION
With inline environments, I introduced quite a bit of complexity to the code base. This is a first attempt at trying to
reduce the complexity.

I've observed this pattern in https://github.com/grafana/cortex-tools/blob/master/pkg/rules/parser.go#L27-L37