### PR TITLE
feat: set pruneMark based on path

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -43,8 +43,11 @@ Tanka's behavior can be customized per Environment using a file called `spec.jso
     "diffStrategy": "[native, subset]" | default = "auto",
 
     // Whether to add a "tanka.dev/environment" label to each created resource.
+    "injectLabels": <boolean> | default = false,
+
+    // Whether to add a "tanka.dev/prune-mark" label to each created resource.
     // Required for garbage collection ("tk prune").
-    "injectLabels": <boolean> | default = false
+    "pruneMark": <boolean> | default = false
   }
 }
 ```

--- a/docs/docs/garbage-collection.md
+++ b/docs/docs/garbage-collection.md
@@ -11,9 +11,9 @@ from Jsonnet.
 
 > **Note:** This feature is **experimental**. Please report problems at https://github.com/grafana/tanka/issues.
 
-To accomplish this, it appends the `tanka.dev/environment: <name>` label to each created
-resource. This is used to identify those which are missing from the local state in the
-future.
+To accomplish this, it appends the `tanka.dev/prune-mark: sha256(relative_path)`
+label to each created resource. This is used to identify those which are missing
+from the local state in the future.
 
 Because the label causes a `diff` for every single object in your cluster and
 not everybody wants this, it needs to be explicitly enabled. To do so, add the
@@ -22,7 +22,7 @@ following field to your `spec.json`:
 ```diff
 {
   "spec": {
-+    "injectLabels": true,
++    "pruneMark": true,
   }
 }
 ```

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -11,6 +11,7 @@ import (
 const (
 	MetadataPrefix   = "tanka.dev"
 	LabelEnvironment = MetadataPrefix + "/environment"
+	PruneMark        = MetadataPrefix + "/prune-mark"
 )
 
 // Process converts the raw Jsonnet evaluation result (JSON tree) into a flat
@@ -61,6 +62,9 @@ func Label(list manifest.List, cfg v1alpha1.Environment) manifest.List {
 		// inject tanka.dev/environment label
 		if cfg.Spec.InjectLabels {
 			m.Metadata().Labels()[LabelEnvironment] = cfg.Metadata.NameLabel()
+		}
+		if cfg.Spec.PruneMark {
+			m.Metadata().Labels()[PruneMark] = cfg.Metadata.PathHash()
 		}
 		list[i] = m
 	}

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -34,6 +34,14 @@ func TestProcess(t *testing.T) {
 			},
 		},
 		{
+			name: "pruneMark",
+			deep: testDataRegular().Deep,
+			flat: mapToList(testDataRegular().Flat),
+			spec: v1alpha1.Spec{
+				PruneMark: true,
+			},
+		},
+		{
 			name: "targets",
 			deep: testDataDeep().Deep,
 			flat: manifest.List{
@@ -116,6 +124,13 @@ func TestProcess(t *testing.T) {
 			if config.Spec.InjectLabels {
 				for i, m := range c.flat {
 					m.Metadata().Labels()[LabelEnvironment] = config.Metadata.NameLabel()
+					c.flat[i] = m
+				}
+			}
+
+			if config.Spec.PruneMark {
+				for i, m := range c.flat {
+					m.Metadata().Labels()[PruneMark] = config.Metadata.PathHash()
 					c.flat[i] = m
 				}
 			}

--- a/pkg/spec/depreciations_test.go
+++ b/pkg/spec/depreciations_test.go
@@ -26,7 +26,7 @@ func TestDeprecated(t *testing.T) {
 }
 `)
 
-	got, err := Parse(data)
+	got, err := Parse(data, "test")
 	require.Equal(t, ErrDeprecated{
 		{old: "server", new: "spec.apiServer"},
 		{old: "team", new: "metadata.labels.team"},

--- a/pkg/spec/v1alpha1/environment.go
+++ b/pkg/spec/v1alpha1/environment.go
@@ -1,6 +1,10 @@
 package v1alpha1
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
 
 // New creates a new Environment object with internal values already set
 func New() *Environment {
@@ -49,12 +53,19 @@ func (m Metadata) NameLabel() string {
 	return strings.Replace(m.Name, "/", ".", -1)
 }
 
+func (m Metadata) PathHash() string {
+	hash := sha256.New()
+	s := hash.Sum([]byte(m.Path))
+	return hex.EncodeToString(s)
+}
+
 // Spec defines Kubernetes properties
 type Spec struct {
 	APIServer        string           `json:"apiServer"`
 	Namespace        string           `json:"namespace"`
 	DiffStrategy     string           `json:"diffStrategy,omitempty"`
 	InjectLabels     bool             `json:"injectLabels,omitempty"`
+	PruneMark        bool             `json:"pruneMark,omitempty"`
 	ResourceDefaults ResourceDefaults `json:"resourceDefaults"`
 	ExpectVersions   ExpectVersions   `json:"expectVersions"`
 }

--- a/pkg/spec/v1alpha1/environment.go
+++ b/pkg/spec/v1alpha1/environment.go
@@ -30,6 +30,7 @@ type Environment struct {
 // Metadata is meant for humans and not parsed
 type Metadata struct {
 	Name   string            `json:"name,omitempty"`
+	Path   string            `json:"path,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -44,6 +44,7 @@ func TestEvalJsonnet(t *testing.T) {
 				Kind:       v1alpha1.New().Kind,
 				Metadata: v1alpha1.Metadata{
 					Name:   "cases/withspecjson",
+					Path:   "cases/withspecjson",
 					Labels: v1alpha1.New().Metadata.Labels,
 				},
 				Spec: v1alpha1.Spec{
@@ -65,6 +66,7 @@ func TestEvalJsonnet(t *testing.T) {
 				Kind:       v1alpha1.New().Kind,
 				Metadata: v1alpha1.Metadata{
 					Name:   "cases/withspecjson",
+					Path:   "cases/withspecjson",
 					Labels: v1alpha1.New().Metadata.Labels,
 				},
 				Spec: v1alpha1.Spec{
@@ -97,6 +99,7 @@ func TestEvalJsonnet(t *testing.T) {
 				Kind:       v1alpha1.New().Kind,
 				Metadata: v1alpha1.Metadata{
 					Name:   "withenv",
+					Path:   "cases/withenv/main.jsonnet",
 					Labels: v1alpha1.New().Metadata.Labels,
 				},
 				Spec: v1alpha1.Spec{

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -18,7 +18,7 @@ type PruneOpts struct {
 }
 
 // Prune deletes all resources from the cluster, that are no longer present in
-// Jsonnet. It uses the `tanka.dev/environment` label to identify those.
+// Jsonnet. It uses the `tanka.dev/prune-mark` label to identify those.
 func Prune(baseDir string, opts PruneOpts) error {
 	// parse jsonnet, init k8s client
 	p, err := load(baseDir, opts.Opts)


### PR DESCRIPTION
The current pruning logic uses the metadata.Name, under the assumption this is unique. We forced it to be unique by
setting the name equal to the path. This has caused a few headaches for newcomers.

This PR proposes to use a hash of the path and add it as a sha256 prune mark. Except for consistency, this also resolves
the issue that labels are limited to 63 characters while paths can be much longer. This can optionally be enabled by
setting `spec.pruneMark` and leaves the original `spec.injectLabels` untouched. What's the catch? This label can't be
used anymore for pruning as the logic to support it would be arguably more complex.

Surplus, this PR also sets metadata.Path at runtime, the path relative to the root. This removes the aformentioned
assumption that name equals path and also shows up in `tk env list --json`, which can in turn be used by other tools
that want to perform bulk actions on Tanka environments.