### PR TITLE
chore(docker): fix Helm install on armv7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,7 @@ RUN git clone https://github.com/jsonnet-bundler/jsonnet-bundler &&\
     mv _output/jb /usr/local/bin/jb
 
 FROM alpine as helm
-RUN apk add --no-cache curl bash openssl
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 &&\
-    chmod 700 get_helm.sh &&\
-    ./get_helm.sh
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing helm
 
 # assemble final container
 FROM alpine
@@ -25,6 +22,6 @@ RUN apk add --no-cache coreutils diffutils less git openssh-client
 COPY tk /usr/local/bin/tk
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=jb /usr/local/bin/jb /usr/local/bin/jb
-COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=helm /usr/bin/helm /usr/local/bin/helm
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/tk"]


### PR DESCRIPTION
While the Helm install script handles armv7 well, our CI actually uses a
armv8 CPU running in armv7 mode when building the image, thus reporting
armv8l as the cpu model, which is not handles by the Helm script.

A simpler way of getting the correct binary is to use the Alpine Linux
package from the edge/testing repository, which appears to be very up to
date: https://pkgs.alpinelinux.org/package/edge/testing/aarch64/helm

Fixes #438 