### PR TITLE
refactor(api): use EvalScript on JsonnetOpts

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -27,7 +27,7 @@ func evalCmd() *cli.Command {
 		jsonnetOpts := tanka.Opts{
 			JsonnetOpts: getJsonnetOpts(),
 		}
-		jsonnetOpts.EvalPattern = *evalPattern
+		jsonnetOpts.EvalScript = strings.Join([]string{"(import '%s')", *evalPattern}, ".")
 		raw, err := tanka.Eval(args[0], jsonnetOpts)
 
 		if raw == nil && err != nil {

--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -27,7 +27,7 @@ func evalCmd() *cli.Command {
 		jsonnetOpts := tanka.Opts{
 			JsonnetOpts: getJsonnetOpts(),
 		}
-		jsonnetOpts.EvalScript = strings.Join([]string{"(import '%s')", *evalPattern}, ".")
+		jsonnetOpts.EvalScript = "(import '%s')." + *evalPattern
 		raw, err := tanka.Eval(args[0], jsonnetOpts)
 
 		if raw == nil && err != nil {

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -79,7 +79,7 @@ func setupConfiguration(baseDir string) *v1alpha1.Environment {
 			}
 		// no spec.json is found, try parsing main.jsonnet
 		case spec.ErrNoSpec:
-			_, config, err := tanka.ParseEnv(baseDir, tanka.ParseOpts{Evaluator: tanka.EnvsOnlyEvaluator})
+			_, config, err := tanka.ParseEnv(baseDir, tanka.JsonnetOpts{EvalScript: tanka.EnvsOnlyEvalScript})
 			if err != nil {
 				switch err.(type) {
 				case tanka.ErrNoEnv:

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -29,7 +29,7 @@ type Opts struct {
 	ExtCode     InjectedCode
 	TLACode     InjectedCode
 	ImportPaths []string
-	EvalPattern string
+	EvalScript  string
 }
 
 // MakeVM returns a Jsonnet VM with some extensions of Tanka, including:

--- a/pkg/tanka/parse_test.go
+++ b/pkg/tanka/parse_test.go
@@ -114,7 +114,7 @@ func TestEvalJsonnet(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		data, env, e := ParseEnv(test.baseDir, ParseOpts{})
+		data, env, e := ParseEnv(test.baseDir, JsonnetOpts{})
 		if data == nil {
 			assert.NoError(t, e)
 		} else if e != nil {

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -18,8 +18,3 @@ type Opts struct {
 	// Filters are used to optionally select a subset of the resources
 	Filters process.Matchers
 }
-
-type ParseOpts struct {
-	JsonnetOpts
-	Evaluator Evaluator
-}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -184,7 +184,7 @@ func Show(baseDir string, opts Opts) (manifest.List, error) {
 
 // Eval returns the raw evaluated Jsonnet output (without any transformations)
 func Eval(dir string, opts Opts) (raw interface{}, err error) {
-	r, _, err := ParseEnv(dir, ParseOpts{JsonnetOpts: opts.JsonnetOpts})
+	r, _, err := ParseEnv(dir, opts.JsonnetOpts)
 	switch err.(type) {
 	case ErrNoEnv, ErrMultipleEnvs:
 		return r, err


### PR DESCRIPTION
Another iteration on evaluators. I hope this reduces code complexity by some degree, instead of passing functions along
through `ParseOpts`, this now passes an `EvalScript` along. It should make the API more flexible as arbitrary jsonnet
can be injected before evaluation.

Note: This (re)moves the `EvalPattern` option as it can now be called by the CLI function that uses it.

Review tip: hide whitespace changes.