### PR TITLE
fix: EvalScript issues

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -27,7 +27,9 @@ func evalCmd() *cli.Command {
 		jsonnetOpts := tanka.Opts{
 			JsonnetOpts: getJsonnetOpts(),
 		}
-		jsonnetOpts.EvalScript = "(import '%s')." + *evalPattern
+		if *evalPattern != "" {
+			jsonnetOpts.EvalScript = "(import '%s')." + *evalPattern
+		}
 		raw, err := tanka.Eval(args[0], jsonnetOpts)
 
 		if raw == nil && err != nil {

--- a/pkg/tanka/parse.go
+++ b/pkg/tanka/parse.go
@@ -152,11 +152,6 @@ func ParseEnv(path string, opts JsonnetOpts) (interface{}, *v1alpha1.Environment
 		return nil, nil, errors.Wrap(err, "unmarshalling data")
 	}
 
-	if opts.EvalScript != "" {
-		// EvalScript has no affinity with an environment, behave as jsonnet interpreter
-		return data, nil, nil
-	}
-
 	extractedEnvs, err := extractEnvironments(data)
 	if _, ok := err.(process.ErrorPrimitiveReached); ok {
 		if specEnv == nil {


### PR DESCRIPTION
ref: #457

Figured that EvalScript might as well be used in combination with Environments. Removing this early returns should allow that.

Also, it should only be set if evalPattern is set in the `tk eval`.