### PR TITLE
fix(api): write relative path to manifest.json

### DIFF
--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -99,9 +99,10 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 			}
 
 			// Create all subfolders in path
-			path := filepath.Join(to, name+"."+opts.Extension)
+			relpath := name + "." + opts.Extension
+			path := filepath.Join(to, relpath)
 
-			fileToEnv[path] = env.Metadata.Namespace
+			fileToEnv[relpath] = env.Metadata.Namespace
 
 			// Abort if already exists
 			if exists, err := fileExists(path); err != nil {


### PR DESCRIPTION
The export wrote the absolute path to the manifest.json, that is not portable. Writing the relative path intead.