### PR TITLE
docs(helm): add installing from chartfile section

### DIFF
--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -155,6 +155,12 @@ repositories:
 +   url: https://grafana.github.io/helm-charts
 ```
 
+**Install charts from chartfile:** To install charts from an existing chartfile, use the following:
+
+```bash
+$ tk tool charts vendor
+```
+
 ## Troubleshooting
 
 ### Helm executable missing


### PR DESCRIPTION
I had some trouble figuring out how to use the Charttool to install charts from an existing `chartfile.yaml`, so I thought it would be nice to add a section explicitly showing the `tk tool charts vendor` call.