### PR TITLE
feat(api): Peek 

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"text/tabwriter"
@@ -78,7 +77,11 @@ func envSetCmd() *cli.Command {
 			tmp.Spec.APIServer = server
 		}
 
-		cfg := setupConfiguration(path)
+		cfg, err := tanka.Peek(path, tanka.JsonnetOpts{})
+		if err != nil {
+			return err
+		}
+
 		if tmp.Spec.APIServer != "" && tmp.Spec.APIServer != cfg.Spec.APIServer {
 			fmt.Printf("updated spec.apiServer (`%s -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)
 			cfg.Spec.APIServer = tmp.Spec.APIServer
@@ -275,15 +278,4 @@ func envListCmd() *cli.Command {
 		return nil
 	}
 	return cmd
-}
-
-func setupConfiguration(baseDir string) *v1alpha1.Environment {
-	env, err := tanka.Load(baseDir, tanka.Opts{
-		JsonnetOpts: tanka.JsonnetOpts{EvalScript: tanka.EnvsOnlyEvalScript},
-	})
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	return env.Env
 }

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -75,12 +75,10 @@ func exportCmd() *cli.Command {
 			}
 
 			// validate environment
-			jsonnetOpts := opts.ParseParallelOpts.JsonnetOpts
-			jsonnetOpts.EvalScript = tanka.EnvsOnlyEvalScript
-			_, err := tanka.Load(path, tanka.Opts{JsonnetOpts: jsonnetOpts})
-			if err != nil {
+			if _, err := tanka.Peek(path, opts.ParseParallelOpts.JsonnetOpts); err != nil {
 				return err
 			}
+
 			paths = append(paths, path)
 		}
 

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -69,6 +69,11 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 	return env, nil
 }
 
+func (i *InlineLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
+	opts.EvalScript = EnvsOnlyEvalScript
+	return i.Load(path, opts)
+}
+
 // extractEnvs filters out any Environment manifests
 func extractEnvs(data interface{}) (manifest.List, error) {
 	// Scan for everything that looks like a Kubernetes object

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -17,7 +17,7 @@ import (
 // Load loads the Environment at `path`. It automatically detects whether to
 // load inline or statically
 func Load(path string, opts Opts) (*LoadResult, error) {
-	loader, err := detectLoader(path)
+	loader, err := DetectLoader(path)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func Load(path string, opts Opts) (*LoadResult, error) {
 // Peek loads the metadata of the environment at path. To get resources as well,
 // use Load
 func Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	loader, err := detectLoader(path)
+	loader, err := DetectLoader(path)
 	if err != nil {
 		return nil, err
 	}
@@ -50,9 +50,9 @@ func Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
 	return loader.Peek(path, opts)
 }
 
-// detectLoader detects whether the environment is inline or static and picks
+// DetectLoader detects whether the environment is inline or static and picks
 // the approriate loader
-func detectLoader(path string) (Loader, error) {
+func DetectLoader(path string) (Loader, error) {
 	_, base, err := jpath.Dirs(path)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -44,6 +44,22 @@ func Load(path string, opts Opts) (*LoadResult, error) {
 	return &LoadResult{Env: env, Resources: processed}, nil
 }
 
+// Peek loads the metadata of the environment at path. To get resources as well,
+// use Load
+func Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
+	_, base, err := jpath.Dirs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	loader, err := detectLoader(base)
+	if err != nil {
+		return nil, err
+	}
+
+	return loader.Peek(path, opts)
+}
+
 // detectLoader detects whether the environment is inline or static and picks
 // the approriate loader
 func detectLoader(base string) (Loader, error) {
@@ -60,7 +76,11 @@ func detectLoader(base string) (Loader, error) {
 
 // Loader is an abstraction over the process of loading Environments
 type Loader interface {
+	// Load the environment with path
 	Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error)
+
+	// Peek only loads metadata and omits the actual resources
+	Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error)
 }
 
 type LoadResult struct {

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -17,12 +17,7 @@ import (
 // Load loads the Environment at `path`. It automatically detects whether to
 // load inline or statically
 func Load(path string, opts Opts) (*LoadResult, error) {
-	_, base, err := jpath.Dirs(path)
-	if err != nil {
-		return nil, err
-	}
-
-	loader, err := detectLoader(base)
+	loader, err := detectLoader(path)
 	if err != nil {
 		return nil, err
 	}
@@ -47,12 +42,7 @@ func Load(path string, opts Opts) (*LoadResult, error) {
 // Peek loads the metadata of the environment at path. To get resources as well,
 // use Load
 func Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	_, base, err := jpath.Dirs(path)
-	if err != nil {
-		return nil, err
-	}
-
-	loader, err := detectLoader(base)
+	loader, err := detectLoader(path)
 	if err != nil {
 		return nil, err
 	}
@@ -62,9 +52,14 @@ func Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
 
 // detectLoader detects whether the environment is inline or static and picks
 // the approriate loader
-func detectLoader(base string) (Loader, error) {
+func detectLoader(path string) (Loader, error) {
+	_, base, err := jpath.Dirs(path)
+	if err != nil {
+		return nil, err
+	}
+
 	// check if spec.json exists
-	_, err := os.Stat(filepath.Join(base, spec.Specfile))
+	_, err = os.Stat(filepath.Join(base, spec.Specfile))
 	if os.IsNotExist(err) {
 		return &InlineLoader{}, nil
 	} else if err != nil {

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -15,12 +15,7 @@ import (
 type StaticLoader struct{}
 
 func (s StaticLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	root, base, err := jpath.Dirs(path)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := parseStaticSpec(root, base)
+	config, err := Peek(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -31,6 +26,20 @@ func (s StaticLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environment
 	}
 
 	if err := json.Unmarshal([]byte(data), &config.Data); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func (s StaticLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
+	root, base, err := jpath.Dirs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := parseStaticSpec(root, base)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Introduces a new functionality called Peek with behaves like Load, but
only loads metadata.

Because this is much faster than full loading, this can be used at
places where only metadata is required.

This formalizes behavior that was previously possible by passing
`EnvsOnlyEvalScript`. The benefit of having this as an interface
implementation is that it can make better use of underlying details,
such as that the static loader does need to start a costly Jsonnet VM
for only parsing `spec.json`