### PR TITLE
feat(api): Environment discovery 

### DIFF
--- a/cmd/tk/args.go
+++ b/cmd/tk/args.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-clix/cli"
 	"github.com/posener/complete"
 
+	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/tanka"
 )
 
@@ -18,14 +19,20 @@ var workflowArgs = cli.Args{
 			return nil
 		}
 
-		dirs, err := tanka.FindBaseDirs(pwd)
+		root, err := jpath.FindRoot(pwd)
+		if err != nil {
+			return nil
+		}
+
+		envs, err := tanka.ListEnvs(pwd, tanka.ListOpts{})
 		if err != nil {
 			return nil
 		}
 
 		var reldirs []string
-		for _, dir := range dirs {
-			reldir, err := filepath.Rel(pwd, dir)
+		for _, env := range envs {
+			path := filepath.Join(root, env.Metadata.Namespace) // namespace == dir on disk
+			reldir, err := filepath.Rel(pwd, path)
 			if err == nil {
 				reldirs = append(reldirs, reldir)
 			}

--- a/cmd/tk/args.go
+++ b/cmd/tk/args.go
@@ -31,7 +31,7 @@ var workflowArgs = cli.Args{
 
 		var reldirs []string
 		for _, env := range envs {
-			path := filepath.Join(root, env.Metadata.Namespace) // namespace == dir on disk
+			path := filepath.Join(root, env.Metadata.Namespace) // namespace == path on disk
 			reldir, err := filepath.Rel(pwd, path)
 			if err == nil {
 				reldirs = append(reldirs, reldir)

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -248,7 +248,7 @@ func envListCmd() *cli.Command {
 			return fmt.Errorf("Not a directory: %s", dir)
 		}
 
-		envs, err := tanka.FindEnvironments(dir, getLabelSelector())
+		envs, err := tanka.ListEnvs(dir, tanka.ListOpts{Selector: getLabelSelector()})
 		if err != nil {
 			return err
 		}

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -63,7 +63,7 @@ func exportCmd() *cli.Command {
 				}
 
 				// get absolute path to Environment
-				envs, err := tanka.FindEnvironments(path, opts.ParseParallelOpts.Selector)
+				envs, err := tanka.ListEnvs(path, tanka.ListOpts{Selector: opts.ParseParallelOpts.Selector})
 				if err != nil {
 					return err
 				}

--- a/pkg/tanka/list.go
+++ b/pkg/tanka/list.go
@@ -1,0 +1,101 @@
+package tanka
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/grafana/tanka/pkg/jsonnet"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ListOpts are optional arguments for ListEnvs
+type ListOpts struct {
+	Selector labels.Selector
+}
+
+// ListEnvs returns metadata of all environments recursively found in 'dir'.
+// Each directory is tested and included if it is a valid environment, either
+// static or inline. If a directory is a valid environment, its subdirectories
+// are not checked.
+func ListEnvs(dir string, opts ListOpts) ([]*v1alpha1.Environment, error) {
+	// list all environments at dir
+	envs, err := list(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// optionally filter
+	if opts.Selector == nil || opts.Selector.Empty() {
+		return envs, nil
+	}
+
+	filtered := make([]*v1alpha1.Environment, 0, len(envs))
+	for _, e := range envs {
+		if !opts.Selector.Matches(e.Metadata) {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+
+	return filtered, nil
+}
+
+// list implements the actual functionality described at 'ListEnvs'
+func list(dir string) ([]*v1alpha1.Environment, error) {
+	// list directory, also checks if dir
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// try if this is an env
+	env, err := Peek(dir, jsonnet.Opts{})
+	if err == nil {
+		// it is one. don't search deeper
+		return []*v1alpha1.Environment{env}, nil
+	}
+
+	// it's not one. Maybe subdirectories are?
+	ch := make(chan listOut)
+	routines := 0
+
+	// recursively list in parallel
+	for _, fi := range files {
+		if !fi.IsDir() {
+			continue
+		}
+
+		routines++
+		go listShim(filepath.Join(dir, fi.Name()), ch)
+	}
+
+	// collect parallel results
+	var lastErr error
+	var envs []*v1alpha1.Environment
+
+	for i := 0; i < routines; i++ {
+		out := <-ch
+		if out.err != nil {
+			lastErr = out.err
+		}
+
+		envs = append(envs, out.envs...)
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	return envs, nil
+}
+
+type listOut struct {
+	envs []*v1alpha1.Environment
+	err  error
+}
+
+func listShim(dir string, ch chan listOut) {
+	envs, err := list(dir)
+	ch <- listOut{envs: envs, err: err}
+}


### PR DESCRIPTION
Introduces `tanka.ListEnvs` for discovering all nested environments starting from any given directory on the filesystem.

This is now implemented by concurrently testing each subfolder of the given directory as to whether it is a valid environment. The recursion stops if any directory is a valid environment.

Switches all occurences of `FindBaseDirs` to the more performant `ListEnvs` algorithm.

A quick `tk env list` on our config repo gave the following:

```
Before: tk env list  25.40s user 0.69s system 946% cpu 2.757 total
After:  tk env list  1.61s  user 0.37s system 811% cpu 0.243 total
```

Needs rebasing on #467 once merged