### PR TITLE
feat(cli): Add --with-prune option for diff command

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -111,6 +111,7 @@ func diffCmd() *cli.Command {
 	var opts tanka.DiffOpts
 	cmd.Flags().StringVar(&opts.Strategy, "diff-strategy", "", "force the diff-strategy to use. Automatically chosen if not set.")
 	cmd.Flags().BoolVarP(&opts.Summarize, "summarize", "s", false, "print summary of the differences, not the actual contents")
+	cmd.Flags().BoolVarP(&opts.WithPrune, "with-prune", "p", false, "include objects deleted from the configuration in the differences")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())

--- a/pkg/kubernetes/apply.go
+++ b/pkg/kubernetes/apply.go
@@ -91,10 +91,14 @@ See https://tanka.dev/garbage-collection for more details.`)
 func (k *Kubernetes) uids(state manifest.List) (map[string]bool, error) {
 	uids := make(map[string]bool)
 
-	live, err := k.ctl.GetByState(state, k.ctl.GetByStateOpts{
-		ignoreNotFound: true,
+	live, err := k.ctl.GetByState(state, client.GetByStateOpts{
+		IgnoreNotFound: true,
 	})
 	if err != nil {
+		if _, ok := err.(client.ErrorNothingReturned); ok {
+			// return empty map of uids when kubectl returns nothing
+			return uids, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/kubernetes/apply.go
+++ b/pkg/kubernetes/apply.go
@@ -94,11 +94,10 @@ func (k *Kubernetes) uids(state manifest.List) (map[string]bool, error) {
 	live, err := k.ctl.GetByState(state, client.GetByStateOpts{
 		IgnoreNotFound: true,
 	})
-	if err != nil {
-		if _, ok := err.(client.ErrorNothingReturned); ok {
-			// return empty map of uids when kubectl returns nothing
-			return uids, nil
-		}
+	if _, ok := err.(client.ErrorNothingReturned); ok {
+		// return empty map of uids when kubectl returns nothing
+		return uids, nil
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubernetes/apply.go
+++ b/pkg/kubernetes/apply.go
@@ -91,7 +91,9 @@ See https://tanka.dev/garbage-collection for more details.`)
 func (k *Kubernetes) uids(state manifest.List) (map[string]bool, error) {
 	uids := make(map[string]bool)
 
-	live, err := k.ctl.GetByState(state)
+	live, err := k.ctl.GetByState(state, k.ctl.GetByStateOpts{
+		ignoreNotFound: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -52,9 +52,10 @@ type ApplyOpts struct {
 // Currently not different from ApplyOpts, but may be required in the future
 type DeleteOpts ApplyOpts
 
-// GetByStateOpts allow to specify additional parameter for GetByState function
-// Currently ignoreNotFound is only useful for GetByState() so we have GetByStateOpts
-// instead of more generic GetOpts for all get operations
+// GetByStateOpts allow to specify additional parameters for GetByState function
+// Currently there is just ignoreNotFound parameter which is only useful for
+// GetByState() so we only have GetByStateOpts instead of more generic GetOpts
+// for all get operations
 type GetByStateOpts struct {
 	// ignoreNotFound allows to ignore errors caused by missing objects
 	IgnoreNotFound bool

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -9,7 +9,7 @@ type Client interface {
 	// Get the specified object(s) from the cluster
 	Get(namespace, kind, name string) (manifest.Manifest, error)
 	GetByLabels(namespace, kind string, labels map[string]string) (manifest.List, error)
-	GetByState(data manifest.List) (manifest.List, error)
+	GetByState(data manifest.List, opts GetByStateOpts) (manifest.List, error)
 
 	// Apply the configuration to the cluster. `data` must contain a plaintext
 	// format that is `kubectl-apply(1)` compatible
@@ -51,3 +51,11 @@ type ApplyOpts struct {
 // DeleteOpts allow to specify additional parameters for delete operations
 // Currently not different from ApplyOpts, but may be required in the future
 type DeleteOpts ApplyOpts
+
+// GetByStateOpts allow to specify additional parameter for GetByState function
+// Currently ignoreNotFound is only useful for GetByState() so we have GetByStateOpts
+// instead of more generic GetOpts for all get operations
+type GetByStateOpts struct {
+	// ignoreNotFound allows to ignore errors caused by missing objects
+	IgnoreNotFound bool
+}

--- a/pkg/kubernetes/client/errors.go
+++ b/pkg/kubernetes/client/errors.go
@@ -34,3 +34,13 @@ type ErrorNoCluster string
 func (e ErrorNoCluster) Error() string {
 	return fmt.Sprintf("no cluster that matches the apiServer `%s` was found. Please check your $KUBECONFIG", string(e))
 }
+
+// ErrorNothingReturned means that there was no output returned
+type ErrorNothingReturned struct {
+	errOut string
+}
+
+func (e ErrorNothingReturned) Error() string {
+	// TODO: this is probably wrong
+	return fmt.Sprintf("Kubectl returned no output. Stderr was: `%s`", string(e.errOut))
+}

--- a/pkg/kubernetes/client/errors.go
+++ b/pkg/kubernetes/client/errors.go
@@ -36,11 +36,8 @@ func (e ErrorNoCluster) Error() string {
 }
 
 // ErrorNothingReturned means that there was no output returned
-type ErrorNothingReturned struct {
-	errOut string
-}
+type ErrorNothingReturned struct {}
 
 func (e ErrorNothingReturned) Error() string {
-	// TODO: this is probably wrong
-	return fmt.Sprintf("Kubectl returned no output. Stderr was: `%s`", string(e.errOut))
+	return "kubectl returned no output"
 }

--- a/pkg/kubernetes/client/errors.go
+++ b/pkg/kubernetes/client/errors.go
@@ -36,7 +36,7 @@ func (e ErrorNoCluster) Error() string {
 }
 
 // ErrorNothingReturned means that there was no output returned
-type ErrorNothingReturned struct {}
+type ErrorNothingReturned struct{}
 
 func (e ErrorNothingReturned) Error() string {
 	return "kubectl returned no output"

--- a/pkg/kubernetes/client/get.go
+++ b/pkg/kubernetes/client/get.go
@@ -44,7 +44,7 @@ func (k Kubectl) GetByState(data manifest.List) (manifest.List, error) {
 		// 	the side effect of adding it here is that prune no longer
 		//	fails when there are new k8s objects in jsonnet
 		ignoreNotFound: true,
-		stdin: data.String(),
+		stdin:          data.String(),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/kubernetes/client/get.go
+++ b/pkg/kubernetes/client/get.go
@@ -36,7 +36,7 @@ func (k Kubectl) GetByLabels(namespace, kind string, labels map[string]string) (
 }
 
 // GetByState returns the full object, including runtime fields for each
-// resource in the state.
+// resource in the state
 func (k Kubectl) GetByState(data manifest.List, opts GetByStateOpts) (manifest.List, error) {
 	list, err := k.get("", "", []string{"-f", "-"}, getOpts{
 		ignoreNotFound: opts.IgnoreNotFound,

--- a/pkg/kubernetes/client/get.go
+++ b/pkg/kubernetes/client/get.go
@@ -35,16 +35,11 @@ func (k Kubectl) GetByLabels(namespace, kind string, labels map[string]string) (
 	return unwrapList(list)
 }
 
-// TODO: this feels wrong
-type GetByStateOpts struct {
-	ignoreNotFound bool
-}
-
 // GetByState returns the full object, including runtime fields for each
-// resource in the state. optIgnoreNotFound passes --ignore-not-found option to kubectl
-func (k Kubectl) GetByState(data manifest.List, opts getByStateOpts) (manifest.List, error) {
+// resource in the state.
+func (k Kubectl) GetByState(data manifest.List, opts GetByStateOpts) (manifest.List, error) {
 	list, err := k.get("", "", []string{"-f", "-"}, getOpts{
-		ignoreNotFound: opts.ignoreNotFound,
+		ignoreNotFound: opts.IgnoreNotFound,
 		stdin:          data.String(),
 	})
 	if err != nil {
@@ -96,8 +91,9 @@ func (k Kubectl) get(namespace, kind string, selector []string, opts getOpts) (m
 	}
 
 	// return error if nothing was returned
+	// because parsing empty output as json would cause errors
 	if sout.Len() == 0 {
-		return nil, ErrorNothingReturned{serr.String()}
+		return nil, ErrorNothingReturned{}
 	}
 
 	// parse result

--- a/pkg/kubernetes/client/get.go
+++ b/pkg/kubernetes/client/get.go
@@ -56,8 +56,9 @@ type getOpts struct {
 func (k Kubectl) get(namespace, kind string, selector []string, opts getOpts) (manifest.Manifest, error) {
 	// build cli flags and args
 	argv := []string{
-		"-o", "json",
+		"-o", "json", "--ignore-not-found",
 	}
+	fmt.Println("FIXME: ignoring not found objects")
 
 	if opts.allNamespaces {
 		argv = append(argv, "--all-namespaces")

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -68,7 +68,7 @@ Please upgrade kubectl to at least version 1.18.1.`)
 	d, err := multiDiff{
 		{differ: liveDiff, state: live},
 		{differ: staticDiffAllCreated, state: soon},
-		{differ: statisDiffAllDeleted, state: orphaned},
+		{differ: staticDiffAllDeleted, state: orphaned},
 	}.diff()
 
 	switch {

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -51,10 +51,23 @@ Please upgrade kubectl to at least version 1.18.1.`)
 	// reports all resources as new
 	staticDiff := StaticDiffer(true)
 
+	// reports all resources as deleted (TODO: check)
+	pruneDiff := StaticDiffer(false)
+
+	orphaned := manifest.List{}
+	if opts.WithPrune {
+		// find orphaned resources
+		orphaned, err = k.Orphaned(state)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// run the diff
 	d, err := multiDiff{
 		{differ: liveDiff, state: live},
 		{differ: staticDiff, state: soon},
+		{differ: pruneDiff, state: orphaned},
 	}.diff()
 
 	switch {

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -48,12 +48,13 @@ Please upgrade kubectl to at least version 1.18.1.`)
 		return nil, err
 	}
 
-	// reports all resources as new
-	staticDiff := StaticDiffer(true)
+	// reports all resources as created
+	staticDiffAllCreated := StaticDiffer(true)
 
-	// reports all resources as deleted (TODO: check)
-	pruneDiff := StaticDiffer(false)
+	// reports all resources as deleted
+	staticDiffAllDeleted := StaticDiffer(false)
 
+	// include orphaned resources in the diff if it was requested by the user
 	orphaned := manifest.List{}
 	if opts.WithPrune {
 		// find orphaned resources
@@ -66,8 +67,8 @@ Please upgrade kubectl to at least version 1.18.1.`)
 	// run the diff
 	d, err := multiDiff{
 		{differ: liveDiff, state: live},
-		{differ: staticDiff, state: soon},
-		{differ: pruneDiff, state: orphaned},
+		{differ: staticDiffAllCreated, state: soon},
+		{differ: statisDiffAllDeleted, state: orphaned},
 	}.diff()
 
 	switch {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -63,6 +63,8 @@ func (k *Kubernetes) Close() error {
 type DiffOpts struct {
 	// Use `diffstat(1)` to create a histogram of the changes instead
 	Summarize bool
+	// Find orphaned resources and include them in the diff
+	WithPrune bool
 
 	// Set the diff-strategy. If unset, the value set in the spec is used
 	Strategy string

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -93,6 +93,8 @@ type DiffOpts struct {
 	Strategy string
 	// Summarize prints a summary, instead of the actual diff
 	Summarize bool
+	// WithPrune includes objects to be deleted by prune command in the diff
+	WithPrune bool
 }
 
 // Diff parses the environment at the given directory (a `baseDir`) and returns
@@ -115,6 +117,7 @@ func Diff(baseDir string, opts DiffOpts) (*string, error) {
 	return kube.Diff(l.Resources, kubernetes.DiffOpts{
 		Summarize: opts.Summarize,
 		Strategy:  opts.Strategy,
+		WithPrune:  opts.WithPrune,
 	})
 }
 

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -117,7 +117,7 @@ func Diff(baseDir string, opts DiffOpts) (*string, error) {
 	return kube.Diff(l.Resources, kubernetes.DiffOpts{
 		Summarize: opts.Summarize,
 		Strategy:  opts.Strategy,
-		WithPrune:  opts.WithPrune,
+		WithPrune: opts.WithPrune,
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/tanka/issues/416 in line with what @malcolmholmes suggested.

Adds `--with-prune` option to `diff` command. This makes it possible to see a full diff of both added and deleted resources.

I'm not sure if it's okay to add `--ignore-not-found` to `GetByState()` or if it should be passed as argument to it. I have left a `TODO` in the code.

Let me know if I should change anything.