### PR TITLE
fix(api): restore parallel export

### DIFF
--- a/pkg/tanka/environments.go
+++ b/pkg/tanka/environments.go
@@ -134,12 +134,12 @@ type parseJob struct {
 
 func parseWorker(envsChan <-chan parseJob) (errs []error) {
 	for req := range envsChan {
-		loaded, err := Load(req.path, Opts{JsonnetOpts: req.opts})
+		env, err := LoadEnvironment(req.path, Opts{JsonnetOpts: req.opts})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s:\n %w", req.path, err))
 			continue
 		}
-		*req.env = *loaded.Env
+		*req.env = *env
 	}
 	if len(errs) != 0 {
 		return errs

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -54,7 +54,13 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 		return fmt.Errorf("Output dir `%s` not empty. Pass --merge to ignore this", to)
 	}
 
-	for _, path := range paths {
+	// get all environments for paths
+	envs, err := ParseParallel(paths, opts.ParseParallelOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, env := range envs {
 		// select targets to export
 		filter, err := process.StrExps(opts.Targets...)
 		if err != nil {
@@ -62,9 +68,7 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 		}
 
 		// get the manifests
-		loaded, err := Load(path, Opts{
-			Filters: filter,
-		})
+		loaded, err := LoadManifests(env, filter)
 		if err != nil {
 			return err
 		}

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -17,6 +17,20 @@ import (
 // Load loads the Environment at `path`. It automatically detects whether to
 // load inline or statically
 func Load(path string, opts Opts) (*LoadResult, error) {
+	env, err := LoadEnvironment(path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := LoadManifests(env, opts.Filters)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func LoadEnvironment(path string, opts Opts) (*v1alpha1.Environment, error) {
 	loader, err := DetectLoader(path)
 	if err != nil {
 		return nil, err
@@ -27,11 +41,15 @@ func Load(path string, opts Opts) (*LoadResult, error) {
 		return nil, err
 	}
 
+	return env, nil
+}
+
+func LoadManifests(env *v1alpha1.Environment, filters process.Matchers) (*LoadResult, error) {
 	if err := checkVersion(env.Spec.ExpectVersions.Tanka); err != nil {
 		return nil, err
 	}
 
-	processed, err := process.Process(*env, opts.Filters)
+	processed, err := process.Process(*env, filters)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Restore functionality that allowed for parallel processing for export. This functionality was mistakenly removed in
#459, I should have not approved that. I intended to bring that functionality back in combination with processing
multiple inline environments, but the recent discussions and PRs with refactorings give me an indication we better
restore it ASAP and have more discussions around the multiple inline environments feature.

Here is what it is actually restoring:
- LoadManifests: https://github.com/grafana/tanka/pull/459/files#diff-e5a9edc90a041a304d2a9ce3c9cd065defeda6af8b2c264fdd004e0cbd7af311L88-L103
- export.go: https://github.com/grafana/tanka/pull/459/files#diff-cde4b57e55103add29a57ad016a8173f3293f9d5442fe4d018e9a5e1933a8e1a
- environments.go: https://github.com/grafana/tanka/pull/459/files#diff-09422f24593b658f6c76015a3190e0f9288139599d6e14be15a2a875d8ae1516
