### PR TITLE
fix: correct namespace when using a file

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -20,7 +20,7 @@ const Specfile = "spec.json"
 
 // ParseDir parses the given environments `spec.json` into a `v1alpha1.Environment`
 // object with the name set to the directories name
-func ParseDir(baseDir, path string) (*v1alpha1.Environment, error) {
+func ParseDir(baseDir, path string, namespace string) (*v1alpha1.Environment, error) {
 	fi, err := os.Stat(baseDir)
 	if err != nil {
 		return nil, err
@@ -34,13 +34,13 @@ func ParseDir(baseDir, path string) (*v1alpha1.Environment, error) {
 		if os.IsNotExist(err) {
 			c := v1alpha1.New()
 			c.Metadata.Name = path // legacy behavior
-			c.Metadata.Namespace = path
+			c.Metadata.Namespace = namespace
 			return c, ErrNoSpec{path}
 		}
 		return nil, err
 	}
 
-	c, err := Parse(data, path)
+	c, err := Parse(data, namespace)
 	if c != nil {
 		// set the name field
 		c.Metadata.Name = path // legacy behavior

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -43,14 +43,6 @@ func ParseDir(path string) (*v1alpha1.Environment, error) {
 		return nil, err
 	}
 
-	fi, err := os.Stat(base)
-	if err != nil {
-		return nil, err
-	}
-	if !fi.IsDir() {
-		return nil, errors.New("baseDir is not an directory")
-	}
-
 	data, err := ioutil.ReadFile(filepath.Join(base, Specfile))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -3,6 +3,7 @@ package tanka
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
@@ -50,7 +51,20 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 		return nil, err
 	}
 
-	name, err := filepath.Rel(root, base)
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// if path is a file, use that as base for the namespace
+	if !fi.IsDir() {
+		base, err = filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	namespace, err := filepath.Rel(root, base)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +75,7 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 		return nil, err
 	}
 
-	env, err := spec.Parse(envData, name)
+	env, err := spec.Parse(envData, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -45,7 +45,7 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 		return nil, fmt.Errorf("Found no environments in '%s'", path)
 	}
 
-	root, _, err := jpath.Dirs(path)
+	root, err := jpath.FindRoot(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -3,7 +3,6 @@ package tanka
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
@@ -46,22 +45,14 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 		return nil, fmt.Errorf("Found no environments in '%s'", path)
 	}
 
-	root, base, err := jpath.Dirs(path)
+	root, _, err := jpath.Dirs(path)
 	if err != nil {
 		return nil, err
 	}
 
-	fi, err := os.Stat(path)
+	base, err := jpath.Entrypoint(path)
 	if err != nil {
 		return nil, err
-	}
-
-	// if path is a file, use that as base for the namespace
-	if !fi.IsDir() {
-		base, err = filepath.Abs(path)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	namespace, err := filepath.Rel(root, base)

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -50,12 +50,12 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 		return nil, err
 	}
 
-	base, err := jpath.Entrypoint(path)
+	file, err := jpath.Entrypoint(path)
 	if err != nil {
 		return nil, err
 	}
 
-	namespace, err := filepath.Rel(root, base)
+	namespace, err := filepath.Rel(root, file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tanka/load_test.go
+++ b/pkg/tanka/load_test.go
@@ -93,7 +93,7 @@ func TestLoad(t *testing.T) {
 				Kind:       v1alpha1.New().Kind,
 				Metadata: v1alpha1.Metadata{
 					Name:      "withenv",
-					Namespace: "cases/withenv",
+					Namespace: "cases/withenv/main.jsonnet",
 					Labels:    v1alpha1.New().Metadata.Labels,
 				},
 				Spec: v1alpha1.Spec{

--- a/pkg/tanka/load_test.go
+++ b/pkg/tanka/load_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEvalJsonnet(t *testing.T) {
+func TestLoad(t *testing.T) {
 	cases := []struct {
 		name     string
 		baseDir  string

--- a/pkg/tanka/load_test.go
+++ b/pkg/tanka/load_test.go
@@ -32,7 +32,7 @@ func TestLoad(t *testing.T) {
 				Kind:       v1alpha1.New().Kind,
 				Metadata: v1alpha1.Metadata{
 					Name:      "cases/withspecjson",
-					Namespace: "cases/withspecjson",
+					Namespace: "cases/withspecjson/main.jsonnet",
 					Labels:    v1alpha1.New().Metadata.Labels,
 				},
 				Spec: v1alpha1.Spec{
@@ -62,7 +62,7 @@ func TestLoad(t *testing.T) {
 				Kind:       v1alpha1.New().Kind,
 				Metadata: v1alpha1.Metadata{
 					Name:      "cases/withspecjson",
-					Namespace: "cases/withspecjson",
+					Namespace: "cases/withspecjson/main.jsonnet",
 					Labels:    v1alpha1.New().Metadata.Labels,
 				},
 				Spec: v1alpha1.Spec{

--- a/pkg/tanka/load_test.go
+++ b/pkg/tanka/load_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoad(t *testing.T) {
+func TestEvalJsonnet(t *testing.T) {
 	cases := []struct {
 		name     string
 		baseDir  string
@@ -79,7 +79,7 @@ func TestLoad(t *testing.T) {
 
 		{
 			name:    "inline",
-			baseDir: "./testdata/cases/withenv/main.jsonnet",
+			baseDir: "./testdata/cases/withenv/",
 			expected: manifest.List{{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
@@ -94,6 +94,36 @@ func TestLoad(t *testing.T) {
 				Metadata: v1alpha1.Metadata{
 					Name:      "withenv",
 					Namespace: "cases/withenv",
+					Labels:    v1alpha1.New().Metadata.Labels,
+				},
+				Spec: v1alpha1.Spec{
+					APIServer: "https://localhost",
+					Namespace: "withenv",
+				},
+				Data: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]interface{}{"name": "config", "namespace": "withenv"},
+				},
+			},
+		},
+		{
+			name:    "inline-filename",
+			baseDir: "./testdata/cases/withenv/main.jsonnet",
+			expected: manifest.List{{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "config",
+					"namespace": "withenv",
+				},
+			}},
+			env: &v1alpha1.Environment{
+				APIVersion: v1alpha1.New().APIVersion,
+				Kind:       v1alpha1.New().Kind,
+				Metadata: v1alpha1.Metadata{
+					Name:      "withenv",
+					Namespace: "cases/withenv/main.jsonnet",
 					Labels:    v1alpha1.New().Metadata.Labels,
 				},
 				Spec: v1alpha1.Spec{

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -3,9 +3,7 @@ package tanka
 import (
 	"encoding/json"
 	"log"
-	"path/filepath"
 
-	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/spec"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
@@ -44,22 +42,7 @@ func (s StaticLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment
 // parseStaticSpec parses the `spec.json` of the environment and returns a
 // *kubernetes.Kubernetes from it
 func parseStaticSpec(path string) (*v1alpha1.Environment, error) {
-	root, base, err := jpath.Dirs(path)
-	if err != nil {
-		return nil, err
-	}
-
-	file, err := jpath.Entrypoint(path)
-	if err != nil {
-		return nil, err
-	}
-
-	namespace, err := filepath.Rel(root, file)
-	if err != nil {
-		return nil, err
-	}
-
-	env, err := spec.ParseDir(base, namespace)
+	env, err := spec.ParseDir(path)
 	if err != nil {
 		switch err.(type) {
 		// the config includes deprecated fields

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -49,12 +49,6 @@ func parseStaticSpec(path string) (*v1alpha1.Environment, error) {
 		return nil, err
 	}
 
-	// name of the environment: relative path from rootDir
-	name, err := filepath.Rel(root, base)
-	if err != nil {
-		return nil, err
-	}
-
 	file, err := jpath.Entrypoint(path)
 	if err != nil {
 		return nil, err
@@ -65,7 +59,7 @@ func parseStaticSpec(path string) (*v1alpha1.Environment, error) {
 		return nil, err
 	}
 
-	env, err := spec.ParseDir(base, name, namespace)
+	env, err := spec.ParseDir(base, namespace)
 	if err != nil {
 		switch err.(type) {
 		// the config includes deprecated fields


### PR DESCRIPTION
This is an edge case, `namespace` should match the full execution path if `path` is a file that is not `main.jsonnet`.