### PR TITLE
refactor: parallel

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -50,7 +50,7 @@ func exportCmd() *cli.Command {
 			Targets:     vars.targets,
 			JsonnetOpts: getJsonnetOpts(),
 			Selector:    getLabelSelector(),
-			Parallel:    *parallel,
+			Parallelism: *parallel,
 		}
 
 		var paths []string

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -44,11 +44,13 @@ func exportCmd() *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		opts := tanka.ExportEnvOpts{
-			Format:      *format,
-			Extension:   *extension,
-			Merge:       *merge,
-			Targets:     vars.targets,
-			JsonnetOpts: getJsonnetOpts(),
+			Format:    *format,
+			Extension: *extension,
+			Merge:     *merge,
+			Targets:   vars.targets,
+			Opts: tanka.Opts{
+				JsonnetOpts: getJsonnetOpts(),
+			},
 			Selector:    getLabelSelector(),
 			Parallelism: *parallel,
 		}
@@ -75,7 +77,7 @@ func exportCmd() *cli.Command {
 			}
 
 			// validate environment
-			if _, err := tanka.Peek(path, opts.JsonnetOpts); err != nil {
+			if _, err := tanka.Peek(path, opts.Opts.JsonnetOpts); err != nil {
 				return err
 			}
 

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -34,6 +34,7 @@ func exportCmd() *cli.Command {
 
 	extension := cmd.Flags().String("extension", "yaml", "File extension")
 	merge := cmd.Flags().Bool("merge", false, "Allow merging with existing directory")
+	parallel := cmd.Flags().IntP("parallel", "p", 8, "Number of environments to process in parallel")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
@@ -43,14 +44,13 @@ func exportCmd() *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		opts := tanka.ExportEnvOpts{
-			Format:    *format,
-			Extension: *extension,
-			Merge:     *merge,
-			Targets:   vars.targets,
-			ParallelOpts: tanka.ParallelOpts{
-				JsonnetOpts: getJsonnetOpts(),
-				Selector:    getLabelSelector(),
-			},
+			Format:      *format,
+			Extension:   *extension,
+			Merge:       *merge,
+			Targets:     vars.targets,
+			JsonnetOpts: getJsonnetOpts(),
+			Selector:    getLabelSelector(),
+			Parallel:    *parallel,
 		}
 
 		var paths []string
@@ -63,7 +63,7 @@ func exportCmd() *cli.Command {
 				}
 
 				// get absolute path to Environment
-				envs, err := tanka.ListEnvs(path, tanka.ListOpts{Selector: opts.ParallelOpts.Selector})
+				envs, err := tanka.ListEnvs(path, tanka.ListOpts{Selector: opts.Selector})
 				if err != nil {
 					return err
 				}
@@ -75,7 +75,7 @@ func exportCmd() *cli.Command {
 			}
 
 			// validate environment
-			if _, err := tanka.Peek(path, opts.ParallelOpts.JsonnetOpts); err != nil {
+			if _, err := tanka.Peek(path, opts.JsonnetOpts); err != nil {
 				return err
 			}
 

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 	"github.com/grafana/tanka/pkg/process"
@@ -37,8 +38,12 @@ type ExportEnvOpts struct {
 	Merge bool
 	// optional: only export specified Kubernetes manifests
 	Targets []string
-	// optional: options for parsing Environments
-	ParallelOpts ParallelOpts
+	// optional: options to parse Jsonnet
+	JsonnetOpts JsonnetOpts
+	// optional: filter environments based on labels
+	Selector labels.Selector
+	// optional: number of environments to process in parallel
+	Parallel int
 }
 
 func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
@@ -55,7 +60,12 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 	}
 
 	// get all environments for paths
-	envs, err := parallelLoadEnvironments(paths, opts.ParallelOpts)
+	p := parallelOpts{
+		JsonnetOpts: opts.JsonnetOpts,
+		Selector:    opts.Selector,
+		Parallel:    opts.Parallel,
+	}
+	envs, err := parallelLoadEnvironments(paths, p)
 	if err != nil {
 		return err
 	}

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -39,7 +39,7 @@ type ExportEnvOpts struct {
 	// optional: only export specified Kubernetes manifests
 	Targets []string
 	// optional: options to parse Jsonnet
-	JsonnetOpts JsonnetOpts
+	Opts Opts
 	// optional: filter environments based on labels
 	Selector labels.Selector
 	// optional: number of environments to process in parallel
@@ -61,7 +61,7 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 
 	// get all environments for paths
 	envs, err := parallelLoadEnvironments(paths, parallelOpts{
-		JsonnetOpts: opts.JsonnetOpts,
+		JsonnetOpts: opts.Opts.JsonnetOpts,
 		Selector:    opts.Selector,
 		Parallelism: opts.Parallelism,
 	})

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -60,12 +60,11 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 	}
 
 	// get all environments for paths
-	p := parallelOpts{
+	envs, err := parallelLoadEnvironments(paths, parallelOpts{
 		JsonnetOpts: opts.JsonnetOpts,
 		Selector:    opts.Selector,
 		Parallel:    opts.Parallel,
-	}
-	envs, err := parallelLoadEnvironments(paths, p)
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -63,7 +63,7 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 	envs, err := parallelLoadEnvironments(paths, parallelOpts{
 		JsonnetOpts: opts.JsonnetOpts,
 		Selector:    opts.Selector,
-		Parallel:    opts.Parallel,
+		Parallelism:    opts.Parallel,
 	})
 	if err != nil {
 		return err

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -43,7 +43,7 @@ type ExportEnvOpts struct {
 	// optional: filter environments based on labels
 	Selector labels.Selector
 	// optional: number of environments to process in parallel
-	Parallel int
+	Parallelism int
 }
 
 func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
@@ -63,7 +63,7 @@ func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
 	envs, err := parallelLoadEnvironments(paths, parallelOpts{
 		JsonnetOpts: opts.JsonnetOpts,
 		Selector:    opts.Selector,
-		Parallelism:    opts.Parallel,
+		Parallelism: opts.Parallelism,
 	})
 	if err != nil {
 		return err

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -4,57 +4,66 @@ import (
 	"fmt"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
 
 const parallel = 8
 
+type parallelOpts struct {
+	JsonnetOpts JsonnetOpts
+	Selector    labels.Selector
+	Parallel    int
+}
+
 // parallelLoadEnvironments evaluates multiple environments in parallel
-func parallelLoadEnvironments(paths []string, opts ParallelOpts) (envs []*v1alpha1.Environment, err error) {
+func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.Environment, error) {
 	wg := sync.WaitGroup{}
 	envsChan := make(chan parallelJob)
-	var allErrors []error
+	outChan := make(chan parallelOut)
 
-	numParallel := parallel
-	if opts.Parallel > 0 {
-		numParallel = opts.Parallel
+	if opts.Parallel <= 0 {
+		opts.Parallel = parallel
 	}
-	for i := 0; i < numParallel; i++ {
+
+	for i := 0; i < opts.Parallel; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errs := parallelWorker(envsChan)
-			if errs != nil {
-				allErrors = append(allErrors, errs...)
-			}
+			parallelWorker(envsChan, outChan)
 		}()
 	}
 
-	results := make([]*v1alpha1.Environment, 0, len(paths))
-
+	jobs := 0
 	for _, path := range paths {
-		env := &v1alpha1.Environment{}
-		results = append(results, env)
 		envsChan <- parallelJob{
 			path: path,
-			opts: opts.JsonnetOpts,
-			env:  env,
+			opts: Opts{JsonnetOpts: opts.JsonnetOpts},
 		}
+		jobs++
 	}
 	close(envsChan)
-	wg.Wait()
 
-	for _, env := range results {
-		if env == nil {
+	var envs []*v1alpha1.Environment
+	var errors []error
+	for i := 0; i < jobs; i++ {
+		out := <-outChan
+		if out.err != nil {
+			errors = append(errors, out.err)
+		}
+		if out.env == nil {
 			continue
 		}
-		if opts.Selector == nil || opts.Selector.Empty() || opts.Selector.Matches(env.Metadata) {
-			envs = append(envs, env)
+		if opts.Selector == nil || opts.Selector.Empty() || opts.Selector.Matches(out.env.Metadata) {
+			envs = append(envs, out.env)
 		}
 	}
 
-	if len(allErrors) != 0 {
-		return envs, ErrParallel{errors: allErrors}
+	wg.Wait()
+
+	if len(errors) != 0 {
+		return envs, ErrParallel{errors: errors}
 	}
 
 	return envs, nil
@@ -62,21 +71,20 @@ func parallelLoadEnvironments(paths []string, opts ParallelOpts) (envs []*v1alph
 
 type parallelJob struct {
 	path string
-	opts JsonnetOpts
-	env  *v1alpha1.Environment
+	opts Opts
 }
 
-func parallelWorker(envsChan <-chan parallelJob) (errs []error) {
-	for req := range envsChan {
-		env, err := LoadEnvironment(req.path, Opts{JsonnetOpts: req.opts})
+type parallelOut struct {
+	env *v1alpha1.Environment
+	err error
+}
+
+func parallelWorker(jobs <-chan parallelJob, out chan parallelOut) {
+	for job := range jobs {
+		env, err := LoadEnvironment(job.path, job.opts)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("%s:\n %w", req.path, err))
-			continue
+			err = fmt.Errorf("%s:\n %w", job.path, err)
 		}
-		*req.env = *env
+		out <- parallelOut{env: env, err: err}
 	}
-	if len(errs) != 0 {
-		return errs
-	}
-	return nil
 }

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/process"
@@ -54,10 +53,4 @@ func checkVersion(constraint string) error {
 	}
 
 	return nil
-}
-
-type ParallelOpts struct {
-	JsonnetOpts JsonnetOpts
-	Selector    labels.Selector
-	Parallel    int
 }


### PR DESCRIPTION
As suggested in #471, this refactors the parallel functions to use the chan idioms. It also makes `parallelOpts` a
private struct.