### PR TITLE
fix: recursive export

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -71,10 +71,7 @@ func exportCmd() *cli.Command {
 				}
 
 				for _, env := range envs {
-					path := filepath.Join(rootDir, env.Metadata.Namespace)
-					if !hasPath(paths, path) {
-						paths = append(paths, path)
-					}
+					paths = append(paths, filepath.Join(rootDir, env.Metadata.Namespace))
 				}
 				continue
 			}
@@ -91,13 +88,4 @@ func exportCmd() *cli.Command {
 		return tanka.ExportEnvironments(paths, args[0], &opts)
 	}
 	return cmd
-}
-
-func hasPath(paths []string, path string) bool {
-	for _, p := range paths {
-		if p == path {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -71,7 +71,10 @@ func exportCmd() *cli.Command {
 				}
 
 				for _, env := range envs {
-					paths = append(paths, filepath.Join(rootDir, env.Metadata.Namespace))
+					path := filepath.Join(rootDir, env.Metadata.Namespace)
+					if !hasPath(paths, path) {
+						paths = append(paths, path)
+					}
 				}
 				continue
 			}
@@ -88,4 +91,13 @@ func exportCmd() *cli.Command {
 		return tanka.ExportEnvironments(paths, args[0], &opts)
 	}
 	return cmd
+}
+
+func hasPath(paths []string, path string) bool {
+	for _, p := range paths {
+		if p == path {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -19,7 +19,7 @@ type parallelOpts struct {
 // parallelLoadEnvironments evaluates multiple environments in parallel
 func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.Environment, error) {
 	jobsCh := make(chan parallelJob)
-	outCh := make(chan parallelOut)
+	outCh := make(chan parallelOut, len(paths))
 
 	if opts.Parallelism <= 0 {
 		opts.Parallelism = defaultParallelism

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -2,6 +2,7 @@ package tanka
 
 import (
 	"fmt"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -11,44 +12,52 @@ import (
 const defaultParallelism = 8
 
 type parallelOpts struct {
-	JsonnetOpts JsonnetOpts
+	JsonnetOpts
 	Selector    labels.Selector
 	Parallelism int
 }
 
 // parallelLoadEnvironments evaluates multiple environments in parallel
 func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.Environment, error) {
+	wg := sync.WaitGroup{}
 	jobsCh := make(chan parallelJob)
-	outCh := make(chan parallelOut)
 
 	if opts.Parallelism <= 0 {
 		opts.Parallelism = defaultParallelism
 	}
 
 	for i := 0; i < opts.Parallelism; i++ {
-		go parallelWorker(jobsCh, outCh)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			parallelWorker(jobsCh)
+		}()
 	}
 
+	var results []*parallelOut
 	for _, path := range paths {
+		out := &parallelOut{}
+		results = append(results, out)
 		jobsCh <- parallelJob{
 			path: path,
 			opts: Opts{JsonnetOpts: opts.JsonnetOpts},
+			out:  out,
 		}
 	}
 	close(jobsCh)
 
 	var envs []*v1alpha1.Environment
 	var errors []error
-	for i := 0; i < len(paths); i++ {
-		out := <-outCh
+	for _, out := range results {
 		if out.err != nil {
 			errors = append(errors, out.err)
 			continue
 		}
 		if opts.Selector == nil || opts.Selector.Empty() || opts.Selector.Matches(out.env.Metadata) {
-			envs = append(envs, out.env)
+			envs = append(envs, &out.env)
 		}
 	}
+	wg.Wait()
 
 	if len(errors) != 0 {
 		return envs, ErrParallel{errors: errors}
@@ -60,19 +69,20 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 type parallelJob struct {
 	path string
 	opts Opts
+	out  *parallelOut
 }
 
 type parallelOut struct {
-	env *v1alpha1.Environment
+	env v1alpha1.Environment
 	err error
 }
 
-func parallelWorker(jobsCh <-chan parallelJob, outCh chan parallelOut) {
+func parallelWorker(jobsCh <-chan parallelJob) {
 	for job := range jobsCh {
 		env, err := LoadEnvironment(job.path, job.opts)
 		if err != nil {
 			err = fmt.Errorf("%s:\n %w", job.path, err)
 		}
-		outCh <- parallelOut{env: env, err: err}
+		*job.out = parallelOut{*env, err}
 	}
 }


### PR DESCRIPTION
This partially reverts changes made in #473.

Turns out the workers kept waiting for `outCh` to be read, this only happens after all 'jobs' have been launched. But as
the limited number of workers kept waiting, no new jobs could be launched.

One of the concerns in #6611 was that a pointer was passed back, this is not the case anymore. The env is now copied
instead of passing along a pointer.