### PR TITLE
feat: multiple inline environments

### DIFF
--- a/cmd/tk/args.go
+++ b/cmd/tk/args.go
@@ -24,7 +24,7 @@ var workflowArgs = cli.Args{
 			return nil
 		}
 
-		envs, err := tanka.ListEnvs(pwd, tanka.ListOpts{})
+		envs, err := tanka.FindEnvs(pwd, tanka.FindOpts{})
 		if err != nil {
 			return nil
 		}

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -240,7 +240,7 @@ func envListCmd() *cli.Command {
 			}
 		}
 
-		envs, err := tanka.ListEnvs(path, tanka.ListOpts{Selector: getLabelSelector()})
+		envs, err := tanka.FindEnvs(path, tanka.FindOpts{Selector: getLabelSelector()})
 		if err != nil {
 			return err
 		}

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -77,7 +77,7 @@ func envSetCmd() *cli.Command {
 			tmp.Spec.APIServer = server
 		}
 
-		cfg, err := tanka.Peek(path, tanka.JsonnetOpts{})
+		cfg, err := tanka.Peek(path, tanka.Opts{})
 		if err != nil {
 			return err
 		}

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -229,26 +229,18 @@ func envListCmd() *cli.Command {
 	useNames := cmd.Flags().Bool("names", false, "plain names output")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		var dir string
+		var path string
 		var err error
 		if len(args) == 1 {
-			dir = args[0]
+			path = args[0]
 		} else {
-			dir, err = os.Getwd()
+			path, err = os.Getwd()
 			if err != nil {
 				return nil
 			}
 		}
 
-		stat, err := os.Stat(dir)
-		if err != nil {
-			return err
-		}
-		if !stat.IsDir() {
-			return fmt.Errorf("Not a directory: %s", dir)
-		}
-
-		envs, err := tanka.ListEnvs(dir, tanka.ListOpts{Selector: getLabelSelector()})
+		envs, err := tanka.ListEnvs(path, tanka.ListOpts{Selector: getLabelSelector()})
 		if err != nil {
 			return err
 		}

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -84,7 +84,7 @@ func exportCmd() *cli.Command {
 			}
 
 			// validate environment
-			if _, err := tanka.LoadEnvironment(path, opts.Opts); err != nil {
+			if _, err := tanka.Peek(path, opts.Opts); err != nil {
 				switch err.(type) {
 				case tanka.ErrMultipleEnvs:
 					fmt.Println("Please use --name to export a single environment or --recursive to export multiple environments.")

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -78,7 +78,13 @@ func exportCmd() *cli.Command {
 
 			// validate environment
 			if _, err := tanka.Peek(path, opts.Opts.JsonnetOpts); err != nil {
-				return err
+				switch err.(type) {
+				case tanka.ErrMultipleEnvs:
+					fmt.Println("Please use --recursive to export with multiple inline environments.")
+					return err
+				default:
+					return err
+				}
 			}
 
 			paths = append(paths, path)

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -72,7 +72,7 @@ func exportCmd() *cli.Command {
 				}
 
 				// get absolute path to Environment
-				envs, err := tanka.ListEnvs(path, tanka.ListOpts{Selector: opts.Selector})
+				envs, err := tanka.FindEnvs(path, tanka.FindOpts{Selector: opts.Selector})
 				if err != nil {
 					return err
 				}

--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -13,11 +13,13 @@ import (
 )
 
 type workflowFlagVars struct {
+	name    string
 	targets []string
 }
 
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
+	fs.StringVar(&v.name, "name", "", "selects an environment from inline environments")
 	fs.StringSliceVarP(&v.targets, "target", "t", nil, "only use the specified objects (Format: <type>/<name>)")
 	return &v
 }

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -43,6 +43,7 @@ func applyCmd() *cli.Command {
 		}
 		opts.Filters = filters
 		opts.JsonnetOpts = getJsonnetOpts()
+		opts.Name = vars.name
 
 		return tanka.Apply(args[0], opts)
 	}
@@ -92,6 +93,7 @@ func deleteCmd() *cli.Command {
 		}
 		opts.Filters = filters
 		opts.JsonnetOpts = getJsonnetOpts()
+		opts.Name = vars.name
 
 		return tanka.Delete(args[0], opts)
 	}
@@ -122,6 +124,7 @@ func diffCmd() *cli.Command {
 		}
 		opts.Filters = filters
 		opts.JsonnetOpts = getJsonnetOpts()
+		opts.Name = vars.name
 
 		changes, err := tanka.Diff(args[0], opts)
 		if err != nil {
@@ -173,6 +176,7 @@ Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
 		pretty, err := tanka.Show(args[0], tanka.Opts{
 			JsonnetOpts: getJsonnetOpts(),
 			Filters:     filters,
+			Name:        vars.name,
 		})
 
 		if err != nil {

--- a/pkg/tanka/errors.go
+++ b/pkg/tanka/errors.go
@@ -22,7 +22,7 @@ type ErrMultipleEnvs struct {
 }
 
 func (e ErrMultipleEnvs) Error() string {
-	return fmt.Sprintf("found multiple Environments (%s) in '%s'", strings.Join(e.names, ", "), e.path)
+	return fmt.Sprintf("found multiple Environments in '%s': \n - %s", e.path, strings.Join(e.names, "\n - "))
 }
 
 // ErrParallel is an array of errors collected while parsing environments in parallel

--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -83,3 +83,35 @@ local noDataEnv(object) =
 
 noDataEnv(main)
 `
+
+// SingleEnvEvalScript returns a Single Environment object
+const SingleEnvEvalScript = `
+local singleEnv(object) =
+  std.prune(
+    if std.isObject(object)
+    then
+      if std.objectHas(object, 'apiVersion')
+         && std.objectHas(object, 'kind')
+      then
+        if object.kind == 'Environment'
+        && object.metadata.name == '%s'
+        then object
+        else {}
+      else
+        std.mapWithKey(
+          function(key, obj)
+            singleEnv(obj),
+          object
+        )
+    else if std.isArray(object)
+    then
+      std.map(
+        function(obj)
+          singleEnv(obj),
+        object
+      )
+    else {}
+  );
+
+singleEnv(main)
+`

--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -53,8 +53,8 @@ function(%s)
 
 const PatternEvalScript = "main.%s"
 
-// EnvsOnlyEvalScript finds the Environment object (without its .data object)
-const EnvsOnlyEvalScript = `
+// MetadataEvalScript finds the Environment object (without its .data object)
+const MetadataEvalScript = `
 local noDataEnv(object) =
   std.prune(
     if std.isObject(object)
@@ -84,8 +84,8 @@ local noDataEnv(object) =
 noDataEnv(main)
 `
 
-// SingleEnvEvalScript returns a Single Environment object
-const SingleEnvEvalScript = `
+// MetadataSingleEnvEvalScript returns a Single Environment object
+const MetadataSingleEnvEvalScript = `
 local singleEnv(object) =
   std.prune(
     if std.isObject(object)
@@ -95,7 +95,7 @@ local singleEnv(object) =
       then
         if object.kind == 'Environment'
         && object.metadata.name == '%s'
-        then object
+        then object { data:: {} }
         else {}
       else
         std.mapWithKey(
@@ -112,6 +112,36 @@ local singleEnv(object) =
       )
     else {}
   );
+
+singleEnv(main)
+`
+
+// SingleEnvEvalScript returns a Single Environment object
+const SingleEnvEvalScript = `
+local singleEnv(object) =
+  if std.isObject(object)
+  then
+    if std.objectHas(object, 'apiVersion')
+       && std.objectHas(object, 'kind')
+    then
+      if object.kind == 'Environment'
+      && object.metadata.name == '%s'
+      then object
+      else {}
+    else
+      std.mapWithKey(
+        function(key, obj)
+          singleEnv(obj),
+        object
+      )
+  else if std.isArray(object)
+  then
+    std.map(
+      function(obj)
+        singleEnv(obj),
+      object
+    )
+  else {};
 
 singleEnv(main)
 `

--- a/pkg/tanka/find.go
+++ b/pkg/tanka/find.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -45,7 +44,7 @@ func FindEnvs(path string, opts FindOpts) ([]*v1alpha1.Environment, error) {
 // find implements the actual functionality described at 'FindEnvs'
 func find(path string) ([]*v1alpha1.Environment, error) {
 	// try if this has envs
-	list, err := List(path, jsonnet.Opts{})
+	list, err := List(path, Opts{})
 	if len(list) != 0 && err == nil {
 		// it has. don't search deeper
 		return list, nil

--- a/pkg/tanka/find.go
+++ b/pkg/tanka/find.go
@@ -12,7 +12,6 @@ import (
 // FindOpts are optional arguments for FindEnvs
 type FindOpts struct {
 	Selector labels.Selector
-	Name     string
 }
 
 // FindEnvs returns metadata of all environments recursively found in 'path'.
@@ -21,7 +20,7 @@ type FindOpts struct {
 // are not checked.
 func FindEnvs(path string, opts FindOpts) ([]*v1alpha1.Environment, error) {
 	// find all environments at dir
-	envs, err := find(path, opts.Name)
+	envs, err := find(path)
 	if err != nil {
 		return nil, err
 	}
@@ -43,9 +42,9 @@ func FindEnvs(path string, opts FindOpts) ([]*v1alpha1.Environment, error) {
 }
 
 // find implements the actual functionality described at 'FindEnvs'
-func find(path, name string) ([]*v1alpha1.Environment, error) {
+func find(path string) ([]*v1alpha1.Environment, error) {
 	// try if this has envs
-	list, err := List(path, Opts{Name: name})
+	list, err := List(path, Opts{})
 	if len(list) != 0 && err == nil {
 		// it has. don't search deeper
 		return list, nil
@@ -78,7 +77,7 @@ func find(path, name string) ([]*v1alpha1.Environment, error) {
 		}
 
 		routines++
-		go findShim(filepath.Join(path, fi.Name()), name, ch)
+		go findShim(filepath.Join(path, fi.Name()), ch)
 	}
 
 	// collect parallel results
@@ -106,7 +105,7 @@ type findOut struct {
 	err  error
 }
 
-func findShim(path, name string, ch chan findOut) {
-	envs, err := find(path, name)
+func findShim(dir string, ch chan findOut) {
+	envs, err := find(dir)
 	ch <- findOut{envs: envs, err: err}
 }

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -54,18 +54,15 @@ func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment
 }
 
 func (i *InlineLoader) Peek(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
-	opts.JsonnetOpts.EvalScript = EnvsOnlyEvalScript
+	opts.JsonnetOpts.EvalScript = MetadataEvalScript
 	if opts.Name != "" {
-		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
+		opts.JsonnetOpts.EvalScript = fmt.Sprintf(MetadataSingleEnvEvalScript, opts.Name)
 	}
 	return i.Load(path, opts)
 }
 
 func (i *InlineLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error) {
-	opts.JsonnetOpts.EvalScript = EnvsOnlyEvalScript
-	if opts.Name != "" {
-		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
-	}
+	opts.JsonnetOpts.EvalScript = MetadataEvalScript
 	list, err := inlineEval(path, opts.JsonnetOpts)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -18,17 +18,7 @@ import (
 type InlineLoader struct{}
 
 func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	raw, err := EvalJsonnet(path, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	var data interface{}
-	if err := json.Unmarshal([]byte(raw), &data); err != nil {
-		return nil, err
-	}
-
-	envs, err := extractEnvs(data)
+	envs, err := inlineEval(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +35,70 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 		return nil, fmt.Errorf("Found no environments in '%s'", path)
 	}
 
+	// TODO: Re-serializing the entire env here. This is horribly inefficient
+	envData, err := json.Marshal(envs[0])
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := inlineParse(path, envData)
+	if err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+func (i *InlineLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
+	opts.EvalScript = EnvsOnlyEvalScript
+	return i.Load(path, opts)
+}
+
+func (i *InlineLoader) List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error) {
+	opts.EvalScript = EnvsOnlyEvalScript
+	list, err := inlineEval(path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	envs := make([]*v1alpha1.Environment, 0, len(list))
+	for _, raw := range list {
+		data, err := json.Marshal(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		env, err := inlineParse(path, data)
+		if err != nil {
+			return nil, err
+		}
+
+		envs = append(envs, env)
+	}
+
+	return envs, nil
+}
+
+func inlineEval(path string, opts JsonnetOpts) (manifest.List, error) {
+	raw, err := EvalJsonnet(path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var data interface{}
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return nil, err
+	}
+
+	envs, err := extractEnvs(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return envs, nil
+}
+
+func inlineParse(path string, data []byte) (*v1alpha1.Environment, error) {
 	root, err := jpath.FindRoot(path)
 	if err != nil {
 		return nil, err
@@ -60,23 +114,12 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 		return nil, err
 	}
 
-	// TODO: Re-serializing the entire env here. This is horribly inefficient
-	envData, err := json.Marshal(envs[0])
-	if err != nil {
-		return nil, err
-	}
-
-	env, err := spec.Parse(envData, namespace)
+	env, err := spec.Parse(data, namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	return env, nil
-}
-
-func (i *InlineLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	opts.EvalScript = EnvsOnlyEvalScript
-	return i.Load(path, opts)
 }
 
 // extractEnvs filters out any Environment manifests

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -17,8 +17,12 @@ import (
 // Kubernetes resources are expected at the `data` key of this very type
 type InlineLoader struct{}
 
-func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	envs, err := inlineEval(path, opts)
+func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
+	if opts.Name != "" {
+		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
+	}
+
+	envs, err := inlineEval(path, opts.JsonnetOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -49,14 +53,20 @@ func (i *InlineLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environmen
 	return env, nil
 }
 
-func (i *InlineLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	opts.EvalScript = EnvsOnlyEvalScript
+func (i *InlineLoader) Peek(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
+	opts.JsonnetOpts.EvalScript = EnvsOnlyEvalScript
+	if opts.Name != "" {
+		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
+	}
 	return i.Load(path, opts)
 }
 
-func (i *InlineLoader) List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error) {
-	opts.EvalScript = EnvsOnlyEvalScript
-	list, err := inlineEval(path, opts)
+func (i *InlineLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error) {
+	opts.JsonnetOpts.EvalScript = EnvsOnlyEvalScript
+	if opts.Name != "" {
+		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
+	}
+	list, err := inlineEval(path, opts.JsonnetOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -36,10 +36,7 @@ func LoadEnvironment(path string, opts Opts) (*v1alpha1.Environment, error) {
 		return nil, err
 	}
 
-	if opts.Name != "" {
-		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
-	}
-	env, err := loader.Load(path, opts.JsonnetOpts)
+	env, err := loader.Load(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
 	if err != nil {
 		return nil, err
 	}
@@ -62,25 +59,25 @@ func LoadManifests(env *v1alpha1.Environment, filters process.Matchers) (*LoadRe
 
 // Peek loads the metadata of the environment at path. To get resources as well,
 // use Load
-func Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
+func Peek(path string, opts Opts) (*v1alpha1.Environment, error) {
 	loader, err := DetectLoader(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return loader.Peek(path, opts)
+	return loader.Peek(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
 }
 
 // List finds metadata of all environments at path that could possibly be
 // loaded. List can be used to deal with multiple inline environments, by first
 // listing them, choosing the right one and then only loading that one
-func List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error) {
+func List(path string, opts Opts) ([]*v1alpha1.Environment, error) {
 	loader, err := DetectLoader(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return loader.List(path, opts)
+	return loader.List(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
 }
 
 // DetectLoader detects whether the environment is inline or static and picks
@@ -105,14 +102,19 @@ func DetectLoader(path string) (Loader, error) {
 // Loader is an abstraction over the process of loading Environments
 type Loader interface {
 	// Load a single environment at path
-	Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error)
+	Load(path string, opts LoaderOpts) (*v1alpha1.Environment, error)
 
 	// Peek only loads metadata and omits the actual resources
-	Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error)
+	Peek(path string, opts LoaderOpts) (*v1alpha1.Environment, error)
 
 	// List returns metadata of all possible environments at path that can be
 	// loaded
-	List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error)
+	List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error)
+}
+
+type LoaderOpts struct {
+	JsonnetOpts
+	Name string
 }
 
 type LoadResult struct {

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -36,6 +36,9 @@ func LoadEnvironment(path string, opts Opts) (*v1alpha1.Environment, error) {
 		return nil, err
 	}
 
+	if opts.Name != "" {
+		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
+	}
 	env, err := loader.Load(path, opts.JsonnetOpts)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -68,6 +68,18 @@ func Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
 	return loader.Peek(path, opts)
 }
 
+// List finds metadata of all environments at path that could possibly be
+// loaded. List can be used to deal with multiple inline environments, by first
+// listing them, choosing the right one and then only loading that one
+func List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error) {
+	loader, err := DetectLoader(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return loader.List(path, opts)
+}
+
 // DetectLoader detects whether the environment is inline or static and picks
 // the approriate loader
 func DetectLoader(path string) (Loader, error) {
@@ -89,11 +101,15 @@ func DetectLoader(path string) (Loader, error) {
 
 // Loader is an abstraction over the process of loading Environments
 type Loader interface {
-	// Load the environment with path
+	// Load a single environment at path
 	Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error)
 
 	// Peek only loads metadata and omits the actual resources
 	Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error)
+
+	// List returns metadata of all possible environments at path that can be
+	// loaded
+	List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error)
 }
 
 type LoadResult struct {

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -27,7 +27,6 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 		}
 		for _, env := range envs {
 			list[env.Metadata.Name] = path
-			fmt.Println(env.Metadata.Name)
 		}
 	}
 	outCh := make(chan parallelOut, len(list))

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -21,12 +21,13 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 	jobsCh := make(chan parallelJob)
 	list := make(map[string]string)
 	for _, path := range paths {
-		envs, err := FindEnvs(path, FindOpts{opts.Selector})
+		envs, err := FindEnvs(path, FindOpts{Selector: opts.Selector, Name: opts.Name})
 		if err != nil {
 			return nil, err
 		}
 		for _, env := range envs {
 			list[env.Metadata.Name] = path
+			fmt.Println(env.Metadata.Name)
 		}
 	}
 	outCh := make(chan parallelOut, len(list))

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -11,7 +11,7 @@ import (
 const defaultParallelism = 8
 
 type parallelOpts struct {
-	JsonnetOpts JsonnetOpts
+	Opts
 	Selector    labels.Selector
 	Parallelism int
 }
@@ -32,7 +32,7 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 	for _, path := range paths {
 		jobsCh <- parallelJob{
 			path: path,
-			opts: Opts{JsonnetOpts: opts.JsonnetOpts},
+			opts: opts.Opts,
 		}
 	}
 	close(jobsCh)

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -26,6 +26,9 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 			return nil, err
 		}
 		for _, env := range envs {
+			if opts.Name != "" && opts.Name != env.Metadata.Name {
+				continue
+			}
 			list[env.Metadata.Name] = path
 		}
 	}

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -19,7 +19,17 @@ type parallelOpts struct {
 // parallelLoadEnvironments evaluates multiple environments in parallel
 func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.Environment, error) {
 	jobsCh := make(chan parallelJob)
-	outCh := make(chan parallelOut, len(paths))
+	list := make(map[string]string)
+	for _, path := range paths {
+		envs, err := FindEnvs(path, FindOpts{opts.Selector})
+		if err != nil {
+			return nil, err
+		}
+		for _, env := range envs {
+			list[env.Metadata.Name] = path
+		}
+	}
+	outCh := make(chan parallelOut, len(list))
 
 	if opts.Parallelism <= 0 {
 		opts.Parallelism = defaultParallelism
@@ -29,17 +39,19 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 		go parallelWorker(jobsCh, outCh)
 	}
 
-	for _, path := range paths {
+	for name, path := range list {
+		o := opts.Opts
+		o.Name = name
 		jobsCh <- parallelJob{
 			path: path,
-			opts: opts.Opts,
+			opts: o,
 		}
 	}
 	close(jobsCh)
 
 	var envs []*v1alpha1.Environment
 	var errors []error
-	for i := 0; i < len(paths); i++ {
+	for i := 0; i < len(list); i++ {
 		out := <-outCh
 		if out.err != nil {
 			errors = append(errors, out.err)

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -21,7 +21,7 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 	jobsCh := make(chan parallelJob)
 	list := make(map[string]string)
 	for _, path := range paths {
-		envs, err := FindEnvs(path, FindOpts{Selector: opts.Selector, Name: opts.Name})
+		envs, err := FindEnvs(path, FindOpts{opts.Selector})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -13,7 +13,7 @@ import (
 type StaticLoader struct{}
 
 func (s StaticLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
-	config, err := Peek(path, opts)
+	config, err := s.Peek(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +37,15 @@ func (s StaticLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment
 	}
 
 	return config, nil
+}
+
+func (s StaticLoader) List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error) {
+	env, err := s.Peek(path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*v1alpha1.Environment{env}, nil
 }
 
 // parseStaticSpec parses the `spec.json` of the environment and returns a

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -12,13 +12,13 @@ import (
 // Jsonnet is evaluated as normal
 type StaticLoader struct{}
 
-func (s StaticLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
+func (s StaticLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
 	config, err := s.Peek(path, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err := EvalJsonnet(path, opts)
+	data, err := EvalJsonnet(path, opts.JsonnetOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (s StaticLoader) Load(path string, opts JsonnetOpts) (*v1alpha1.Environment
 	return config, nil
 }
 
-func (s StaticLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment, error) {
+func (s StaticLoader) Peek(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
 	config, err := parseStaticSpec(path)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (s StaticLoader) Peek(path string, opts JsonnetOpts) (*v1alpha1.Environment
 	return config, nil
 }
 
-func (s StaticLoader) List(path string, opts JsonnetOpts) ([]*v1alpha1.Environment, error) {
+func (s StaticLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error) {
 	env, err := s.Peek(path, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -21,6 +21,9 @@ type Opts struct {
 
 	// Filters are used to optionally select a subset of the resources
 	Filters process.Matchers
+
+	// Name is used to extract a single environment from multiple environments
+	Name string
 }
 
 // DEFAULT_DEV_VERSION is the placeholder version used when no actual semver is


### PR DESCRIPTION
This PR provides a solution to work with multiple inline environments. Bulk operations like `tk export --recursive` and
`tk env list` will now be able to work on multiple inline environments found in a `main.jsonnet`. The regular workflow
commands like `tk apply`, `tk show`, etc. will require the `--name` flag if multiple environments are present.

Ideally I'd like an interactive UI for selecting an environment, however there are multiple ways to do it with shell
integrations, for example `fzf` has been brought up in recent discussions. If we do want an integrated UI, I propose to
introduce that in a separate PR.

closes #432

be9dafc is a rebase of 91651e9 (kudos @sh0rez), which could also have its own PR, this PR just takes it one step further.

~commit c15952a comes from #475, need a rebase after it is merged, [compare](https://github.com/grafana/tanka/compare/duologic/fix_recursive_export...duologic/multi_env) without that commit~