### PR TITLE
feat(cli): by default don't delete namespace

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -58,6 +58,7 @@ func pruneCmd() *cli.Command {
 	}
 
 	var opts tanka.PruneOpts
+	cmd.Flags().BoolVar(&opts.IncludeNamespaces, "namespaces", false, "prune namespace objects")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
@@ -79,6 +80,7 @@ func deleteCmd() *cli.Command {
 	}
 
 	var opts tanka.DeleteOpts
+	cmd.Flags().BoolVar(&opts.IncludeNamespaces, "namespaces", false, "delete namespace objects")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -116,6 +116,7 @@ func diffCmd() *cli.Command {
 	cmd.Flags().StringVar(&opts.Strategy, "diff-strategy", "", "force the diff-strategy to use. Automatically chosen if not set.")
 	cmd.Flags().BoolVarP(&opts.Summarize, "summarize", "s", false, "print summary of the differences, not the actual contents")
 	cmd.Flags().BoolVarP(&opts.WithPrune, "with-prune", "p", false, "include objects deleted from the configuration in the differences")
+	cmd.Flags().BoolVar(&opts.IncludeNamespaces, "prune-namespaces", false, "prune namespace objects")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -49,8 +49,19 @@ type ApplyOpts struct {
 }
 
 // DeleteOpts allow to specify additional parameters for delete operations
-// Currently not different from ApplyOpts, but may be required in the future
-type DeleteOpts ApplyOpts
+type DeleteOpts struct {
+	// force allows to ignore checks and force the operation
+	Force bool
+
+	// validate allows to enable/disable kubectl validation
+	Validate bool
+
+	// autoApprove allows to skip the interactive approval
+	AutoApprove bool
+
+	// includeNamespaces allows to delete namespaces
+	IncludeNamespaces bool
+}
 
 // GetByStateOpts allow to specify additional parameters for GetByState function
 // Currently there is just ignoreNotFound parameter which is only useful for

--- a/pkg/kubernetes/delete.go
+++ b/pkg/kubernetes/delete.go
@@ -18,6 +18,9 @@ func (k *Kubernetes) Delete(state manifest.List, opts DeleteOpts) error {
 	}
 
 	for _, m := range state {
+		if !opts.IncludeNamespaces && m.Kind() == "Namespace" {
+			continue
+		}
 		if err := k.ctl.Delete(m.Metadata().Namespace(), m.Kind(), m.Metadata().Name(), client.DeleteOpts(opts)); err != nil {
 			return err
 		}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -68,6 +68,9 @@ type DiffOpts struct {
 
 	// Set the diff-strategy. If unset, the value set in the spec is used
 	Strategy string
+
+	// Include namespaces for prune/delete
+	IncludeNamespaces bool
 }
 
 // Info about the client, etc.

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -34,7 +34,7 @@ func Prune(baseDir string, opts PruneOpts) error {
 	defer kube.Close()
 
 	// find orphaned resources
-	orphaned, err := kube.Orphaned(p.Resources, kubernetes.OrphanedOpts{opts.IncludeNamespaces})
+	orphaned, err := kube.Orphaned(p.Resources, kubernetes.OrphanedOpts{IncludeNamespaces: opts.IncludeNamespaces})
 	if err != nil {
 		return err
 	}

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -34,7 +34,7 @@ func Prune(baseDir string, opts PruneOpts) error {
 	defer kube.Close()
 
 	// find orphaned resources
-	orphaned, err := kube.Orphaned(p.Resources)
+	orphaned, err := kube.Orphaned(p.Resources, kubernetes.OrphanedOpts{opts.IncludeNamespaces})
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func Prune(baseDir string, opts PruneOpts) error {
 	}
 
 	// print diff
-	diff, err := kubernetes.StaticDiffer(false)(orphaned)
+	diff, err := kubernetes.StaticDiffer(false, opts.IncludeNamespaces)(orphaned)
 	if err != nil {
 		// static diff can't fail normally, so unlike in apply, this is fatal
 		// here

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/tanka/pkg/kubernetes"
-	"github.com/grafana/tanka/pkg/process"
 	"github.com/grafana/tanka/pkg/term"
 )
 
@@ -23,15 +22,6 @@ type PruneOpts struct {
 // Prune deletes all resources from the cluster, that are no longer present in
 // Jsonnet. It uses the `tanka.dev/environment` label to identify those.
 func Prune(baseDir string, opts PruneOpts) error {
-	// By default, don't delete namespaces
-	if !opts.IncludeNamespaces {
-		ignoreNamespace, err := process.StrExps("!namespace*")
-		if err != nil {
-			return err
-		}
-		opts.Opts.Filters = append(opts.Opts.Filters, ignoreNamespace)
-	}
-
 	// parse jsonnet, init k8s client
 	p, err := Load(baseDir, opts.Opts)
 	if err != nil {
@@ -71,6 +61,7 @@ func Prune(baseDir string, opts PruneOpts) error {
 
 	// delete resources
 	return kube.Delete(orphaned, kubernetes.DeleteOpts{
-		Force: opts.Force,
+		Force:             opts.Force,
+		IncludeNamespaces: opts.IncludeNamespaces,
 	})
 }

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/kubernetes/client"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"github.com/grafana/tanka/pkg/process"
 	"github.com/grafana/tanka/pkg/term"
 )
 
@@ -141,15 +140,6 @@ type DeleteOpts struct {
 // the generated objects from the Kubernetes cluster defined in the environment's
 // `spec.json`.
 func Delete(baseDir string, opts DeleteOpts) error {
-	// By default, don't delete namespaces
-	if !opts.IncludeNamespaces {
-		ignoreNamespace, err := process.StrExps("!namespace*")
-		if err != nil {
-			return err
-		}
-		opts.Opts.Filters = append(opts.Opts.Filters, ignoreNamespace)
-	}
-
 	l, err := Load(baseDir, opts.Opts)
 	if err != nil {
 		return err
@@ -181,8 +171,9 @@ func Delete(baseDir string, opts DeleteOpts) error {
 	}
 
 	return kube.Delete(l.Resources, kubernetes.DeleteOpts{
-		Force:    opts.Force,
-		Validate: opts.Validate,
+		Force:             opts.Force,
+		Validate:          opts.Validate,
+		IncludeNamespaces: opts.IncludeNamespaces,
 	})
 }
 

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -95,6 +95,8 @@ type DiffOpts struct {
 	Summarize bool
 	// WithPrune includes objects to be deleted by prune command in the diff
 	WithPrune bool
+	// IncludeNamespaces includes namespace objects for pruning
+	IncludeNamespaces bool
 }
 
 // Diff parses the environment at the given directory (a `baseDir`) and returns
@@ -115,9 +117,10 @@ func Diff(baseDir string, opts DiffOpts) (*string, error) {
 	defer kube.Close()
 
 	return kube.Diff(l.Resources, kubernetes.DiffOpts{
-		Summarize: opts.Summarize,
-		Strategy:  opts.Strategy,
-		WithPrune: opts.WithPrune,
+		Summarize:         opts.Summarize,
+		Strategy:          opts.Strategy,
+		WithPrune:         opts.WithPrune,
+		IncludeNamespaces: opts.IncludeNamespaces,
 	})
 }
 
@@ -152,7 +155,7 @@ func Delete(baseDir string, opts DeleteOpts) error {
 
 	// show diff
 	// static differ will never fail and always return something if input is not nil
-	diff, err := kubernetes.StaticDiffer(false)(l.Resources)
+	diff, err := kubernetes.StaticDiffer(false, opts.IncludeNamespaces)(l.Resources)
 
 	if err != nil {
 		fmt.Println("Error diffing:", err)


### PR DESCRIPTION
This is a simple way to safeguard. It would be nice to also clean up empty namespaces as mentioned in #311, but that is
way more elaborate and not sure if Tanka should bother with it.

closes #311, if above has no objections.