### PR TITLE
fix(jsonnet): Restore tk.env

### DIFF
--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -32,6 +32,25 @@ type Opts struct {
 	EvalScript  string
 }
 
+// Clone returns a deep copy of Opts
+func (o Opts) Clone() Opts {
+	var extCode, tlaCode InjectedCode
+	for k, v := range o.ExtCode {
+		extCode[k] = v
+	}
+
+	for k, v := range o.TLACode {
+		tlaCode[k] = v
+	}
+
+	return Opts{
+		TLACode:     tlaCode,
+		ExtCode:     extCode,
+		ImportPaths: append([]string{}, o.ImportPaths...),
+		EvalScript:  o.EvalScript,
+	}
+}
+
 // MakeVM returns a Jsonnet VM with some extensions of Tanka, including:
 // - extended importer
 // - extCode and tlaCode applied

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -87,6 +87,9 @@ func (i *InlineLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environme
 }
 
 func inlineEval(path string, opts JsonnetOpts) (manifest.List, error) {
+	// Can't provide env as extVar, as we need to evaluate Jsonnet first to know it
+	opts.ExtCode.Set(environmentExtCode, `error "Using tk.env and std.extVar('tanka.dev/environment') is only supported for static environments. Directly access this data using standard Jsonnet instead."`)
+
 	raw, err := EvalJsonnet(path, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -14,6 +14,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// environmentExtCode is the extCode ID `tk.env` uses underneath
+// TODO: remove "import tk" and replace it with tanka-util
+const environmentExtCode = spec.APIGroup + "/environment"
+
 // Load loads the Environment at `path`. It automatically detects whether to
 // load inline or statically
 func Load(path string, opts Opts) (*LoadResult, error) {

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -44,6 +44,14 @@ func parallelLoadEnvironments(paths []string, opts parallelOpts) ([]*v1alpha1.En
 
 	for name, path := range list {
 		o := opts.Opts
+
+		// TODO: This is required because the map[string]string in here is not
+		// concurrency-safe. Instead of putting this burden on the caller, find
+		// a way to handle this inside the jsonnet package. A possible way would
+		// be to make the jsonnet package less general, more tightly coupling it
+		// to Tanka workflow thus being able to handle such cases
+		o.JsonnetOpts = o.JsonnetOpts.Clone()
+
 		o.Name = name
 		jobsCh <- parallelJob{
 			path: path,

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -18,6 +18,12 @@ func (s StaticLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment,
 		return nil, err
 	}
 
+	envCode, err := specToExtCode(*config)
+	if err != nil {
+		return nil, err
+	}
+	opts.ExtCode.Set(environmentExtCode, envCode)
+
 	data, err := EvalJsonnet(path, opts.JsonnetOpts)
 	if err != nil {
 		return nil, err
@@ -46,6 +52,16 @@ func (s StaticLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environmen
 	}
 
 	return []*v1alpha1.Environment{env}, nil
+}
+
+func specToExtCode(spec v1alpha1.Environment) (string, error) {
+	spec.Data = nil
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
 }
 
 // parseStaticSpec parses the `spec.json` of the environment and returns a


### PR DESCRIPTION
In a recent refactor (https://github.com/grafana/tanka/pull/459) we lost `tk.env` respectivley
`std.extVar("tanka.dev/environment")` support.

For static environment this however is still the way to go for accessing
env data from within Jsonnet.

This PR restores the functionality and also makes Tanka properly fail
with a message when attempting to use `tk.env` from an inline environment

Fixes #480 