### PR TITLE
doc: improve --target help

### DIFF
--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -19,8 +19,8 @@ type workflowFlagVars struct {
 
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
-	fs.StringVar(&v.name, "name", "", "selects an environment from inline environments")
-	fs.StringSliceVarP(&v.targets, "target", "t", nil, "only use the specified objects (Format: <type>/<name>)")
+	fs.StringVar(&v.name, "name", "", "Selects an environment from inline environments")
+	fs.StringSliceVarP(&v.targets, "target", "t", nil, "Regex filter on '<kind>/<name>'. See https://tanka.dev/output-filtering")
 	return &v
 }
 


### PR DESCRIPTION
Changes the help message of --target / -t so that it reflects the
accurate format and the fact it uses regex.

Fixes #452 

/cc @ghostsquad