### PR TITLE
fix(jsonnet): EvalJsonnet through Loader interface

### DIFF
--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -11,7 +11,7 @@ import (
 )
 
 // EvalJsonnet evaluates the jsonnet environment at the given file system path
-func EvalJsonnet(path string, opts jsonnet.Opts) (raw string, err error) {
+func evalJsonnet(path string, opts jsonnet.Opts) (raw string, err error) {
 	entrypoint, err := jpath.Entrypoint(path)
 	if err != nil {
 		return "", err

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -22,7 +22,7 @@ func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment
 		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
 	}
 
-	data, err := i.EvalJsonnet(path, opts)
+	data, err := i.Eval(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (i *InlineLoader) Peek(path string, opts LoaderOpts) (*v1alpha1.Environment
 
 func (i *InlineLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error) {
 	opts.JsonnetOpts.EvalScript = MetadataEvalScript
-	data, err := i.EvalJsonnet(path, opts)
+	data, err := i.Eval(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (i *InlineLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environme
 	return envs, nil
 }
 
-func (i *InlineLoader) EvalJsonnet(path string, opts LoaderOpts) (interface{}, error) {
+func (i *InlineLoader) Eval(path string, opts LoaderOpts) (interface{}, error) {
 	// Can't provide env as extVar, as we need to evaluate Jsonnet first to know it
 	opts.ExtCode.Set(environmentExtCode, `error "Using tk.env and std.extVar('tanka.dev/environment') is only supported for static environments. Directly access this data using standard Jsonnet instead."`)
 

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -84,14 +84,14 @@ func List(path string, opts Opts) ([]*v1alpha1.Environment, error) {
 	return loader.List(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
 }
 
-// EvalJsonnet returns the raw evaluated Jsonnet
-func EvalJsonnet(path string, opts Opts) (interface{}, error) {
+// Eval returns the raw evaluated Jsonnet
+func Eval(path string, opts Opts) (interface{}, error) {
 	loader, err := DetectLoader(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return loader.EvalJsonnet(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
+	return loader.Eval(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
 }
 
 // DetectLoader detects whether the environment is inline or static and picks
@@ -125,8 +125,8 @@ type Loader interface {
 	// loaded
 	List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error)
 
-	// EvalJsonnet returns the raw evaluated Jsonnet
-	EvalJsonnet(path string, opts LoaderOpts) (interface{}, error)
+	// Eval returns the raw evaluated Jsonnet
+	Eval(path string, opts LoaderOpts) (interface{}, error)
 }
 
 type LoaderOpts struct {

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -84,6 +84,16 @@ func List(path string, opts Opts) ([]*v1alpha1.Environment, error) {
 	return loader.List(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
 }
 
+// EvalJsonnet returns the raw evaluated Jsonnet
+func EvalJsonnet(path string, opts Opts) (interface{}, error) {
+	loader, err := DetectLoader(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return loader.EvalJsonnet(path, LoaderOpts{opts.JsonnetOpts, opts.Name})
+}
+
 // DetectLoader detects whether the environment is inline or static and picks
 // the approriate loader
 func DetectLoader(path string) (Loader, error) {
@@ -114,6 +124,9 @@ type Loader interface {
 	// List returns metadata of all possible environments at path that can be
 	// loaded
 	List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error)
+
+	// EvalJsonnet returns the raw evaluated Jsonnet
+	EvalJsonnet(path string, opts LoaderOpts) (interface{}, error)
 }
 
 type LoaderOpts struct {

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -18,7 +18,7 @@ func (s StaticLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment,
 		return nil, err
 	}
 
-	data, err := s.EvalJsonnet(path, opts)
+	data, err := s.Eval(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (s StaticLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environmen
 	return []*v1alpha1.Environment{env}, nil
 }
 
-func (s *StaticLoader) EvalJsonnet(path string, opts LoaderOpts) (interface{}, error) {
+func (s *StaticLoader) Eval(path string, opts LoaderOpts) (interface{}, error) {
 	config, err := s.Peek(path, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -1,7 +1,6 @@
 package tanka
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/fatih/color"
@@ -188,13 +187,8 @@ func Show(baseDir string, opts Opts) (manifest.List, error) {
 
 // Eval returns the raw evaluated Jsonnet output (without any transformations)
 func Eval(dir string, opts Opts) (interface{}, error) {
-	raw, err := EvalJsonnet(dir, opts.JsonnetOpts)
+	data, err := EvalJsonnet(dir, opts)
 	if err != nil {
-		return nil, err
-	}
-
-	var data interface{}
-	if err := json.Unmarshal([]byte(raw), &data); err != nil {
 		return nil, err
 	}
 

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -184,13 +184,3 @@ func Show(baseDir string, opts Opts) (manifest.List, error) {
 
 	return l.Resources, nil
 }
-
-// Eval returns the raw evaluated Jsonnet output (without any transformations)
-func Eval(dir string, opts Opts) (interface{}, error) {
-	data, err := EvalJsonnet(dir, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}


### PR DESCRIPTION
To run `tk eval`, we also need to handle `import "tk"` and related. As this behavior is specific to the Loader, it seems to make sense to use the Loader interface for this.

Fixes #480 again. :)