### PR TITLE
Add --inject-labels to `tk env add/set`

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -83,16 +83,20 @@ func envSetCmd() *cli.Command {
 		}
 
 		if tmp.Spec.APIServer != "" && tmp.Spec.APIServer != cfg.Spec.APIServer {
-			fmt.Printf("updated spec.apiServer (`%s -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)
+			fmt.Printf("updated spec.apiServer (`%s` -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)
 			cfg.Spec.APIServer = tmp.Spec.APIServer
 		}
 		if tmp.Spec.Namespace != "" && tmp.Spec.Namespace != cfg.Spec.Namespace {
-			fmt.Printf("updated spec.namespace (`%s -> `%s`)\n", cfg.Spec.Namespace, tmp.Spec.Namespace)
+			fmt.Printf("updated spec.namespace (`%s` -> `%s`)\n", cfg.Spec.Namespace, tmp.Spec.Namespace)
 			cfg.Spec.Namespace = tmp.Spec.Namespace
 		}
 		if tmp.Spec.DiffStrategy != "" && tmp.Spec.DiffStrategy != cfg.Spec.DiffStrategy {
-			fmt.Printf("updated spec.diffStrategy (`%s -> `%s`)\n", cfg.Spec.DiffStrategy, tmp.Spec.DiffStrategy)
+			fmt.Printf("updated spec.diffStrategy (`%s` -> `%s`)\n", cfg.Spec.DiffStrategy, tmp.Spec.DiffStrategy)
 			cfg.Spec.DiffStrategy = tmp.Spec.DiffStrategy
+		}
+		if tmp.Spec.InjectLabels != cfg.Spec.InjectLabels {
+			fmt.Printf("updated spec.injectLabels (`%t` -> `%t`)\n", cfg.Spec.InjectLabels, tmp.Spec.InjectLabels)
+			cfg.Spec.InjectLabels = tmp.Spec.InjectLabels
 		}
 
 		if err := writeJSON(cfg, filepath.Join(path, "spec.json")); err != nil {

--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -90,4 +90,5 @@ func envSettingsFlags(env *v1alpha1.Environment, fs *pflag.FlagSet) {
 	fs.StringVar(&env.Spec.APIServer, "server-from-context", env.Spec.APIServer, "set the server to a known one from $KUBECONFIG")
 	fs.StringVar(&env.Spec.Namespace, "namespace", env.Spec.Namespace, "namespace to create objects in")
 	fs.StringVar(&env.Spec.DiffStrategy, "diff-strategy", env.Spec.DiffStrategy, "specify diff-strategy. Automatically detected otherwise.")
+	fs.BoolVar(&env.Spec.InjectLabels, "inject-labels", env.Spec.InjectLabels, "add tanka environment label to each created resource. Required for `tk prune`.")
 }


### PR DESCRIPTION
Implements: https://github.com/grafana/tanka/issues/504

Plus fixes minor errors in `tk env set` output.