### PR TITLE
Remove `helm repo update`

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -91,11 +91,6 @@ func (c Charts) Vendor() error {
 		return err
 	}
 
-	log.Println("Syncing Repositories ...")
-	if err := c.Helm.RepoUpdate(Opts{Repositories: c.Manifest.Repositories}); err != nil {
-		return err
-	}
-
 	log.Println("Pulling Charts ...")
 	for _, r := range c.Manifest.Requires {
 		chartName := parseReqName(r.Chart)

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -1,9 +1,7 @@
 package helm
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -15,9 +13,6 @@ import (
 type Helm interface {
 	// Pull downloads a Helm Chart from a remote
 	Pull(chart, version string, opts PullOpts) error
-
-	// RepoUpdate fetches the latest remote index
-	RepoUpdate(opts Opts) error
 
 	// Template returns the individual resources of a Helm Chart
 	Template(name, chart string, opts TemplateOpts) (manifest.List, error)
@@ -55,27 +50,6 @@ func (e ExecHelm) Pull(chart, version string, opts PullOpts) error {
 	)
 
 	return cmd.Run()
-}
-
-// RepoUpdate implements Helm.RepoUpdate
-func (e ExecHelm) RepoUpdate(opts Opts) error {
-	repoFile, err := writeRepoTmpFile(opts.Repositories)
-	if err != nil {
-		return err
-	}
-	defer os.Remove(repoFile)
-
-	cmd := e.cmd("repo", "update",
-		"--repository-config", repoFile,
-	)
-	var errBuf bytes.Buffer
-	cmd.Stderr = &errBuf
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s\n%s", errBuf.String(), err)
-	}
-
-	return nil
 }
 
 // cmd returns a prepared exec.Cmd to use the `helm` binary


### PR DESCRIPTION
It is entirely possible I've missed something important, but I can't figure out why `helm repo update` ever needs to be run by tanka. As far as I can tell, tanka execs helm in 2 contexts: `helm pull`, as part of `tk tool charts vendor`, and `helm template`, as part of rendering jsonnet.

The `helm pull` invocation passes `--repository-config` with a freshly created temporary helm repo file. The `helm repo update` invocation that precedes `helm pull` also passes in `--repository-config`, with a _different_ freshly created tempfile, that is never used again.

The `helm template` invocation in pkg/helm/jsonnet.go passes in a local path to the already-vendored chart, and does not interact with remote repositories.

If I'm right, removing this code speeds up `tk tool charts vendor` by removing an unnecessary network call, and if the correct chart versions are already present on the filesystem, no network calls will be made at all, due to the idempotence introduced in https://github.com/grafana/tanka/pull/420. This helps make CI flows that cache/vendor helm charts more reliable.

Draft in case I'm totally wrong about this call being unncessary!