### PR TITLE
Allow inline environments to be pruned

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -60,6 +60,7 @@ func pruneCmd() *cli.Command {
 	var opts tanka.PruneOpts
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	cmd.Flags().StringVar(&opts.Name, "name", "", "Selects an environment from inline environments")
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {

--- a/pkg/spec/v1alpha1/environment.go
+++ b/pkg/spec/v1alpha1/environment.go
@@ -1,6 +1,10 @@
 package v1alpha1
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
 
 // New creates a new Environment object with internal values already set
 func New() *Environment {
@@ -46,7 +50,9 @@ func (m Metadata) Get(label string) (value string) {
 }
 
 func (m Metadata) NameLabel() string {
-	return strings.Replace(m.Name, "/", ".", -1)
+	partsHash := sha256.Sum256([]byte(fmt.Sprintf("%s:%s", m.Name, m.Namespace)))
+	chars := []rune(hex.EncodeToString(partsHash[:]))
+	return string(chars[:48])
 }
 
 // Spec defines Kubernetes properties

--- a/pkg/tanka/load_test.go
+++ b/pkg/tanka/load_test.go
@@ -149,3 +149,8 @@ func TestLoad(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadFailsWhenDuplicateEnv(t *testing.T) {
+	_, err := Load("./testdata/cases/withduplicateenv", Opts{Name: "withenv"})
+	assert.NotNil(t, err)
+}

--- a/pkg/tanka/testdata/cases/withduplicateenv/main.jsonnet
+++ b/pkg/tanka/testdata/cases/withduplicateenv/main.jsonnet
@@ -1,0 +1,34 @@
+{
+  env1: {
+    apiVersion: 'tanka.dev/v1alpha1',
+    kind: 'Environment',
+    metadata: {
+      name: 'withenv',
+    },
+    spec: {
+      apiServer: 'https://localhost',
+      namespace: 'withenv',
+    },
+    data: {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'config' },
+    },
+  },
+  env2: {
+    apiVersion: 'tanka.dev/v1alpha1',
+    kind: 'Environment',
+    metadata: {
+      name: 'withenv',
+    },
+    spec: {
+      apiServer: 'https://localhost',
+      namespace: 'withenv',
+    },
+    data: {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'config' },
+    },
+  },
+}


### PR DESCRIPTION
By adding the name field to the prune flags. This just works due to
environment loading logic being shared across subcommands.

Base NameLabel on both namespace and name. The namespace of inline
environments includes the path on disk, and multiple environments with
the same given name cannot be loaded from the same path on disk, so the
tuple of these 2 fields is guaranteed to be unique.

Use a truncated hash of a combination of these 2 fields to form a label
that is guaranteed to fit in Kubernetes' 63 character limit for label
values.

This fixes a bug in which 2 inline environments with identical
metadata.Name, applied separately from 2 paths on disk to the same
Kubernetes namespace would create resources with identical
`tanka.dev/environment` labels, and so pruning one release would delete
the resources of the other.

When upgrading to this tanka version, environments with
spec.injectLabels=true will show diffs on the `tanka.dev/environment`
label, and prune-diffs will run clean, even if prune-able resources were
previously visible. After applying the label change, the previously
prune-able resources should be prune-able.

Add test case for the "don't load multiple envs" assertion.

Fixes https://github.com/grafana/tanka/issues/510