### PR TITLE
fix(cli): Do not silently fail on find/List

### DIFF
--- a/cmd/tk/args.go
+++ b/cmd/tk/args.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -24,8 +25,8 @@ var workflowArgs = cli.Args{
 			return nil
 		}
 
-		envs, err := tanka.FindEnvs(pwd, tanka.FindOpts{})
-		if err != nil {
+		envs, _ := tanka.FindEnvs(pwd, tanka.FindOpts{})
+		if err != nil && !errors.As(err, &tanka.ErrParallel{}) {
 			return nil
 		}
 
@@ -42,6 +43,6 @@ var workflowArgs = cli.Args{
 			return reldirs
 		}
 
-		return complete.PredictDirs("*").Predict(args)
+		return complete.PredictFiles("*").Predict(args)
 	}),
 }

--- a/cmd/tk/args.go
+++ b/cmd/tk/args.go
@@ -25,7 +25,7 @@ var workflowArgs = cli.Args{
 			return nil
 		}
 
-		envs, _ := tanka.FindEnvs(pwd, tanka.FindOpts{})
+		envs, err := tanka.FindEnvs(pwd, tanka.FindOpts{})
 		if err != nil && !errors.As(err, &tanka.ErrParallel{}) {
 			return nil
 		}

--- a/pkg/tanka/errors.go
+++ b/pkg/tanka/errors.go
@@ -25,15 +25,15 @@ func (e ErrMultipleEnvs) Error() string {
 	return fmt.Sprintf("found multiple Environments in '%s': \n - %s", e.path, strings.Join(e.names, "\n - "))
 }
 
-// ErrParallel is an array of errors collected while parsing environments in parallel
+// ErrParallel is an array of errors collected while processing in parallel
 type ErrParallel struct {
 	errors []error
 }
 
 func (e ErrParallel) Error() string {
-	returnErr := fmt.Sprintf("Unable to parse selected Environments:\n\n")
+	returnErr := fmt.Sprintf("Errors occured during parallel processing:\n\n")
 	for _, err := range e.errors {
-		returnErr = fmt.Sprintf("%s- %s\n", returnErr, err.Error())
+		returnErr = fmt.Sprintf("%s- %s\n\n", returnErr, err.Error())
 	}
 	return returnErr
 }


### PR DESCRIPTION
On export of inline environments, Tanka would silently exit if the List failed. This catches the error and returns it.