### PR TITLE
fix(tool/imports): add path info to error message

### DIFF
--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -76,7 +76,6 @@ func importsCmd() *cli.Command {
 	}
 
 	check := cmd.Flags().StringP("check", "c", "", "git commit hash to check against")
-	verbose := cmd.Flags().BoolP("verbose", "v", false, "log as imports are walked, to help locate errors")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		var modFiles []string
@@ -102,7 +101,7 @@ func importsCmd() *cli.Command {
 			return fmt.Errorf("The argument must be an environment's directory, but this does not seem to be the case.")
 		}
 
-		deps, err := jsonnet.TransitiveImports(dir, *verbose)
+		deps, err := jsonnet.TransitiveImports(dir)
 		if err != nil {
 			return fmt.Errorf("Resolving imports: %s", err)
 		}

--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -76,6 +76,7 @@ func importsCmd() *cli.Command {
 	}
 
 	check := cmd.Flags().StringP("check", "c", "", "git commit hash to check against")
+	verbose := cmd.Flags().BoolP("verbose", "v", false, "log as imports are walked, to help locate errors")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		var modFiles []string
@@ -101,7 +102,7 @@ func importsCmd() *cli.Command {
 			return fmt.Errorf("The argument must be an environment's directory, but this does not seem to be the case.")
 		}
 
-		deps, err := jsonnet.TransitiveImports(dir)
+		deps, err := jsonnet.TransitiveImports(dir, *verbose)
 		if err != nil {
 			return fmt.Errorf("Resolving imports: %s", err)
 		}

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -89,6 +89,7 @@ func importRecursive(list map[string]bool, vm *jsonnet.VM, node ast.Node, curren
 	// we have an `import`
 	case *ast.Import:
 		p := node.File.Value
+
 		contents, foundAt, err := vm.ImportAST(currentPath, p)
 		if err != nil {
 			return errors.Wrapf(err, "importing %s from %s", p, currentPath)

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -1,6 +1,7 @@
 package jsonnet
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"sort"
@@ -92,7 +93,7 @@ func importRecursive(list map[string]bool, vm *jsonnet.VM, node ast.Node, curren
 
 		contents, foundAt, err := vm.ImportAST(currentPath, p)
 		if err != nil {
-			return errors.Wrapf(err, "importing %s from %s", p, currentPath)
+			return fmt.Errorf("importing '%s' from '%s': %w", p, currentPath, err)
 		}
 
 		abs, _ := filepath.Abs(foundAt)


### PR DESCRIPTION
`tk tool imports` is a really useful tool for identify imports within a Jsonnet codebase.

However, if you use it with a complex codebase, it can report "couldn't load foo/bar.libsonnet" without telling you where it was when it failed. This very minor tweak gives direct feedback as to where the error is facilitating an easy and immediate fix.