### PR TITLE
feat(cli): sort environments by name

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -249,39 +249,18 @@ func envListCmd() *cli.Command {
 		if err != nil {
 			return err
 		}
-
-		envNames := []string{}
-		for _, env := range envs {
-			envNames = append(envNames, env.Metadata.Name)
-		}
-		sort.Strings(envNames)
+		sort.Slice(envs, func(i, j int) bool { return envs[i].Metadata.Name < envs[j].Metadata.Name })
 
 		if *useJSON {
-			// sort environments by name for consistent output
-			sorted := make([]*v1alpha1.Environment, 0, len(envs))
-			for _, name := range envNames {
-				index := 0
-				todo := make([]*v1alpha1.Environment, 0, len(envs))
-				for _, env := range envs {
-					index += 1
-					if env.Metadata.Name == name {
-						sorted = append(sorted, env)
-						break
-					}
-					todo = append(todo, env)
-				}
-				envs = append(todo, envs[index:]...)
-			}
-
-			j, err := json.Marshal(sorted)
+			j, err := json.Marshal(envs)
 			if err != nil {
 				return fmt.Errorf("Formatting as json: %s", err)
 			}
 			fmt.Println(string(j))
 			return nil
 		} else if *useNames {
-			for _, name := range envNames {
-				fmt.Println(name)
+			for _, e := range envs {
+				fmt.Println(e.Metadata.Name)
 			}
 			return nil
 		}

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -249,7 +249,7 @@ func envListCmd() *cli.Command {
 		if err != nil {
 			return err
 		}
-		sort.Slice(envs, func(i, j int) bool { return envs[i].Metadata.Name < envs[j].Metadata.Name })
+		sort.SliceStable(envs, func(i, j int) bool { return envs[i].Metadata.Name < envs[j].Metadata.Name })
 
 		if *useJSON {
 			j, err := json.Marshal(envs)


### PR DESCRIPTION
I'd like to use the output of `tk env list --json` in various places and check if something has changed in the
environments metadata by comparing the output with standard diff tools. Due to the async nature of FindEnvs, the output
is random. This adds a sorting algorithm on that output so they are alphabetically sorted by name so we get consistent
output.