### PR TITLE
feat: support .metadata.generateName (#526)

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -29,7 +29,7 @@ func exportCmd() *cli.Command {
 
 	format := cmd.Flags().String(
 		"format",
-		"{{.apiVersion}}.{{.kind}}-{{.metadata.name}}",
+		"{{.apiVersion}}.{{.kind}}-{{or .metadata.name .metadata.generateName}}",
 		"https://tanka.dev/exporting#filenames",
 	)
 

--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -62,7 +62,7 @@ func (m Manifest) Verify() error {
 		if !o.Get("metadata").IsMSI() {
 			fields["metadata"] = ErrInvalidMap
 		}
-		if !o.Get("metadata.name").IsStr() {
+		if !o.Get("metadata.name").IsStr() && !o.Get("metadata.generateName").IsStr() {
 			fields["metadata.name"] = ErrInvalidStr
 		}
 


### PR DESCRIPTION
Adds support for `tk show` and `tk export` to handle K8s objects that use `.metadata.generateName` instead of `.metadata.name`.

Changes the default format (being backwards compatible) to also support outputting such files with `tk export`.
