### PR TITLE
Only update helm repositories when necessary

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -91,11 +91,7 @@ func (c Charts) Vendor() error {
 		return err
 	}
 
-	log.Println("Syncing Repositories ...")
-	if err := c.Helm.RepoUpdate(Opts{Repositories: c.Manifest.Repositories}); err != nil {
-		return err
-	}
-
+	repositoriesUpdated := false
 	log.Println("Pulling Charts ...")
 	for _, r := range c.Manifest.Requires {
 		chartName := parseReqName(r.Chart)
@@ -126,6 +122,13 @@ func (c Charts) Vendor() error {
 			return err
 		}
 
+		if !repositoriesUpdated {
+			log.Println("Syncing Repositories ...")
+			if err := c.Helm.RepoUpdate(Opts{Repositories: c.Manifest.Repositories}); err != nil {
+				return err
+			}
+			repositoriesUpdated = true
+		}
 		err = c.Helm.Pull(r.Chart, r.Version.String(), PullOpts{
 			Destination: dir,
 			Opts:        Opts{Repositories: c.Manifest.Repositories},


### PR DESCRIPTION
We currently run `helm repo update` every time we run `tk tool charts
vendor`. Some tanka users may check in their charts directory to avoid
many network calls to helm repositories in CI, which can be flaky. By
delaying the `helm repo update` call until there is a chart to pull, we
can better support these workflows.

Hopefully a non-broken version of https://github.com/grafana/tanka/pull/507!