### PR TITLE
fix(cli): Split diff and non-diff output

### DIFF
--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -14,7 +14,7 @@ func (k Kubectl) Delete(namespace, kind, name string, opts DeleteOpts) error {
 	}
 
 	cmd := k.ctl("delete", argv...)
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -2,6 +2,7 @@ package tanka
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/fatih/color"
 
@@ -40,7 +41,7 @@ func Prune(baseDir string, opts PruneOpts) error {
 	}
 
 	if len(orphaned) == 0 {
-		fmt.Println("Nothing found to prune.")
+		log.Println("Nothing found to prune.")
 		return nil
 	}
 
@@ -61,12 +62,12 @@ func Prune(baseDir string, opts PruneOpts) error {
 		}
 	}
 	if len(namespaces) > 0 {
-		warning := color.New(color.FgHiYellow, color.Bold).PrintFunc()
-		warning("WARNING: This will delete following namespaces and all resources in them:\n")
+		warning := color.New(color.FgHiYellow, color.Bold).FprintfFunc()
+		warning(color.Error, "WARNING: This will delete following namespaces and all resources in them:\n")
 		for _, ns := range namespaces {
-			fmt.Printf(" - %s\n", ns)
+			log.Printf(" - %s\n", ns)
 		}
-		fmt.Println("")
+		log.Println("")
 	}
 
 	// prompt for confirm

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -2,6 +2,7 @@ package tanka
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/fatih/color"
 
@@ -45,7 +46,7 @@ func Apply(baseDir string, opts ApplyOpts) error {
 	switch {
 	case err != nil:
 		// This is not fatal, the diff is not strictly required
-		fmt.Println("Error diffing:", err)
+		log.Println("Error diffing:", err)
 	case diff == nil:
 		tmp := "Warning: There are no differences. Your apply may not do anything at all."
 		diff = &tmp


### PR DESCRIPTION
On commands that produce diffs: diff, apply, and prune.

It is desirable for some use cases to parse diff output from `kubectl
diff` (e.g. secret redaction until
https://github.com/kubernetes/kubernetes/issues/87840 is resolved). This
is a lot easier when diff and non-diff output are not combined on the
same channel, stdout.

This commit moves diagnostic, non-diff output for the 3 relevant
subcommands to stderr.

See https://gitlab.com/gitlab-com/gl-infra/k8s-workloads/tanka-deployments/-/merge_requests/123 for an example of a diff-parsing workflow that would be made easier by this split 🙂.