### PR TITLE
Add "validate" diff strategy

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -107,7 +107,7 @@ func diffCmd() *cli.Command {
 		Short: "differences between the configuration and the cluster",
 		Args:  workflowArgs,
 		Predictors: complete.Flags{
-			"diff-strategy": cli.PredictSet("native", "subset"),
+			"diff-strategy": cli.PredictSet("native", "subset", "validate"),
 		},
 	}
 

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -39,8 +39,9 @@ Tanka's behavior can be customized per Environment using a file called `spec.jso
     // diffStrategy to use. Automatically chosen by default based on
     // the availability of "kubectl diff".
     // - native: uses "kubectl diff". Recommended
+    // - validate: uses "kubectl diff --server-side". Safest, but slower than "native"
     // - subset: fallback for k8s versions below 1.13.0
-    "diffStrategy": "[native, subset]" | default = "auto",
+    "diffStrategy": "[native, validate, subset]" | default = "auto",
 
     // Whether to add a "tanka.dev/environment" label to each created resource.
     // Required for garbage collection ("tk prune").

--- a/docs/docs/diff-strategy.md
+++ b/docs/docs/diff-strategy.md
@@ -21,6 +21,9 @@ You can specify the diff-strategy to use on the command line as well:
 # native
 tk diff --diff-strategy=native .
 
+# validate: Like native but with a server-side validation
+tk diff --diff-strategy=validate .
+
 # subset
 tk diff --diff-strategy=subset .
 ```

--- a/pkg/kubernetes/client/diff.go
+++ b/pkg/kubernetes/client/diff.go
@@ -11,25 +11,49 @@ import (
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
-// DiffServerSide takes the desired state and computes the differences on the
-// server, returning them in `diff(1)` format
+// DiffServerSide takes the desired state and computes the differences, returning them in `diff(1)` format
+// It also validates that manifests are valid server-side
 func (k Kubectl) DiffServerSide(data manifest.List) (*string, error) {
-	cmd := k.ctl("diff", "-f", "-")
+	return k.diff(data, true)
+}
 
-	raw := bytes.Buffer{}
-	cmd.Stdout = &raw
+// DiffClientSide takes the desired state and computes the differences, returning them in `diff(1)` format
+func (k Kubectl) DiffClientSide(data manifest.List) (*string, error) {
+	return k.diff(data, false)
+}
 
+func (k Kubectl) diff(data manifest.List, validate bool) (*string, error) {
 	fw := FilterWriter{filters: []*regexp.Regexp{regexp.MustCompile(`exit status \d`)}}
-	cmd.Stderr = &fw
+	diffCmd := func(serverSide bool) (string, error) {
+		args := []string{"-f", "-"}
+		if serverSide {
+			args = append(args, "--server-side")
+		}
+		cmd := k.ctl("diff", args...)
 
-	cmd.Stdin = strings.NewReader(data.String())
+		raw := bytes.Buffer{}
+		cmd.Stdout = &raw
+		cmd.Stderr = &fw
+		cmd.Stdin = strings.NewReader(data.String())
+		err := cmd.Run()
+		return raw.String(), err
+	}
 
-	err := cmd.Run()
+	if validate {
+		// Running the diff server-side, this checks that the resource definitions are valid
+		// However, it also diffs with server-side kubernetes elements, so it adds in a lot of elements that we shouldn't consider
+		_, err := diffCmd(true)
+		if diffErr := parseDiffErr(err, fw.buf, k.Info().ClientVersion); diffErr != nil {
+			return nil, diffErr
+		}
+	}
+
+	// Running the actual diff without considering server-side elements
+	s, err := diffCmd(false)
 	if diffErr := parseDiffErr(err, fw.buf, k.Info().ClientVersion); diffErr != nil {
 		return nil, diffErr
 	}
 
-	s := raw.String()
 	if s == "" {
 		return nil, nil
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -46,8 +46,9 @@ func New(env v1alpha1.Environment) (*Kubernetes, error) {
 		Env: env,
 		ctl: ctl,
 		differs: map[string]Differ{
-			"native": ctl.DiffServerSide,
-			"subset": SubsetDiffer(ctl),
+			"native":   ctl.DiffClientSide,
+			"validate": ctl.DiffServerSide,
+			"subset":   SubsetDiffer(ctl),
 		},
 	}
 

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -88,7 +88,7 @@ func confirmPrompt(action, namespace string, info client.Info) error {
 type DiffOpts struct {
 	Opts
 
-	// Strategy must be one of "native" or "subset"
+	// Strategy must be one of "native", "validate", or "subset"
 	Strategy string
 	// Summarize prints a summary, instead of the actual diff
 	Summarize bool


### PR DESCRIPTION
Fixes https://github.com/grafana/tanka/issues/332

In the "validate" mode, diff will be called an additional time with "--server-side"
The reason why it's called an additional time is because this argument will add server-only attributes to the diff such as "last-applied-configuration", users probably don't want to see these since they will change on every run
By adding a second diff call that's only use to find errors, we keep the same diff as before but we add an extra validation

Let me know if you think that this solution is adequate. I left the existing "native" mode as the default

I also didn't add any tests, some guidance would be appreciated here. I might be mistaken but there doesn't seem to be any tests around Kubernetes.client.diff, is this because it meant to stay without any logic?