### PR TITLE
Add support for `--no-hooks` switch in Helm template

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -69,6 +69,8 @@ type TemplateOpts struct {
 	IncludeCRDs bool
 	// Namespace scope for this request
 	Namespace string
+	// NoHooks specifies whether hooks should be excluded from the template output
+	NoHooks bool
 }
 
 // Flags returns all options apart from Values as their respective `helm
@@ -83,6 +85,10 @@ func (t TemplateOpts) Flags() []string {
 
 	if t.IncludeCRDs {
 		flags = append(flags, "--include-crds")
+	}
+
+	if t.NoHooks {
+		flags = append(flags, "--no-hooks")
 	}
 
 	if t.Namespace != "" {


### PR DESCRIPTION
This will allow users disabling hooks when rendering manifests from helm templates.

A use-case is, for example, installing Loki on EKS from https://github.com/grafana/helm-charts/tree/main/charts/loki-stack
When running `tk diff` you'll get an error
```
Error from server (BadRequest): admission webhook "iam-for-pods.amazonaws.com" does not support dry run
```
This isn't an issue in Tanka but the scope of this functionality is not limited to it and I think you can very much find use-cases outside of this example.

A potential improvement here could be to allow passing any args to `helm template` maybe using an array without any validation.