### PR TITLE
docs: fix broken link to spec.json Golang source

### DIFF
--- a/docs/docs/directory-structure.md
+++ b/docs/docs/directory-structure.md
@@ -46,7 +46,7 @@ This file configures environment properties such as cluster connection
 (`spec.apiServer`), default namespace (`spec.namespace`), etc.
 
 For the full set of options, see the [Golang source
-code](https://github.com/grafana/tanka/blob/master/pkg/spec/v1alpha1/config.go).
+code](https://github.com/grafana/tanka/blob/master/pkg/spec/v1alpha1/environment.go).
 
 #### main.jsonnet
 


### PR DESCRIPTION
Fix this broken link to the source code that had broken due to a change in
filename in 12f771628078e282a2c39c93e319cdcf1bae103c.