### PR TITLE
Don't fail on listing namespaces

### DIFF
--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -24,6 +24,10 @@ type Client interface {
 
 	// Namespaces the cluster currently has
 	Namespaces() (map[string]bool, error)
+
+	// Namespace retrieves a namespace from the cluster
+	Namespace(namespace string) (manifest.Manifest, error)
+
 	// Resources returns all known api-resources of the cluster
 	Resources() (Resources, error)
 

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"regexp"
 
@@ -77,10 +78,12 @@ func (k Kubectl) Namespaces() (map[string]bool, error) {
 	return namespaces, nil
 }
 
-type ErrNamespaceNotFound struct{}
+type ErrNamespaceNotFound struct {
+	Namespace string
+}
 
 func (e ErrNamespaceNotFound) Error() string {
-	return "Namespace not found"
+	return fmt.Sprintf("Namespace not found: %s", e.Namespace)
 }
 
 // Namespace finds a single namespace in the cluster
@@ -96,7 +99,9 @@ func (k Kubectl) Namespace(namespace string) (manifest.Manifest, error) {
 		return nil, err
 	}
 	if len(sout.Bytes()) == 0 {
-		return nil, ErrNamespaceNotFound{}
+		return nil, ErrNamespaceNotFound{
+			Namespace: namespace,
+		}
 	}
 	var ns manifest.Manifest
 	if err := json.Unmarshal(sout.Bytes(), &ns); err != nil {

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -76,6 +76,26 @@ func (k Kubectl) Namespaces() (map[string]bool, error) {
 	return namespaces, nil
 }
 
+// Namespace finds a single namespace in the cluster
+func (k Kubectl) Namespace(namespace string) (manifest.Manifest, error) {
+	cmd := k.ctl("get", "namespaces", namespace, "-o", "json")
+
+	var sout bytes.Buffer
+	cmd.Stdout = &sout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	var ns manifest.Manifest
+	if err := json.Unmarshal(sout.Bytes(), &ns); err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
 // FilterWriter is an io.Writer that discards every message that matches at
 // least one of the regular expressions.
 type FilterWriter struct {

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -51,12 +51,13 @@ func (k Kubectl) Namespaces() (map[string]bool, error) {
 	cmd := k.ctl("get", "namespaces", "-o", "json")
 
 	var sout bytes.Buffer
+	var serr bytes.Buffer
 	cmd.Stdout = &sout
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = &serr
 
 	err := cmd.Run()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, string(serr.Bytes()))
 	}
 
 	var list manifest.Manifest

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -28,7 +28,7 @@ Please upgrade kubectl to at least version 1.18.1.`)
 		for _, namespace := range resourceNamespaces {
 			_, err = k.ctl.Namespace(namespace)
 			if err != nil {
-				if errors.Is(err, client.ErrNamespaceNotFound{}) {
+				if errors.As(err, client.ErrNamespaceNotFound{}) {
 					continue
 				}
 				return nil, errors.Wrap(err, "retrieving namespaces")

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -22,7 +22,7 @@ Please upgrade kubectl to at least version 1.18.1.`)
 
 	// required for separating
 	namespaces, err := k.ctl.Namespaces()
-	if err != nil || err == nil {
+	if err != nil {
 		resourceNamespaces := findNamespaces(state)
 		namespaces = map[string]bool{}
 		for namespace := range resourceNamespaces {

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -22,10 +22,10 @@ Please upgrade kubectl to at least version 1.18.1.`)
 
 	// required for separating
 	namespaces, err := k.ctl.Namespaces()
-	if err != nil {
-		resourceNamespaces := findNamespaces(state)
+	if err != nil || err == nil {
+		resourceNamespaces := state.Namespaces()
 		namespaces = map[string]bool{}
-		for namespace := range resourceNamespaces {
+		for _, namespace := range resourceNamespaces {
 			_, err = k.ctl.Namespace(namespace)
 			if err != nil {
 				if errors.Is(err, client.ErrNamespaceNotFound{}) {
@@ -219,14 +219,4 @@ func (m multiDiff) diff() (*string, error) {
 		return nil, nil
 	}
 	return &diff, nil
-}
-
-func findNamespaces(state manifest.List) map[string]bool {
-	namespaces := map[string]bool{}
-	for _, m := range state {
-		if namespace := m.Metadata().Namespace(); namespace != "" {
-			namespaces[namespace] = true
-		}
-	}
-	return namespaces
 }

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -22,7 +22,7 @@ Please upgrade kubectl to at least version 1.18.1.`)
 
 	// required for separating
 	namespaces, err := k.ctl.Namespaces()
-	if err != nil || err == nil {
+	if err != nil {
 		resourceNamespaces := state.Namespaces()
 		namespaces = map[string]bool{}
 		for _, namespace := range resourceNamespaces {

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -28,6 +28,9 @@ Please upgrade kubectl to at least version 1.18.1.`)
 		for namespace := range resourceNamespaces {
 			_, err = k.ctl.Namespace(namespace)
 			if err != nil {
+				if errors.Is(err, client.ErrNamespaceNotFound{}) {
+					continue
+				}
 				return nil, errors.Wrap(err, "retrieving namespaces")
 			}
 			namespaces[namespace] = true
@@ -222,7 +225,7 @@ func findNamespaces(state manifest.List) map[string]bool {
 	namespaces := map[string]bool{}
 	for _, m := range state {
 		if namespace := m.Metadata().Namespace(); namespace != "" {
-			namespaces[m.Metadata().Namespace()] = true
+			namespaces[namespace] = true
 		}
 	}
 	return namespaces

--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -221,7 +221,7 @@ func (m multiDiff) diff() (*string, error) {
 func findNamespaces(state manifest.List) map[string]bool {
 	namespaces := map[string]bool{}
 	for _, m := range state {
-		if m.Metadata().HasNamespace() {
+		if namespace := m.Metadata().Namespace(); namespace != "" {
 			namespaces[m.Metadata().Namespace()] = true
 		}
 	}

--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -263,6 +263,20 @@ func (m List) String() string {
 	return buf.String()
 }
 
+func (m List) Namespaces() []string {
+	namespaces := map[string]struct{}{}
+	for _, manifest := range m {
+		if namespace := manifest.Metadata().Namespace(); namespace != "" {
+			namespaces[namespace] = struct{}{}
+		}
+	}
+	keys := []string{}
+	for k := range namespaces {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 func m2o(m interface{}) objx.Map {
 	switch mm := m.(type) {
 	case Metadata:


### PR DESCRIPTION
Fixes #301.

If we don't have permission to list namespaces, take a (potentially) slower approach, filter
out the namespaces that are referenced in the resources, and check each of those in turn.

These can then be used to identify whether a diff will break, as before.
