### PR TITLE
fix(docs): typo in faq

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -39,7 +39,7 @@ available** and are not likely to be ever added.
 Tanka development has started at the time when kubecfg was a part of
 already-deprecated `ksonnet` project. Although these projects are similar, Tanka
 aims to provide continuity for `ksonnet` users, whereas `kubecfg` is (according
-to the project's [README.md](https://github.com/bitnami/kubecfg/blob/master/README.md)
+to the project's [README.md](https://github.com/bitnami/kubecfg/blob/master/README.md))
 really just a thin Kubernetes-specific wrapper around jsonnet evaluation.
 
 ## Why not Helm?


### PR DESCRIPTION
Adding a missing `)` in the `What about kubecfg ?` section of the FAQ