### PR TITLE
perf(export): only call FindEnvs once

### DIFF
--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -43,7 +43,7 @@ type ExportEnvOpts struct {
 	Parallelism int
 }
 
-func ExportEnvironments(paths []string, to string, opts *ExportEnvOpts) error {
+func ExportEnvironments(paths map[string]string, to string, opts *ExportEnvOpts) error {
 	// Keep track of which file maps to which environment
 	fileToEnv := map[string]string{}
 

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
 
 // BelRune is a string of the Ascii character BEL which made computers ring in ancient times
@@ -43,7 +44,7 @@ type ExportEnvOpts struct {
 	Parallelism int
 }
 
-func ExportEnvironments(paths map[string]string, to string, opts *ExportEnvOpts) error {
+func ExportEnvironments(envs []*v1alpha1.Environment, to string, opts *ExportEnvOpts) error {
 	// Keep track of which file maps to which environment
 	fileToEnv := map[string]string{}
 
@@ -57,7 +58,7 @@ func ExportEnvironments(paths map[string]string, to string, opts *ExportEnvOpts)
 	}
 
 	// get all environments for paths
-	envs, err := parallelLoadEnvironments(paths, parallelOpts{
+	loadedEnvs, err := parallelLoadEnvironments(envs, parallelOpts{
 		Opts:        opts.Opts,
 		Selector:    opts.Selector,
 		Parallelism: opts.Parallelism,
@@ -66,7 +67,7 @@ func ExportEnvironments(paths map[string]string, to string, opts *ExportEnvOpts)
 		return err
 	}
 
-	for _, env := range envs {
+	for _, env := range loadedEnvs {
 		// get the manifests
 		loaded, err := LoadManifests(env, opts.Opts.Filters)
 		if err != nil {

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -3,10 +3,13 @@ package tanka
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+	"github.com/pkg/errors"
 )
 
 const defaultParallelism = 8
@@ -18,9 +21,9 @@ type parallelOpts struct {
 }
 
 // parallelLoadEnvironments evaluates multiple environments in parallel
-func parallelLoadEnvironments(paths map[string]string, opts parallelOpts) ([]*v1alpha1.Environment, error) {
+func parallelLoadEnvironments(envs []*v1alpha1.Environment, opts parallelOpts) ([]*v1alpha1.Environment, error) {
 	jobsCh := make(chan parallelJob)
-	outCh := make(chan parallelOut, len(paths))
+	outCh := make(chan parallelOut, len(envs))
 
 	if opts.Parallelism <= 0 {
 		opts.Parallelism = defaultParallelism
@@ -30,7 +33,7 @@ func parallelLoadEnvironments(paths map[string]string, opts parallelOpts) ([]*v1
 		go parallelWorker(jobsCh, outCh)
 	}
 
-	for name, path := range paths {
+	for _, env := range envs {
 		o := opts.Opts
 
 		// TODO: This is required because the map[string]string in here is not
@@ -40,32 +43,37 @@ func parallelLoadEnvironments(paths map[string]string, opts parallelOpts) ([]*v1
 		// to Tanka workflow thus being able to handle such cases
 		o.JsonnetOpts = o.JsonnetOpts.Clone()
 
-		o.Name = name
+		o.Name = env.Metadata.Name
+		path := env.Metadata.Namespace
+		rootDir, err := jpath.FindRoot(path)
+		if err != nil {
+			return nil, errors.Wrap(err, "finding root")
+		}
 		jobsCh <- parallelJob{
-			path: path,
+			path: filepath.Join(rootDir, path),
 			opts: o,
 		}
 	}
 	close(jobsCh)
 
-	var envs []*v1alpha1.Environment
+	var outenvs []*v1alpha1.Environment
 	var errors []error
-	for i := 0; i < len(paths); i++ {
+	for i := 0; i < len(envs); i++ {
 		out := <-outCh
 		if out.err != nil {
 			errors = append(errors, out.err)
 			continue
 		}
 		if opts.Selector == nil || opts.Selector.Empty() || opts.Selector.Matches(out.env.Metadata) {
-			envs = append(envs, out.env)
+			outenvs = append(outenvs, out.env)
 		}
 	}
 
 	if len(errors) != 0 {
-		return envs, ErrParallel{errors: errors}
+		return outenvs, ErrParallel{errors: errors}
 	}
 
-	return envs, nil
+	return outenvs, nil
 }
 
 type parallelJob struct {


### PR DESCRIPTION
On the internal Grafana Labs jsonnet code base, this can improve the performance of the export significantly. Tests on my local
machine went from 2m08s to 1m32s.