### PR TITLE
Fetch tags on docker builds

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -39,6 +39,7 @@ local docker(arch) = pipeline('docker-' + arch) {
     arch: arch,
   },
   steps: [
+    go('fetch-tags', ['git fetch origin --tags']),
     make('static'),
     {
       name: 'container',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -70,9 +70,9 @@ steps:
     api_key:
       from_secret: GITHUB_TOKEN
     draft: true
-    files: "dist/*"
+    files: dist/*
     note: "This is release ${DRONE_TAG} of Tanka (`tk`). Check out the [CHANGELOG](CHANGELOG.md) for detailed release notes.\n## Install instructions\n\n#### Binary:\n```bash\n# download the binary (adapt os and arch as needed)\n$ curl -fSL -o \"/usr/local/bin/tk\" \"https://github.com/grafana/tanka/releases/download/${DRONE_TAG}/tk-linux-amd64\"\n\n# make it executable\n$ chmod a+x \"/usr/local/bin/tk\"\n\n# have fun :)\n$ tk --help\n```\n\n#### Docker container:\nhttps://hub.docker.com/r/grafana/tanka\n```bash\n$ docker pull grafana/tanka:${DRONE_TAG#v}\n```\n"
-    title: "${DRONE_TAG}"
+    title: ${DRONE_TAG}
 
 volumes:
 - name: gopath
@@ -94,6 +94,14 @@ platform:
   arch: amd64
 
 steps:
+- name: fetch-tags
+  image: golang:1.15
+  commands:
+  - git fetch origin --tags
+  volumes:
+  - name: gopath
+    path: /go
+
 - name: static
   image: golang:1.15
   commands:
@@ -121,7 +129,7 @@ trigger:
   ref:
   - refs/heads/master
   - refs/heads/docker
-  - "refs/tags/v*"
+  - refs/tags/v*
 
 depends_on:
 - check
@@ -135,6 +143,14 @@ platform:
   arch: arm
 
 steps:
+- name: fetch-tags
+  image: golang:1.15
+  commands:
+  - git fetch origin --tags
+  volumes:
+  - name: gopath
+    path: /go
+
 - name: static
   image: golang:1.15
   commands:
@@ -162,7 +178,7 @@ trigger:
   ref:
   - refs/heads/master
   - refs/heads/docker
-  - "refs/tags/v*"
+  - refs/tags/v*
 
 depends_on:
 - check
@@ -176,6 +192,14 @@ platform:
   arch: arm64
 
 steps:
+- name: fetch-tags
+  image: golang:1.15
+  commands:
+  - git fetch origin --tags
+  volumes:
+  - name: gopath
+    path: /go
+
 - name: static
   image: golang:1.15
   commands:
@@ -203,7 +227,7 @@ trigger:
   ref:
   - refs/heads/master
   - refs/heads/docker
-  - "refs/tags/v*"
+  - refs/tags/v*
 
 depends_on:
 - check
@@ -236,7 +260,7 @@ trigger:
   ref:
   - refs/heads/master
   - refs/heads/docker
-  - "refs/tags/v*"
+  - refs/tags/v*
 
 depends_on:
 - docker-amd64


### PR DESCRIPTION
Currently, the executables within the docker images have no version

```
➜  ~ docker run --rm -it grafana/tanka:0.15.0 --version
tk version 014fae3
```

By fetching the tags before building the execs, this should be fixed