### PR TITLE
WIP: Use KUBECTL_EXTERNAL_DIFF for static diffs

### DIFF
--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -52,7 +52,12 @@ func Prune(baseDir string, opts PruneOpts) error {
 		// here
 		return err
 	}
-	fmt.Print(term.Colordiff(*diff).String())
+	// in case of non-fatal error diff may be nil
+	if diff != nil {
+		fmt.Print(term.Colordiff(*diff).String())
+	} else {
+		fmt.Print("<no error but also no diff - this should not happen>\n")
+	}
 
 	// print namespace removal warning
 	namespaces := []string{}


### PR DESCRIPTION
Kubectl diff uses `KUBECTL_EXTERNAL_COMMAND` for diffing when it is set. Tanka uses `kubectl diff` when diffing existing k8s resources. But it uses standard `diff` for newly created or destroyed resources.

For consistency, we want Tanka to respect the `KUBECTL_EXTERNAL_COMMAND` env variable when doing static diffs.

Thread in Grafana Labs Slack: https://grafana.slack.com/archives/CPPEN0KMH/p1619600657038100?thread_ts=1618844404.031100&cid=CPPEN0KMH

-----

Handling of `KUBECTL_EXTERNAL_DIFF` was picked up from `kubectl` itself to achieve the exactly same behavior.
Both Tanka and Kubernetes is released as Apache 2.0 so this should be okay. But IANAL.

------

I wanted to use `kubectl-neat-diff` to test this but it can't accept files as arguments - it expects directories.
I'm not sure if it's a good idea to work around `kubectl-neat-diff` by preparing directories for it in Tanka.
