### PR TITLE
Fix support for multiple --tla-code arguments

### DIFF
--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -21,7 +21,7 @@ func evalJsonnet(path string, opts jsonnet.Opts) (raw string, err error) {
 	if opts.EvalScript != "" {
 		var tla []string
 		for k := range opts.TLACode {
-			tla = append(tla, k)
+			tla = append(tla, k+"="+k)
 		}
 		evalScript := fmt.Sprintf(`
   local main = (import '%s');

--- a/pkg/tanka/evaluators_test.go
+++ b/pkg/tanka/evaluators_test.go
@@ -1,0 +1,33 @@
+package tanka
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/tanka/pkg/jsonnet"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvalJsonnet(t *testing.T) {
+	var tlaCode jsonnet.InjectedCode
+	// Pass in the mandatory parameters as TLA codes, but note that only `foo`
+	// contains `data`, which is a valid key inside the `o` object defined in
+	// testdata/cases/withtlas/main.jsonnet. If they are passed as positional
+	// parameters, then their names are ignored, which will lead to arbitrary
+	// failures because the order in which they're passed is random.
+	// `evalJsonnet` has been updated to pass them as named parameters.
+	tlaCode.Set("foo", "'data'")
+	tlaCode.Set("bar", "'kaboom'")
+	tlaCode.Set("baz", "'kaboom'")
+
+	opts := jsonnet.Opts{
+		EvalScript: "main",
+		TLACode:    tlaCode,
+	}
+
+	// This will fail intermittently if TLAs are passed as positional
+	// parameters.
+	json, err := evalJsonnet("testdata/cases/withtlas", opts)
+	assert.NoError(t, err)
+	assert.Equal(t, `"foovalue"`, strings.TrimSpace(json))
+}

--- a/pkg/tanka/testdata/cases/withtlas/main.jsonnet
+++ b/pkg/tanka/testdata/cases/withtlas/main.jsonnet
@@ -1,0 +1,5 @@
+local o = {
+  data: 'foovalue',
+};
+
+function(foo, bar, baz) o[foo]


### PR DESCRIPTION
While running the `tk apply` command with multiple `--tla-code` arguments, each containing a `key='value'` parameter, I noticed that the JSONNET code would not receive them correctly. More specifically, instead of being passed as named parameters, they are passed as positional parameters and since they're stored in a [`jsonnet.InjectedCode`](https://github.com/grafana/tanka/blob/17da685bbff3baee75e529b13c19d8f047015395/pkg/jsonnet/eval.go#L16) map, they end up being serialised in an arbitrary order which differs each time Tanka is run. I added a test in this PR which highlights this issue (you might need to run it multiple times to get a failure).

Note that this issue only surfaces when using multiple `--tla-code` args when calling `tk apply`.

I am rather new to this tool, so I'm not fully aware of all the ways in which people use the `--tla-code` argument. Please let me know if I missed any other edge cases.