### PR TITLE
fix(helm): Pass multiple --api-versions flags to Helm 

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 	"github.com/pkg/errors"
@@ -78,8 +77,7 @@ type TemplateOpts struct {
 func (t TemplateOpts) Flags() []string {
 	var flags []string
 
-	if t.APIVersions != nil {
-		value := strings.Join(t.APIVersions, ",")
+	for _, value := range t.APIVersions {
 		flags = append(flags, "--api-versions="+value)
 	}
 


### PR DESCRIPTION
Helm expects the --api-versions flag to be passed for each API, not once with a comma-separated list of APIs.

Fixes #573.