### PR TITLE
feat: Add support to specify `--kube-version` in Helm template

### DIFF
--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -83,6 +83,8 @@ The following options control how the command is invoked:
     includeCrds: true,
     // Equivalent to: --api-versions v1 --api-versions apps/v1
     apiVersions: ['v1', 'apps/v1']
+    // Equivalent to: --kube-version v1.20.0
+    kubeVersion: 'v1.20.0'
     // Equivalent to: --no-hooks
     noHooks: true,
 }

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -67,6 +67,8 @@ type TemplateOpts struct {
 	// IncludeCRDs specifies whether CustomResourceDefinitions are included in
 	// the template output
 	IncludeCRDs bool
+	// Kubernetes version used for Capabilities.KubeVersion
+	KubeVersion string
 	// Namespace scope for this request
 	Namespace string
 	// NoHooks specifies whether hooks should be excluded from the template output
@@ -85,6 +87,10 @@ func (t TemplateOpts) Flags() []string {
 
 	if t.IncludeCRDs {
 		flags = append(flags, "--include-crds")
+	}
+
+	if t.KubeVersion != "" {
+		flags = append(flags, "--kube-version="+t.KubeVersion)
 	}
 
 	if t.NoHooks {


### PR DESCRIPTION
This PR adds the support to specify a custom Kubernetes version when using `helm` feature. 

It would enable to use  helm charts such as [this](https://github.com/dexidp/helm-charts/blob/master/charts/dex/templates/ingress.yaml#L4)  for older kubernetes version easier. We use  `tk export` in CI (docker). Thus, helm cannot detect server's version and fall back to default built-in. 
As workaround, I downgraded the helm to the version where buit-in KubeVersion matches k8s version of the k8s clusters.
It would be much nicer to define the k8s version natively.
