### PR TITLE
Allow to specify `--k8s=false` for `tk init`

### DIFF
--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -58,12 +58,12 @@ func initCmd() *cli.Command {
 
 		version := *installK8s
 		doInstall, err := strconv.ParseBool(*installK8s)
-		if doInstall && err == nil {
-			// --k8s=true, fallback to default version
-			version = defaultK8sVersion
-		} else {
+		if err != nil {
 			// --k8s=<non-boolean>
 			doInstall = true
+		} else {
+			// --k8s=<boolean>, fallback to default version
+			version = defaultK8sVersion
 		}
 
 		if doInstall {


### PR DESCRIPTION
Preserves compatibility with versions before 0.16.0.

#563 redefined flag as string, to optionally specify the desired k8s version. However only `--k8s=true` and  `--k8s=1.18` work but `--k8s=false` doesn't.