### PR TITLE
Add more context when `extract` fails

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -28,7 +28,7 @@ func Process(cfg v1alpha1.Environment, exprs Matchers) (manifest.List, error) {
 	// Scan for everything that looks like a Kubernetes object
 	extracted, err := Extract(raw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("got an error while extracting env `%s`: %w", cfg.Metadata.Name, err)
 	}
 
 	// Unwrap *List types


### PR DESCRIPTION
In case we're loading lots of files, having the environment is important context