### PR TITLE
fix: Do not remove data

### DIFF
--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -63,7 +63,7 @@ local noDataEnv(object) =
          && std.objectHas(object, 'kind')
       then
         if object.kind == 'Environment'
-        then object { data:: {} }
+        then object { data:: super.data }
         else {}
       else
         std.mapWithKey(
@@ -95,7 +95,7 @@ local singleEnv(object) =
       then
         if object.kind == 'Environment'
         && object.metadata.name == '%s'
-        then object { data:: {} }
+        then object { data:: super.data }
         else {}
       else
         std.mapWithKey(

--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -63,7 +63,7 @@ local noDataEnv(object) =
          && std.objectHas(object, 'kind')
       then
         if object.kind == 'Environment'
-        then object { data:: super.data }
+        then object { data+:: {} }
         else {}
       else
         std.mapWithKey(


### PR DESCRIPTION
It is possible to reference the data object in the environment spec, however this doesn't
work if we remove it. Hiding should be sufficient to get the speed boost from lazy
loading.

The example references `this.data` outside the `data: {}` block, which is perfectly valid although I would discourage that, I'd rather suggest that `data` receives information from the environment it belongs to than the other way around.

Example:

```
local clusterEnvConfig = { namespace: 'a' };
{
  local this = self,
  apiVersion: 'tanka.dev/v1alpha1',
  kind: 'Environment',
  metadata: {
    name: 'environments/my-app/local',
  },
  spec: {
    namespace: this.data.app._config.namespace,
  },
  data: {
    app: { _config:: { namespace: 'b' } } +
         {
           _config+:: clusterEnvConfig,
           app+: {
             _config+:: {
               image: 'localhost:5000/my-app',
             },
           },
         },
  },
}
```

ref: https://github.com/nabadger/tanka-export-issue (reported by @nabadger)