### PR TITLE
Add `tk lint` command

### DIFF
--- a/cmd/tk/lint.go
+++ b/cmd/tk/lint.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/go-clix/cli"
+	"github.com/gobwas/glob"
+	"github.com/posener/complete"
+
+	"github.com/grafana/tanka/pkg/jsonnet"
+)
+
+func lintCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "lint <FILES|DIRECTORIES>",
+		Short: "lint Jsonnet code",
+		Args: cli.Args{
+			Validator: cli.ValidateFunc(func(args []string) error {
+				if len(args) == 0 {
+					return errors.New("at least one file or directory is required")
+				}
+				return nil
+			}),
+			Predictor: complete.PredictFiles("*.*sonnet"),
+		},
+	}
+
+	exclude := cmd.Flags().StringSliceP("exclude", "e", []string{"**/.*", ".*", "**/vendor/**", "vendor/**"}, "globs to exclude")
+	verbose := cmd.Flags().BoolP("verbose", "v", false, "print each checked file")
+
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		globs := make([]glob.Glob, len(*exclude))
+		for i, e := range *exclude {
+			g, err := glob.Compile(e)
+			if err != nil {
+				return err
+			}
+			globs[i] = g
+		}
+
+		return jsonnet.Lint(args, &jsonnet.LintOpts{Excludes: globs, PrintNames: *verbose})
+	}
+
+	return cmd
+}

--- a/cmd/tk/lint.go
+++ b/cmd/tk/lint.go
@@ -26,6 +26,7 @@ func lintCmd() *cli.Command {
 	}
 
 	exclude := cmd.Flags().StringSliceP("exclude", "e", []string{"**/.*", ".*", "**/vendor/**", "vendor/**"}, "globs to exclude")
+	parallelism := cmd.Flags().IntP("parallelism", "n", 4, "amount of workers")
 	verbose := cmd.Flags().BoolP("verbose", "v", false, "print each checked file")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
@@ -38,7 +39,7 @@ func lintCmd() *cli.Command {
 			globs[i] = g
 		}
 
-		return jsonnet.Lint(args, &jsonnet.LintOpts{Excludes: globs, PrintNames: *verbose})
+		return jsonnet.Lint(args, &jsonnet.LintOpts{Excludes: globs, PrintNames: *verbose, Parallelism: *parallelism})
 	}
 
 	return cmd

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -44,6 +44,7 @@ func main() {
 	// jsonnet commands
 	rootCmd.AddCommand(
 		fmtCmd(),
+		lintCmd(),
 		evalCmd(),
 		initCmd(),
 		toolCmd(),

--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -46,7 +46,7 @@ func jpathCmd() *cli.Command {
 			return fmt.Errorf("Resolving JPATH: %s", err)
 		}
 
-		jsonnetpath, base, root, err := jpath.Resolve(entrypoint)
+		jsonnetpath, base, root, err := jpath.Resolve(entrypoint, false)
 		if err != nil {
 			return fmt.Errorf("Resolving JPATH: %s", err)
 		}

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -132,7 +132,7 @@ func evaluateSnippet(evalFunc evalFunc, path, data string, opts Opts) (string, e
 	}
 
 	// Create VM
-	jpath, _, _, err := jpath.Resolve(path)
+	jpath, _, _, err := jpath.Resolve(path, false)
 	if err != nil {
 		return "", errors.Wrap(err, "resolving import paths")
 	}

--- a/pkg/jsonnet/files.go
+++ b/pkg/jsonnet/files.go
@@ -1,0 +1,55 @@
+package jsonnet
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gobwas/glob"
+	"github.com/karrick/godirwalk"
+)
+
+// FindFiles takes a file / directory and finds all Jsonnet files
+func FindFiles(target string, excludes []glob.Glob) ([]string, error) {
+	// if it's a file, don't try to find children
+	fi, err := os.Stat(target)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Mode().IsRegular() {
+		return []string{target}, nil
+	}
+
+	var files []string
+
+	// godirwalk is faster than filepath.Walk, 'cause no os.Stat required
+	err = godirwalk.Walk(target, &godirwalk.Options{
+		Callback: func(rawPath string, de *godirwalk.Dirent) error {
+			// Normalize slashes for Windows
+			path := filepath.ToSlash(rawPath)
+
+			if de.IsDir() {
+				return nil
+			}
+
+			// excluded?
+			for _, g := range excludes {
+				if g.Match(path) {
+					return nil
+				}
+			}
+
+			// only .jsonnet or .libsonnet
+			if ext := filepath.Ext(path); ext == ".jsonnet" || ext == ".libsonnet" {
+				files = append(files, path)
+			}
+			return nil
+		},
+		// faster, no sort required
+		Unsorted: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -40,7 +40,7 @@ func TransitiveImports(dir string) ([]string, error) {
 		return nil, errors.Wrap(err, "opening file")
 	}
 
-	jpath, _, rootDir, err := jpath.Resolve(dir)
+	jpath, _, rootDir, err := jpath.Resolve(dir, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "resolving JPATH")
 	}

--- a/pkg/jsonnet/jpath/dirs_test.go
+++ b/pkg/jsonnet/jpath/dirs_test.go
@@ -188,7 +188,7 @@ func TestFindRoot(t *testing.T) {
 			dir := makeTestdata(t, s.testdata)
 			defer os.RemoveAll(dir)
 
-			_, base, root, err := Resolve(filepath.Join(dir, s.environment))
+			_, base, root, err := Resolve(filepath.Join(dir, s.environment), false)
 			assert.Equal(t, s.err, err)
 
 			if err == nil {

--- a/pkg/jsonnet/jpath/jpath.go
+++ b/pkg/jsonnet/jpath/jpath.go
@@ -14,14 +14,19 @@ const DEFAULT_ENTRYPOINT = "main.jsonnet"
 // It then constructs a jPath with the base directory, vendor/ and lib/.
 // This results in predictable imports, as it doesn't matter whether the user called
 // called the command further down tree or not. A little bit like git.
-func Resolve(path string) (jpath []string, base, root string, err error) {
+func Resolve(path string, allowMissingBase bool) (jpath []string, base, root string, err error) {
 	root, err = FindRoot(path)
 	if err != nil {
 		return nil, "", "", err
 	}
 
 	base, err = FindBase(path, root)
-	if err != nil {
+	if err != nil && allowMissingBase {
+		base, err = FsDir(path)
+		if err != nil {
+			return nil, "", "", err
+		}
+	} else if err != nil {
 		return nil, "", "", err
 	}
 

--- a/pkg/jsonnet/lint.go
+++ b/pkg/jsonnet/lint.go
@@ -7,10 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/gobwas/glob"
-	jsonnet "github.com/google/go-jsonnet"
 	"github.com/google/go-jsonnet/linter"
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
-	"github.com/grafana/tanka/pkg/jsonnet/native"
 	"github.com/pkg/errors"
 )
 
@@ -61,11 +59,7 @@ func Lint(fds []string, opts *LintOpts) error {
 				fmt.Fprintf(buf, "Linting %s...\n", file)
 			}
 
-			vm := jsonnet.MakeVM()
-			for _, nf := range native.Funcs() {
-				vm.NativeFunction(nf)
-			}
-
+			vm := MakeVM(Opts{})
 			jpaths, _, _, err := jpath.Resolve(file, true)
 			if err != nil {
 				fmt.Fprintf(buf, "got an error getting JPATH for %s: %v\n\n", file, err)
@@ -76,7 +70,7 @@ func Lint(fds []string, opts *LintOpts) error {
 			vm.Importer(NewExtendedImporter(jpaths))
 
 			content, _ := ioutil.ReadFile(file)
-			failed := linter.LintSnippet(vm, buf, file, string(content))
+			failed := linter.LintSnippet(vm, buf, []linter.Snippet{{FileName: file, Code: string(content)}})
 			resultCh <- result{failed: failed, output: buf.String()}
 		}
 	}

--- a/pkg/jsonnet/lint.go
+++ b/pkg/jsonnet/lint.go
@@ -56,7 +56,7 @@ func Lint(fds []string, opts *LintOpts) error {
 			}
 
 			if opts.PrintNames {
-				fmt.Fprintf(buf, "Linting %s...\n", file)
+				fmt.Printf("Linting %s...\n", file)
 			}
 
 			vm := MakeVM(Opts{})

--- a/pkg/jsonnet/lint.go
+++ b/pkg/jsonnet/lint.go
@@ -1,0 +1,70 @@
+package jsonnet
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/gobwas/glob"
+	jsonnet "github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/linter"
+	"github.com/grafana/tanka/pkg/jsonnet/jpath"
+	"github.com/grafana/tanka/pkg/jsonnet/native"
+	"github.com/pkg/errors"
+)
+
+// LintOpts modifies the behaviour of Lint
+type LintOpts struct {
+	// Excludes are a list of globs to exclude files while searching for Jsonnet
+	// files
+	Excludes []glob.Glob
+
+	// PrintNames causes all filenames to be printed
+	PrintNames bool
+}
+
+// Lint takes a list of files and directories, processes them and prints
+// out to stderr if there are linting warnings
+func Lint(fds []string, opts *LintOpts) error {
+	vm := jsonnet.MakeVM()
+	for _, nf := range native.Funcs() {
+		vm.NativeFunction(nf)
+	}
+
+	var paths []string
+	for _, f := range fds {
+		fs, err := FindFiles(f, opts.Excludes)
+		if err != nil {
+			return errors.Wrap(err, "finding Jsonnet files")
+		}
+		paths = append(paths, fs...)
+	}
+
+	lintingFailed := false
+	importedDirs := map[string]bool{}
+	for _, file := range paths {
+		if opts.PrintNames {
+			log.Printf("Linting %s...\n", file)
+		}
+
+		dir := filepath.Dir(file)
+		if _, ok := importedDirs[dir]; !ok {
+			jpath, _, _, err := jpath.Resolve(dir)
+			if err != nil {
+				return errors.Wrap(err, "resolving JPATH")
+			}
+
+			vm.Importer(NewExtendedImporter(jpath))
+			importedDirs[dir] = true
+		}
+
+		content, _ := ioutil.ReadFile(file)
+		lintingFailed = lintingFailed || linter.LintSnippet(vm, os.Stderr, file, string(content))
+	}
+
+	if lintingFailed {
+		return errors.New("Linting has failed for at least one file")
+	}
+	return nil
+}

--- a/pkg/jsonnet/lint.go
+++ b/pkg/jsonnet/lint.go
@@ -52,7 +52,7 @@ func Lint(fds []string, opts *LintOpts) error {
 			var err error
 			file, err = filepath.Abs(file)
 			if err != nil {
-				fmt.Fprintf(buf, "got an error get the absolute path for %s: %v", file, err)
+				fmt.Fprintf(buf, "got an error getting the absolute path for %s: %v\n\n", file, err)
 				resultCh <- result{failed: true, output: buf.String()}
 				continue
 			}
@@ -66,15 +66,14 @@ func Lint(fds []string, opts *LintOpts) error {
 				vm.NativeFunction(nf)
 			}
 
-			dir := filepath.Dir(file)
-			jpath, _, _, err := jpath.Resolve(dir)
+			jpaths, _, _, err := jpath.Resolve(file, true)
 			if err != nil {
-				fmt.Fprintf(buf, "got an error resolving JPATH for %s: %v", dir, err)
+				fmt.Fprintf(buf, "got an error getting JPATH for %s: %v\n\n", file, err)
 				resultCh <- result{failed: true, output: buf.String()}
 				continue
 			}
 
-			vm.Importer(NewExtendedImporter(jpath))
+			vm.Importer(NewExtendedImporter(jpaths))
 
 			content, _ := ioutil.ReadFile(file)
 			failed := linter.LintSnippet(vm, buf, file, string(content))


### PR DESCRIPTION
Like `fmt`, this takes a list of dirs/files as argument and evaluates them with the go-jsonnet lint utility
The linting results are directly printed out to stderr
If there are any linting errors, the command exit with status code 1
Closes https://github.com/grafana/tanka/issues/342