### PR TITLE
Fix api-resources table parsing

### DIFF
--- a/pkg/kubernetes/client/resources.go
+++ b/pkg/kubernetes/client/resources.go
@@ -29,7 +29,7 @@ func (r Resources) Namespaced(m manifest.Manifest) bool {
 
 // Resource is a Kubernetes API Resource
 type Resource struct {
-	APIGroup   string `json:"APIGROUP"`
+	APIVersion string `json:"APIVERSION"`
 	Kind       string `json:"KIND"`
 	Name       string `json:"NAME"`
 	Namespaced bool   `json:"NAMESPACED,string"`
@@ -38,7 +38,11 @@ type Resource struct {
 }
 
 func (r Resource) FQN() string {
-	return strings.TrimSuffix(r.Kind+"."+r.APIGroup, ".")
+	apiGroup := ""
+	if pos := strings.Index(r.APIVersion, "/"); pos > 0 {
+		apiGroup = r.APIVersion[0:pos]
+	}
+	return strings.TrimSuffix(r.Name+"."+apiGroup, ".")
 }
 
 // Resources returns all API resources known to the server

--- a/pkg/kubernetes/client/resources.go
+++ b/pkg/kubernetes/client/resources.go
@@ -29,6 +29,7 @@ func (r Resources) Namespaced(m manifest.Manifest) bool {
 
 // Resource is a Kubernetes API Resource
 type Resource struct {
+	APIGroup   string `json:"APIGROUP"`
 	APIVersion string `json:"APIVERSION"`
 	Kind       string `json:"KIND"`
 	Name       string `json:"NAME"`
@@ -39,7 +40,10 @@ type Resource struct {
 
 func (r Resource) FQN() string {
 	apiGroup := ""
-	if pos := strings.Index(r.APIVersion, "/"); pos > 0 {
+	if r.APIGroup != "" {
+		// this is only set in kubectl v1.18 and earlier
+		apiGroup = r.APIGroup
+	} else if pos := strings.Index(r.APIVersion, "/"); pos > 0 {
 		apiGroup = r.APIVersion[0:pos]
 	}
 	return strings.TrimSuffix(r.Name+"."+apiGroup, ".")

--- a/pkg/kubernetes/client/resources_test.go
+++ b/pkg/kubernetes/client/resources_test.go
@@ -20,10 +20,10 @@ func TestUnmarshalTable(t *testing.T) {
 			name: "normal",
 			tbl:  strings.TrimSpace(tblNormal),
 			want: &Resources{
-				{APIGroup: "apps", Name: "Deployment", Namespaced: true},
-				{APIGroup: "networking", Name: "Ingress", Namespaced: true},
-				{APIGroup: "", Name: "Namespace", Namespaced: false},
-				{APIGroup: "extensions", Name: "DaemonSet", Namespaced: true},
+				{APIVersion: "apps/v1", Name: "Deployment", Namespaced: true},
+				{APIVersion: "networking/v1", Name: "Ingress", Namespaced: true},
+				{APIVersion: "v1", Name: "Namespace", Namespaced: false},
+				{APIVersion: "extensions/v1", Name: "DaemonSet", Namespaced: true},
 			},
 			dest: &Resources{},
 		},
@@ -32,7 +32,7 @@ func TestUnmarshalTable(t *testing.T) {
 			tbl:  strings.TrimSpace(tblEmpty),
 			want: &Resources{},
 			dest: &Resources{
-				{APIGroup: "apps", Name: "Deployment", Namespaced: true},
+				{APIVersion: "apps/v1", Name: "Deployment", Namespaced: true},
 			},
 		},
 		{
@@ -57,15 +57,15 @@ func TestUnmarshalTable(t *testing.T) {
 }
 
 var tblNormal = `
-APIGROUP    NAME        NAMESPACED
-apps        Deployment  true
-networking  Ingress     true
-            Namespace   false
-extensions  DaemonSet   true
+APIVERSION     NAME        NAMESPACED
+apps/v1        Deployment  true
+networking/v1  Ingress     true
+v1             Namespace   false
+extensions/v1  DaemonSet   true
 `
 
 var tblEmpty = `
-APIGROUP    NAME        NAMESPACED
+APIVERSION    NAME        NAMESPACED
 `
 
 var tblNoHeader = `

--- a/pkg/kubernetes/client/resources_test.go
+++ b/pkg/kubernetes/client/resources_test.go
@@ -8,22 +8,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func collectFQNs(resIntf interface{}) []string {
+	resPtr, ok := resIntf.(*Resources)
+	if !ok {
+		return nil
+	}
+	res := *resPtr
+	if len(res) == 0 {
+		return nil
+	}
+	out := make([]string, len(res))
+	for pos := range res {
+		out[pos] = res[pos].FQN()
+	}
+	return out
+}
+
 func TestUnmarshalTable(t *testing.T) {
 	cases := []struct {
-		name string
-		tbl  string
-		dest interface{}
-		want interface{}
-		err  error
+		name     string
+		tbl      string
+		dest     interface{}
+		want     interface{}
+		wantFQNs []string
+		err      error
 	}{
 		{
 			name: "normal",
 			tbl:  strings.TrimSpace(tblNormal),
 			want: &Resources{
-				{APIVersion: "apps/v1", Name: "Deployment", Namespaced: true},
-				{APIVersion: "networking/v1", Name: "Ingress", Namespaced: true},
-				{APIVersion: "v1", Name: "Namespace", Namespaced: false},
-				{APIVersion: "extensions/v1", Name: "DaemonSet", Namespaced: true},
+				{APIVersion: "v1", Kind: "Namespace", Name: "namespaces", Shortnames: "ns", Namespaced: false},
+				{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "daemonsets", Shortnames: "ds", Namespaced: true},
+				{APIVersion: "apps/v1", Kind: "Deployment", Name: "deployments", Shortnames: "deploy", Namespaced: true},
+				{APIVersion: "networking.k8s.io/v1", Kind: "Ingress", Name: "ingresses", Shortnames: "ing", Namespaced: true},
+			},
+			wantFQNs: []string{
+				"namespaces",
+				"daemonsets.apps",
+				"deployments.apps",
+				"ingresses.networking.k8s.io",
+			},
+			dest: &Resources{},
+		},
+		{
+			name: "normal-v1.18-and-older",
+			tbl:  strings.TrimSpace(tblNormal1Dot18AndOlder),
+			want: &Resources{
+				{APIGroup: "", Kind: "Namespace", Name: "namespaces", Shortnames: "ns", Namespaced: false},
+				{APIGroup: "apps", Kind: "DaemonSet", Name: "daemonsets", Shortnames: "ds", Namespaced: true},
+				{APIGroup: "apps", Kind: "Deployment", Name: "deployments", Shortnames: "deploy", Namespaced: true},
+				{APIGroup: "networking.k8s.io", Kind: "Ingress", Name: "ingresses", Shortnames: "ing", Namespaced: true},
+			},
+			wantFQNs: []string{
+				"namespaces",
+				"daemonsets.apps",
+				"deployments.apps",
+				"ingresses.networking.k8s.io",
 			},
 			dest: &Resources{},
 		},
@@ -52,16 +92,29 @@ func TestUnmarshalTable(t *testing.T) {
 			err := UnmarshalTable(c.tbl, c.dest)
 			require.Equal(t, c.err, err)
 			assert.Equal(t, c.want, c.dest)
+			assert.Equal(t, c.wantFQNs, collectFQNs(c.dest))
 		})
 	}
 }
 
+// this output was generated with kubectl v1.21.1
+// $ kubectl api-resources | grep -e "Deployment\|DaemonSet\|Namespace\|networking.k8s.io.*Ingress$\|KIND"
 var tblNormal = `
-APIVERSION     NAME        NAMESPACED
-apps/v1        Deployment  true
-networking/v1  Ingress     true
-v1             Namespace   false
-extensions/v1  DaemonSet   true
+NAME                                SHORTNAMES                             APIVERSION                             NAMESPACED   KIND
+namespaces                          ns                                     v1                                     false        Namespace
+daemonsets                          ds                                     apps/v1                                true         DaemonSet
+deployments                         deploy                                 apps/v1                                true         Deployment
+ingresses                           ing                                    networking.k8s.io/v1                   true         Ingress
+`
+
+// this output was generated with kubectl v1.18.10
+// $ kubectl api-resources | grep -e "Deployment\|DaemonSet\|Namespace\|networking.k8s.io.*Ingress$\|KIND"
+var tblNormal1Dot18AndOlder = `
+NAME                                SHORTNAMES                             APIGROUP                       NAMESPACED   KIND
+namespaces                          ns                                                                    false        Namespace
+daemonsets                          ds                                     apps                           true         DaemonSet
+deployments                         deploy                                 apps                           true         Deployment
+ingresses                           ing                                    networking.k8s.io              true         Ingress
 `
 
 var tblEmpty = `

--- a/pkg/kubernetes/diff_test.go
+++ b/pkg/kubernetes/diff_test.go
@@ -111,10 +111,10 @@ func TestSeparate(t *testing.T) {
 	// static set of resources for this test (usually obtained using
 	// `client.Resources()`)
 	staticResources := client.Resources{
-		{APIGroup: "", Kind: "Namespace", Namespaced: false},
-		{APIGroup: "apps/v1", Kind: "Deployment", Namespaced: true},
-		{APIGroup: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Namespaced: false},
-		{APIGroup: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Namespaced: false},
+		{APIVersion: "", Kind: "Namespace", Namespaced: false},
+		{APIVersion: "apps/v1", Kind: "Deployment", Namespaced: true},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Namespaced: false},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Namespaced: false},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
For sometime `tk pruning` fails, as my cluster has overlapping CRD names/mismatching Kind and Name fields . Errors persisted like this:

```
$ tk prune environments/default
fetching UID's .. done 555.50452ms
fetching previously created resources .. Error: error: the server doesn't have a resource type "NetworkAttachmentDefinition"
```

The reason why this was happing was a failed parsing of the `-o wide` table of `kubectl api-resources`: The field `APIGROUP` no longer exists and is now part of `APIVERSION`.