### PR TITLE
Add hint to inline environment error

### DIFF
--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -41,7 +41,7 @@ func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment
 	}
 
 	if len(envs) == 0 {
-		return nil, fmt.Errorf("Found no environments in '%s'", path)
+		return nil, fmt.Errorf("Found no matching environments; run 'tk env list %s' to view available options", path)
 	}
 
 	// TODO: Re-serializing the entire env here. This is horribly inefficient


### PR DESCRIPTION
If I run:

`tk diff --name abc <path>` and the environment does not match exactly, I receive this error:

`Found no environments in <path>`

This is pretty misleading because it indicates that there are no inline environments defined at all, which is evidently not true by running `tk env list <path>`.

I've touched up the wording a bit to give users more of a clue.
In my case I wasn't using the correct environment name (a partial name, as it turned out)