### PR TITLE
Add `--max-stack` jsonnet option

### DIFF
--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -41,11 +41,13 @@ func labelSelectorFlag(fs *pflag.FlagSet) func() labels.Selector {
 
 func jsonnetFlags(fs *pflag.FlagSet) func() tanka.JsonnetOpts {
 	getExtCode, getTLACode := cliCodeParser(fs)
+	maxStack := fs.Int("max-stack", 0, "Jsonnet VM max stack. The default value is the value set in the go-jsonnet library. Increase this if you get: max stack frames exceeded")
 
 	return func() tanka.JsonnetOpts {
 		return tanka.JsonnetOpts{
-			ExtCode: getExtCode(),
-			TLACode: getTLACode(),
+			MaxStack: *maxStack,
+			ExtCode:  getExtCode(),
+			TLACode:  getTLACode(),
 		}
 	}
 }

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -29,6 +29,7 @@ func (i *InjectedCode) Set(key, value string) {
 
 // Opts are additional properties for the Jsonnet VM
 type Opts struct {
+	MaxStack    int
 	ExtCode     InjectedCode
 	TLACode     InjectedCode
 	ImportPaths []string
@@ -89,6 +90,10 @@ func MakeVM(opts Opts) *jsonnet.VM {
 
 	for _, nf := range native.Funcs() {
 		vm.NativeFunction(nf)
+	}
+
+	if opts.MaxStack > 0 {
+		vm.MaxStack = opts.MaxStack
 	}
 
 	return vm


### PR DESCRIPTION
This can be useful, as a debugging option or a permanent fix, when you get `max stack frames exceeded`
Currently, the only way to debug jsonnet failing with that error is to use the jsonnet executable. I'd rather use Tanka :)