### PR TITLE
Add instructions to use `--name` on multiple envs error

### DIFF
--- a/pkg/tanka/errors.go
+++ b/pkg/tanka/errors.go
@@ -22,7 +22,7 @@ type ErrMultipleEnvs struct {
 }
 
 func (e ErrMultipleEnvs) Error() string {
-	return fmt.Sprintf("found multiple Environments in '%s': \n - %s", e.path, strings.Join(e.names, "\n - "))
+	return fmt.Sprintf("found multiple Environments in '%s'. Use `--name` to select a single one: \n - %s", e.path, strings.Join(e.names, "\n - "))
 }
 
 // ErrParallel is an array of errors collected while processing in parallel
@@ -31,7 +31,7 @@ type ErrParallel struct {
 }
 
 func (e ErrParallel) Error() string {
-	returnErr := fmt.Sprintf("Errors occured during parallel processing:\n\n")
+	returnErr := "Errors occurred during parallel processing:\n\n"
 	for _, err := range e.errors {
 		returnErr = fmt.Sprintf("%s- %s\n\n", returnErr, err.Error())
 	}

--- a/pkg/tanka/load_test.go
+++ b/pkg/tanka/load_test.go
@@ -157,11 +157,11 @@ func TestLoadSelectEnvironment(t *testing.T) {
 
 	// Empty options, match all environments
 	_, err = Load("./testdata/cases/multiple-inline-envs", Opts{})
-	assert.EqualError(t, err, "found multiple Environments in './testdata/cases/multiple-inline-envs': \n - project1-env1\n - project1-env2\n - project2-env1")
+	assert.EqualError(t, err, "found multiple Environments in './testdata/cases/multiple-inline-envs'. Use `--name` to select a single one: \n - project1-env1\n - project1-env2\n - project2-env1")
 
 	// Partial match two environments
 	_, err = Load("./testdata/cases/multiple-inline-envs", Opts{Name: "env1"})
-	assert.EqualError(t, err, "found multiple Environments in './testdata/cases/multiple-inline-envs': \n - project1-env1\n - project2-env1")
+	assert.EqualError(t, err, "found multiple Environments in './testdata/cases/multiple-inline-envs'. Use `--name` to select a single one: \n - project1-env1\n - project2-env1")
 
 	// Partial match
 	result, err := Load("./testdata/cases/multiple-inline-envs", Opts{Name: "project2"})


### PR DESCRIPTION
I have gotten asked multiple times from users how to resolve the multiple environments error
Pointing to the `--name` argument should direct users better