### PR TITLE
uses exclude directive instead of replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,11 @@ module github.com/grafana/tanka
 
 go 1.17
 
-// Pin gopkg.in/yaml.v3
-// yaml.v3 should be bumped with care. The new versions change all list indents
-replace gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+// exclude incompatible versions of yaml.v3 required from dependencies
+exclude (
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -24,7 +26,8 @@ require (
 	github.com/thoas/go-funk v0.9.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	// yaml.v3 should be bumped with care. The new versions change all list indents
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	k8s.io/apimachinery v0.22.2
 	sigs.k8s.io/yaml v1.3.0
 )


### PR DESCRIPTION
To select correct version of yaml.v3, we exclude unwanted versions:
(eeeca48fe776, 496545a6307b)

Then issue an explicit go get:
go get -d gopkg.in/yaml.v3@9f266ea9e77c k8s.io/apimachinery@v0.22.2

The result is that the require directive correctly references the wanted
version (9f266ea9e77c).

This will allow consuming modules to get the expected version of
yaml.v3, which would not have been the case if using replace directives.

ref:
https://golang.org/ref/mod#go-mod-file-exclude
https://golang.org/ref/mod#graph-pruning

Note that keeping this dependency in the past adds technical debt, and we should find a solution to the indentation discrepancies. 

closes #629 