### PR TITLE
Add a fallback to inline environment when path doesn't exist

### DIFF
--- a/pkg/tanka/errors.go
+++ b/pkg/tanka/errors.go
@@ -17,12 +17,17 @@ func (e ErrNoEnv) Error() string {
 
 // ErrMultipleEnvs means that the given jsonnet has multiple Environment objects
 type ErrMultipleEnvs struct {
-	path  string
-	names []string
+	path      string
+	givenName string
+	foundEnvs []string
 }
 
 func (e ErrMultipleEnvs) Error() string {
-	return fmt.Sprintf("found multiple Environments in '%s'. Use `--name` to select a single one: \n - %s", e.path, strings.Join(e.names, "\n - "))
+	if e.givenName != "" {
+		return fmt.Sprintf("found multiple Environments in %q matching %q. Provide a more specific name that matches a single one: \n - %s", e.path, e.givenName, strings.Join(e.foundEnvs, "\n - "))
+	}
+
+	return fmt.Sprintf("found multiple Environments in %q. Use `--name` to select a single one: \n - %s", e.path, strings.Join(e.foundEnvs, "\n - "))
 }
 
 // ErrParallel is an array of errors collected while processing in parallel

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -46,7 +46,7 @@ func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment
 		}
 		if len(envs) > 1 {
 			sort.Strings(names)
-			return nil, ErrMultipleEnvs{path, names}
+			return nil, ErrMultipleEnvs{path, opts.Name, names}
 		}
 	}
 

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -2,6 +2,7 @@ package tanka
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -43,12 +44,9 @@ func Load(path string, opts Opts) (*LoadResult, error) {
 func LoadEnvironment(path string, opts Opts) (*v1alpha1.Environment, error) {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		oldPath := path
-		path, err = os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-		opts.Name = oldPath
+		log.Printf("Path %q does not exist, trying to use it as an environment name", path)
+		opts.Name = path
+		path = "."
 	} else if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a feature proposal PoC for #636

It allows a user to reference an inline environment by name if it's present in the current working directory.
i.e instead of:
```
tk status --name stage/service main.jsonnet
```
Can simply write:
```
tk status stage/service
```
Because this patch replaces the path with the current working directory the standard enumeration logic will be used to discover the environment.
