### PR TITLE
add flag to allow insecure tls cert

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -30,6 +30,7 @@ func applyCmd() *cli.Command {
 
 	var opts tanka.ApplyOpts
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force applying (kubectl apply --force)")
+	cmd.Flags().BoolVar(&opts.InsecureSkipTlsVerify, "insecure-skip-tls-verify", false, "ignore tls verififcation (kubectl --insecure-skip-tls-verification)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 

--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -18,6 +18,10 @@ func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
 		argv = append(argv, "--validate=false")
 	}
 
+	if !opts.InsecureSkipTlsVerify {
+		argv = append(argv, "--insecure-skip-tls-verify")
+	}
+
 	cmd := k.ctl("apply", argv...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -50,6 +50,9 @@ type ApplyOpts struct {
 
 	// autoApprove allows to skip the interactive approval
 	AutoApprove bool
+
+	// InsecureSkipTlsVerify allows to ignore tls verification
+	InsecureSkipTlsVerify bool   
 }
 
 // DeleteOpts allow to specify additional parameters for delete operations

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -52,7 +52,7 @@ type ApplyOpts struct {
 	AutoApprove bool
 
 	// InsecureSkipTlsVerify allows to ignore tls verification
-	InsecureSkipTlsVerify bool   
+	InsecureSkipTlsVerify bool
 }
 
 // DeleteOpts allow to specify additional parameters for delete operations

--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -15,6 +15,10 @@ func (k Kubectl) Delete(namespace, kind, name string, opts DeleteOpts) error {
 		argv = append(argv, "--force")
 	}
 
+        if !opts.InsecureSkipTlsVerify {
+                argv = append(argv, "--insecure-skip-tls-verify")
+        }
+
 	cmd := k.ctl("delete", argv...)
 
 	var stdout bytes.Buffer

--- a/pkg/kubernetes/client/delete.go
+++ b/pkg/kubernetes/client/delete.go
@@ -14,10 +14,9 @@ func (k Kubectl) Delete(namespace, kind, name string, opts DeleteOpts) error {
 	if opts.Force {
 		argv = append(argv, "--force")
 	}
-
-        if !opts.InsecureSkipTlsVerify {
-                argv = append(argv, "--insecure-skip-tls-verify")
-        }
+	if opts.InsecureSkipTlsVerify {
+		argv = append(argv, "--insecure-skip-tls-verify")
+	}
 
 	cmd := k.ctl("delete", argv...)
 

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -23,6 +23,8 @@ type ApplyOpts struct {
 
 	// Force ignores any warnings kubectl might have
 	Force bool
+
+	InsecureSkipTlsVerify bool
 	// Validate set to false ignores invalid Kubernetes schemas
 	Validate bool
 }


### PR DESCRIPTION
Allow flag for using kubectl with insecure tls configuration
`kubectl --insecure-skip-tls-verify`