### PR TITLE
multiline/tabbed data manifest serialisation fix

### DIFF
--- a/pkg/kubernetes/manifest/manifest.go
+++ b/pkg/kubernetes/manifest/manifest.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/pkg/errors"
 	"github.com/stretchr/objx"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // Manifest represents a Kubernetes API object. The fields `apiVersion` and

--- a/pkg/kubernetes/manifest/manifest_test.go
+++ b/pkg/kubernetes/manifest/manifest_test.go
@@ -165,11 +165,18 @@ func TestManifestMarshalMultiline(t *testing.T) {
 
 	const expectedYAML = `apiVersion: core/v1
 data:
-  script.sh: "#/bin/sh\nset -e\n\n# This is a sample secript as configmap\n\necho
-    \"test\"if test -f 'test'; then\n\techo \"If test\"\nfi"
+    script.sh: |-
+        #/bin/sh
+        set -e
+
+        # This is a sample secript as configmap
+
+        echo "test"if test -f 'test'; then
+        	echo "If test"
+        fi
 kind: ConfigMap
 metadata:
-  name: MyConfigMap
+    name: MyConfigMap
 `
 	var m Manifest
 	err := json.Unmarshal([]byte(data), &m)

--- a/pkg/kubernetes/manifest/manifest_test.go
+++ b/pkg/kubernetes/manifest/manifest_test.go
@@ -149,6 +149,38 @@ func TestListAsMap(t *testing.T) {
 	}
 }
 
+func TestManifestMarshalMultiline(t *testing.T) {
+	const data = `
+{
+   "apiVersion":"core/v1",
+   "kind":"ConfigMap",
+   "metadata":{
+	  "name":"MyConfigMap"
+   },
+   "data":{
+	"script.sh": "#/bin/sh\nset -e\n\n# This is a sample secript as configmap\n\necho \"test\"if test -f 'test'; then\n\techo \"If test\"\nfi"
+   }
+}
+`
+
+	const expectedYAML = `apiVersion: core/v1
+data:
+  script.sh: "#/bin/sh\nset -e\n\n# This is a sample secript as configmap\n\necho
+    \"test\"if test -f 'test'; then\n\techo \"If test\"\nfi"
+kind: ConfigMap
+metadata:
+  name: MyConfigMap
+`
+	var m Manifest
+	err := json.Unmarshal([]byte(data), &m)
+	require.NoError(t, err)
+
+	outYAML := m.String()
+	if diff := cmp.Diff(outYAML, expectedYAML); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 func configMap(name string) map[string]interface{} {
 	return map[string]interface{}{
 		"apiVersion": "v1",


### PR DESCRIPTION
Hi,

While using tanka on a project of mine, I happened to get erroneous YAML outputs for some manifests I generated from plain text files (using `importstr 'script.sh` for example).

Empirically, I found that whenever the input file contained a tab character, the output would be truncated on each line (see commit 671b00e5 for the sample test input/output), and the resulting YAML was unusable.

While the root cause is not known, this does seem to point to the yaml.v2 library misbehaving in such a case, which seems to have been fixed on yaml.v3.

The library was already being used in the project, so I replaced it in the manifest.go file, which has indeed fixed the formatting issue.

Please let me know if I should perform some more tests or if you want me to change more things on the related code.