### PR TITLE
feature: add --dry-run kubectl option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## 0.19.1 (2022-xx-xx)
-
-### Features
-
-- **cli**: Add `--dry-run` option
-  **[#667](https://github.com/grafana/tanka/pull/667)**
-
 ## 0.19.0 (2021-11-22)
 
 ### Notice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.19.1 (2022-xx-xx)
+
+### Features
+
+- **cli**: Add `--dry-run` option
+  **[#667](https://github.com/grafana/tanka/pull/667)**
+
 ## 0.19.0 (2021-11-22)
 
 ### Notice

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -26,7 +26,7 @@ func validateDryRun(dryRunStr string) error {
 	case "", "none", "client", "server":
 		return nil
 	}
-	return fmt.Errorf("--dry-run must be either: \"\", \"none\", \"server\" or \"client\"")
+	return fmt.Errorf(`--dry-run must be either: "", "none", "server" or "client"`)
 }
 
 func applyCmd() *cli.Command {
@@ -40,7 +40,7 @@ func applyCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force applying (kubectl apply --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
-	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "", "--dry-run parameter to pass down to kubectl, must be \"none\", \"server\", or \"client\"")
+	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "", `--dry-run parameter to pass down to kubectl, must be "none", "server", or "client"`)
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
@@ -72,7 +72,7 @@ func pruneCmd() *cli.Command {
 	}
 
 	var opts tanka.PruneOpts
-	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "none", "--dry-run parameter to pass down to kubectl, must be \"none\", \"server\", or \"client\"")
+	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "", `--dry-run parameter to pass down to kubectl, must be "none", "server", or "client"`)
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	cmd.Flags().StringVar(&opts.Name, "name", "", "string that only a single inline environment contains in its name")
@@ -100,7 +100,7 @@ func deleteCmd() *cli.Command {
 	}
 
 	var opts tanka.DeleteOpts
-	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "none", "--dry-run parameter to pass down to kubectl, must be \"none\", \"server\", or \"client\"")
+	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "", `--dry-run parameter to pass down to kubectl, must be "none", "server", or "client"`)
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -21,6 +21,14 @@ const (
 	ExitStatusDiff = 16
 )
 
+func validateDryRun(dryRunStr string) error {
+	switch dryRunStr {
+	case "", "none", "client", "server":
+		return nil
+	}
+	return fmt.Errorf("--dry-run must be either: \"\", \"none\", \"server\" or \"client\"")
+}
+
 func applyCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "apply <path>",
@@ -32,11 +40,17 @@ func applyCmd() *cli.Command {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force applying (kubectl apply --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "", "--dry-run parameter to pass down to kubectl, must be \"none\", \"server\", or \"client\"")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
+		err := validateDryRun(opts.DryRun)
+		if err != nil {
+			return err
+		}
+
 		filters, err := process.StrExps(vars.targets...)
 		if err != nil {
 			return err
@@ -58,12 +72,18 @@ func pruneCmd() *cli.Command {
 	}
 
 	var opts tanka.PruneOpts
+	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "none", "--dry-run parameter to pass down to kubectl, must be \"none\", \"server\", or \"client\"")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	cmd.Flags().StringVar(&opts.Name, "name", "", "string that only a single inline environment contains in its name")
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
+		err := validateDryRun(opts.DryRun)
+		if err != nil {
+			return err
+		}
+
 		opts.JsonnetOpts = getJsonnetOpts()
 
 		return tanka.Prune(args[0], opts)
@@ -80,6 +100,7 @@ func deleteCmd() *cli.Command {
 	}
 
 	var opts tanka.DeleteOpts
+	cmd.Flags().StringVar(&opts.DryRun, "dry-run", "none", "--dry-run parameter to pass down to kubectl, must be \"none\", \"server\", or \"client\"")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force deleting (kubectl delete --force)")
 	cmd.Flags().BoolVar(&opts.Validate, "validate", true, "validation of resources (kubectl --validate=false)")
 	cmd.Flags().BoolVar(&opts.AutoApprove, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
@@ -88,6 +109,11 @@ func deleteCmd() *cli.Command {
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
+		err := validateDryRun(opts.DryRun)
+		if err != nil {
+			return err
+		}
+
 		filters, err := process.StrExps(vars.targets...)
 		if err != nil {
 			return err

--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -30,7 +30,6 @@ func (k Kubectl) applyCtl(data manifest.List, opts ApplyOpts) *exec.Cmd {
 
 // Apply applies the given yaml to the cluster
 func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
-
 	cmd := k.applyCtl(data, opts)
 
 	cmd.Stdout = os.Stdout

--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -1,14 +1,16 @@
 package client
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 )
 
-// Apply applies the given yaml to the cluster
-func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
+// Test-ability: isolate applyCtl to build and return exec.Cmd from ApplyOpts
+func (k Kubectl) applyCtl(data manifest.List, opts ApplyOpts) *exec.Cmd {
 	argv := []string{"-f", "-"}
 	if opts.Force {
 		argv = append(argv, "--force")
@@ -18,7 +20,19 @@ func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
 		argv = append(argv, "--validate=false")
 	}
 
-	cmd := k.ctl("apply", argv...)
+	if opts.DryRun != "" {
+		dryRun := fmt.Sprintf("--dry-run=%s", opts.DryRun)
+		argv = append(argv, dryRun)
+	}
+
+	return k.ctl("apply", argv...)
+}
+
+// Apply applies the given yaml to the cluster
+func (k Kubectl) Apply(data manifest.List, opts ApplyOpts) error {
+
+	cmd := k.applyCtl(data, opts)
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/pkg/kubernetes/client/apply_test.go
+++ b/pkg/kubernetes/client/apply_test.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+)
+
+func TestKubectl_applyCtl(t *testing.T) {
+	info := Info{
+		Kubeconfig: Config{
+			Context: Context{
+				Name: "foo-context",
+			},
+		},
+	}
+
+	type args struct {
+		data manifest.List
+		opts ApplyOpts
+	}
+	tests := []struct {
+		name           string
+		args           args
+		expectedArgs   []string
+		unExpectedArgs []string
+	}{
+		{
+			name: "test default",
+			args: args{
+				opts: ApplyOpts{Validate: true},
+			},
+			expectedArgs:   []string{"--context", info.Kubeconfig.Context.Name},
+			unExpectedArgs: []string{"--force", "--dry-run=server", "--validate=false"},
+		},
+		{
+			name: "test force",
+			args: args{
+				opts: ApplyOpts{Validate: true, Force: true},
+			},
+			expectedArgs:   []string{"--force"},
+			unExpectedArgs: []string{"--validate=false"},
+		},
+		{
+			name: "test validate",
+			args: args{
+				opts: ApplyOpts{Validate: false},
+			},
+			expectedArgs: []string{"--validate=false"},
+		},
+		{
+			name: "test dry-run",
+			args: args{
+				opts: ApplyOpts{Validate: true, DryRun: "server"},
+			},
+			expectedArgs:   []string{"--dry-run=server"},
+			unExpectedArgs: []string{"--validate=false"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := Kubectl{
+				info: info,
+			}
+			got := k.applyCtl(tt.args.data, tt.args.opts)
+			gotSet := sets.NewString(got.Args...)
+			if !gotSet.HasAll(tt.expectedArgs...) {
+				t.Errorf("Kubectl.applyCtl() = %v doesn't have (all) expectedArgs='%v'", got.Args, tt.expectedArgs)
+			}
+			if gotSet.HasAny(tt.unExpectedArgs...) {
+				t.Errorf("Kubectl.applyCtl() = %v has (any) unExpectedArgs='%v'", got.Args, tt.unExpectedArgs)
+			}
+
+		})
+	}
+}

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -50,6 +50,9 @@ type ApplyOpts struct {
 
 	// autoApprove allows to skip the interactive approval
 	AutoApprove bool
+
+	// DryRun string passed to kubectl as --dry-run=<DryRun>
+	DryRun string
 }
 
 // DeleteOpts allow to specify additional parameters for delete operations

--- a/pkg/kubernetes/client/delete_test.go
+++ b/pkg/kubernetes/client/delete_test.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestKubectl_deleteCtl(t *testing.T) {
+	info := Info{
+		Kubeconfig: Config{
+			Context: Context{
+				Name: "foo-context",
+			},
+		},
+	}
+
+	type args struct {
+		ns   string
+		kind string
+		name string
+		opts DeleteOpts
+	}
+
+	tests := []struct {
+		name           string
+		args           args
+		expectedArgs   []string
+		unExpectedArgs []string
+	}{
+		{
+			name: "test default",
+			args: args{
+				ns:   "foo-ns",
+				kind: "deploy",
+				name: "foo-deploy",
+				opts: DeleteOpts{},
+			},
+			expectedArgs:   []string{"--context", info.Kubeconfig.Context.Name, "-n", "foo-ns", "deploy", "foo-deploy"},
+			unExpectedArgs: []string{"--force", "--dry-run=server"},
+		},
+		{
+			name: "test dry-run",
+			args: args{
+				opts: DeleteOpts{DryRun: "server"},
+			},
+			expectedArgs: []string{"--dry-run=server"},
+		},
+		{
+			name: "test force",
+			args: args{
+				opts: DeleteOpts{Force: true},
+			},
+			expectedArgs: []string{"--force"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := Kubectl{
+				info: info,
+			}
+			got := k.deleteCtl(tt.args.ns, tt.args.kind, tt.args.name, tt.args.opts)
+			gotSet := sets.NewString(got.Args...)
+			if !gotSet.HasAll(tt.expectedArgs...) {
+				t.Errorf("Kubectl.applyCtl() = %v doesn't have (all) expectedArgs='%v'", got.Args, tt.expectedArgs)
+			}
+			if gotSet.HasAny(tt.unExpectedArgs...) {
+				t.Errorf("Kubectl.applyCtl() = %v has (any) unExpectedArgs='%v'", got.Args, tt.unExpectedArgs)
+			}
+
+		})
+	}
+}

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -18,6 +18,8 @@ type PruneOpts struct {
 	AutoApprove bool
 	// Force ignores any warnings kubectl might have
 	Force bool
+	// DryRun string passed to kubectl as --dry-run=<DryRun>
+	DryRun string
 }
 
 // Prune deletes all resources from the cluster, that are no longer present in


### PR DESCRIPTION
Fixes #666.

* add --dry-run kubectl option to `apply`,
  `delete`, `prune`
* add some simple testing to pkg/kubernetes/client
