### PR TITLE
tk/export: introduce a configurable memory ballast

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"runtime"
 
@@ -38,7 +39,11 @@ func exportCmd() *cli.Command {
 	parallel := cmd.Flags().IntP("parallel", "p", 8, "Number of environments to process in parallel")
 	cachePath := cmd.Flags().StringP("cache-path", "c", "", "Local file path where cached evaluations should be stored")
 	cacheEnvs := cmd.Flags().StringArrayP("cache-envs", "e", nil, "Regexes which define which environment should be cached (if caching is enabled)")
-	ballastBytes := cmd.Flags().Int("mem-ballast-size-bytes", 0, "Size of memory ballast to allocate.")
+
+	ballastBytes := cmd.Flags().Int("mem-ballast-size-bytes", 0, "(Experimental) Size of memory ballast to allocate.")
+	if err := cmd.Flags().MarkHidden("mem-ballast-size-bytes"); err != nil {
+		log.Fatalf("Could not mark flag as hidden: %s", err)
+	}
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())


### PR DESCRIPTION
Context: At GrafanaLabs, we are currently trying to optimise how long it takes us to do a `tk export` operation of our jsonnet codebase. 

We are currently testing different alternatives, one of them is leveraging a memory ballast to reduce the amount of time spent doing garbage collection.

I'm currently working on getting some hard data to back that up, but in the meantime, I'm proposing this PR which introduces a memory ballast behind a hidden flag for `tk export`.

[1]: https://blog.twitch.tv/en/2019/04/10/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap/