### PR TITLE
Adds support for specifying valid context names for an environment

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -33,6 +33,10 @@ Tanka's behavior can be customized per Environment using a file called `spec.jso
     // Must be the full URL, e.g. https://cluster.fqdn:6443
     "apiServer": "<url>",
 
+    // The Kubernetes context name(s) to use.
+    // This field supports regular expressions and is mutually exclusive with apiServer field.
+    "contextNames": ["<string>"],
+    
     // Default namespace for objects that don't explicitely specify one
     "namespace": "<string>" | default = "default",
 

--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/stretchr/objx"
@@ -214,7 +215,7 @@ func find(list []map[string]interface{}, prop string, expected string, ptr inter
 			findErr = fmt.Errorf("testing whether `%s` is `%s`: unable to parse `%v` as string", prop, expected, got)
 			return false
 		}
-		return str == expected
+		return regexp.MustCompile(expected).MatchString(str)
 	})
 	if findErr != nil {
 		return findErr

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -23,7 +23,7 @@ func New(endpoint string) (*Kubectl, error) {
 
 	// discover context
 	var err error
-	k.info.Kubeconfig, err = findContext(endpoint)
+	k.info.Kubeconfig, err = findContextFromEndpoint(endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding usable context")
 	}
@@ -35,6 +35,25 @@ func New(endpoint string) (*Kubectl, error) {
 	}
 
 	return &k, nil
+}
+
+func NewFromNames(names []string) (*Kubectl, error) {
+	k := Kubectl{}
+
+	var err error
+	k.info.Kubeconfig, err = findContextFromNames(names)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding usable context")
+	}
+
+	// query versions (requires context)
+	k.info.ClientVersion, k.info.ServerVersion, err = k.version()
+	if err != nil {
+		return nil, errors.Wrap(err, "obtaining versions")
+	}
+
+	return &k, nil
+
 }
 
 // Info returns known informational data about the client and its environment

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -28,7 +28,13 @@ type Differ func(manifest.List) (*string, error)
 // New creates a new Kubernetes with an initialized client
 func New(env v1alpha1.Environment) (*Kubernetes, error) {
 	// setup client
-	ctl, err := client.New(env.Spec.APIServer)
+	var ctl *client.Kubectl
+	var err error
+	if len(env.Spec.ContextNames) < 1 {
+		ctl, err = client.New(env.Spec.APIServer)
+	} else {
+		ctl, err = client.NewFromNames(env.Spec.ContextNames)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -74,7 +74,7 @@ func Parse(data []byte, namespace string) (*v1alpha1.Environment, error) {
 	}
 
 	// default apiServer URL to https
-	if !regexp.MustCompile("^.+://").MatchString(config.Spec.APIServer) {
+	if config.Spec.APIServer != "" && !regexp.MustCompile("^.+://").MatchString(config.Spec.APIServer) {
 		config.Spec.APIServer = "https://" + config.Spec.APIServer
 	}
 

--- a/pkg/spec/v1alpha1/environment.go
+++ b/pkg/spec/v1alpha1/environment.go
@@ -58,6 +58,7 @@ func (m Metadata) NameLabel() string {
 // Spec defines Kubernetes properties
 type Spec struct {
 	APIServer        string           `json:"apiServer"`
+	ContextNames     []string         `json:"contextNames"`
 	Namespace        string           `json:"namespace"`
 	DiffStrategy     string           `json:"diffStrategy,omitempty"`
 	InjectLabels     bool             `json:"injectLabels,omitempty"`

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -150,8 +150,10 @@ func (l LoadResult) Connect() (*kubernetes.Kubernetes, error) {
 
 	// check env is complete
 	s := ""
-	if env.Spec.APIServer == "" {
-		s += "  * spec.apiServer: No Kubernetes cluster endpoint specified"
+	if env.Spec.APIServer == "" && len(env.Spec.ContextNames) < 1 {
+		s += "  * spec.apiServer|spec.contextNames: No Kubernetes cluster endpoint or context names specified. Please specify only one."
+	} else if env.Spec.APIServer != "" && len(env.Spec.ContextNames) > 0 {
+		s += "  * spec.apiServer|spec.contextNames: These fields are mutually exclusive, please only specify one."
 	}
 	if env.Spec.Namespace == "" {
 		s += "  * spec.namespace: Default namespace missing"

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -150,9 +150,9 @@ func (l LoadResult) Connect() (*kubernetes.Kubernetes, error) {
 
 	// check env is complete
 	s := ""
-	if env.Spec.APIServer == "" && len(env.Spec.ContextNames) < 1 {
+	if env.Spec.APIServer == "https://" && len(env.Spec.ContextNames) < 1 {
 		s += "  * spec.apiServer|spec.contextNames: No Kubernetes cluster endpoint or context names specified. Please specify only one."
-	} else if env.Spec.APIServer != "" && len(env.Spec.ContextNames) > 0 {
+	} else if env.Spec.APIServer != "https://" && len(env.Spec.ContextNames) > 0 {
 		s += "  * spec.apiServer|spec.contextNames: These fields are mutually exclusive, please only specify one."
 	}
 	if env.Spec.Namespace == "" {

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -150,9 +150,9 @@ func (l LoadResult) Connect() (*kubernetes.Kubernetes, error) {
 
 	// check env is complete
 	s := ""
-	if env.Spec.APIServer == "https://" && len(env.Spec.ContextNames) < 1 {
+	if env.Spec.APIServer == "" && len(env.Spec.ContextNames) < 1 {
 		s += "  * spec.apiServer|spec.contextNames: No Kubernetes cluster endpoint or context names specified. Please specify only one."
-	} else if env.Spec.APIServer != "https://" && len(env.Spec.ContextNames) > 0 {
+	} else if env.Spec.APIServer != "" && len(env.Spec.ContextNames) > 0 {
 		s += "  * spec.apiServer|spec.contextNames: These fields are mutually exclusive, please only specify one."
 	}
 	if env.Spec.Namespace == "" {


### PR DESCRIPTION
https://github.com/grafana/tanka/issues/58#issuecomment-1054952428

I appreciate the protection `spec.apiServer` provides, but Tanka does not work for our environments without support for matching on context names. I'm happy to update docs if this is something that would potentially be merged.

Our use case is summed up in the comment at the top.

Example `spec.json`

```go
{
  "apiVersion": "tanka.dev/v1alpha1",
  "kind": "Environment",
  "metadata": {
    "name": "environments/development"
  },
  "spec": {
    "contextNames": ["automation-generated-context", "local-generated-context"],
    "namespace": "default",
    "resourceDefaults": {},
    "expectVersions": {}
  }
}
```

There's also a bug this PR fixes with an empty env.Spec.APIServer where the value will never be an empty string in `(l LoadResult) Connect()` because of the regular expression check in `func Parse(data []byte, namespace string) (*v1alpha1.Environment, error)`.  The fix is to only prepend that if the APIServer is not an empty string.