### PR TITLE
Fix `target must be a non-nil pointer`

### DIFF
--- a/pkg/kubernetes/diff.go
+++ b/pkg/kubernetes/diff.go
@@ -28,7 +28,7 @@ Please upgrade kubectl to at least version 1.18.1.`)
 		for _, namespace := range resourceNamespaces {
 			_, err = k.ctl.Namespace(namespace)
 			if err != nil {
-				if errors.As(err, client.ErrNamespaceNotFound{}) {
+				if errors.As(err, &client.ErrNamespaceNotFound{}) {
 					continue
 				}
 				return nil, errors.Wrap(err, "retrieving namespaces")


### PR DESCRIPTION
With an API server for which I'm not authentified with correctly, `tanka` would panic with `target must be a non-nil pointer` because of a call to `errors.As`. Since we are actually only checking the type of the error and not its content, `errors.Is` can be used here. The It could also be moved to a variable to avoid creating a new instance each time just to check if it's of the right type.

This was happening trying to show the diff because it seems I'm not configured correctly.

```
WARNING: version difference between client (1.23) and server (1.20) exceeds the supported minor version skew of +/-1
Error from server (Forbidden): namespaces "default" is forbidden: User "<email>" cannot get resource "namespaces" in API group "" in the namespace "default": requires one of ["container.namespaces.get"] permission(s).
panic: errors: target must be a non-nil pointer
```


```
panic: errors: target must be a non-nil pointer

goroutine 1 [running]:
errors.As({0x10130dae8, 0x140000b2000}, {0x1012c0800, 0x101794360})
	/usr/local/go/src/errors/wrap.go:85 +0x3e0
github.com/pkg/errors.As(...)
	/Users/maoueh/go/pkg/mod/github.com/pkg/errors@v0.9.1/go113.go:31
github.com/grafana/tanka/pkg/kubernetes.(*Kubernetes).Diff(0x140004961a0, {0x140003f39d0, 0x2, 0x2}, {0x0?, 0x0?, {0x0?, 0x0?}})
	/Users/maoueh/work/github/grafana_tanka/pkg/kubernetes/diff.go:31 +0x4b8
github.com/grafana/tanka/pkg/tanka.Diff({0x16effebc0?, 0x140001edc58?}, {{{0x0, 0x140003227b0, 0x140003227e0, {0x0, 0x0, 0x0}, {0x0, 0x0}, ...}, ...}, ...})
	/Users/maoueh/work/github/grafana_tanka/pkg/tanka/workflow.go:122 +0xdc
main.diffCmd.func1(0x140001c4800?, {0x140002f8390, 0x1, 0x1?})
	/Users/maoueh/work/github/grafana_tanka/cmd/tk/workflow.go:158 +0x19c
github.com/go-clix/cli.(*Command).execute(0x140002afea0, {0x140002f8370, 0x1, 0x1})
	/Users/maoueh/go/pkg/mod/github.com/go-clix/cli@v0.2.0/command.go:118 +0x2b4
github.com/go-clix/cli.(*Command).Execute(0x140002af0e0)
	/Users/maoueh/go/pkg/mod/github.com/go-clix/cli@v0.2.0/command.go:76 +0xd4
main.main()
	/Users/maoueh/work/github/grafana_tanka/cmd/tk/main.go:58 +0x5bc
```