### PR TITLE
Remove backticks from -inject-labels flag desc

### DIFF
--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -92,5 +92,5 @@ func envSettingsFlags(env *v1alpha1.Environment, fs *pflag.FlagSet) {
 	fs.StringVar(&env.Spec.APIServer, "server-from-context", env.Spec.APIServer, "set the server to a known one from $KUBECONFIG")
 	fs.StringVar(&env.Spec.Namespace, "namespace", env.Spec.Namespace, "namespace to create objects in")
 	fs.StringVar(&env.Spec.DiffStrategy, "diff-strategy", env.Spec.DiffStrategy, "specify diff-strategy. Automatically detected otherwise.")
-	fs.BoolVar(&env.Spec.InjectLabels, "inject-labels", env.Spec.InjectLabels, "add tanka environment label to each created resource. Required for `tk prune`.")
+	fs.BoolVar(&env.Spec.InjectLabels, "inject-labels", env.Spec.InjectLabels, "add tanka environment label to each created resource. Required for 'tk prune'.")
 }


### PR DESCRIPTION
Backticks in a flag description have a special meaning, in both standard`flag` and the `pflag` package used here. 
Because of this, flag was described as:

    --inject-labels tk prune       add tanka environment label to each created resource. Required for tk prune.

Now it will look like:

    --inject-labels                add tanka environment label to each created resource. Required for 'tk prune'.

See https://github.com/spf13/pflag/issues/200

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>