### PR TITLE
Support interactive diff utilities

### DIFF
--- a/docs/docs/diff-strategy.md
+++ b/docs/docs/diff-strategy.md
@@ -75,3 +75,10 @@ runtime, which we cannot know of on the client side. To produce a somewhat
 usable output, we can effectively only compare what we already know about.
 
 If this is a problem for you, consider switching to [native](#native) mode.
+
+## External diff utilities
+
+You can use external diff utilities by setting the environment variable
+`KUBECTL_EXTERNAL_DIFF`. If you want to use a GUI or interactive diff utility
+you must also set `KUBECTL_INTERACTIVE_DIFF=1` to prevent Tanka from capturing
+stdout.

--- a/pkg/kubernetes/client/diff.go
+++ b/pkg/kubernetes/client/diff.go
@@ -45,7 +45,7 @@ func (k Kubectl) diff(data manifest.List, serverSide bool) (*string, error) {
 
 	raw := bytes.Buffer{}
 	// If using an external diff tool, let it keep the parent's stdout
-	if os.Getenv("KUBECTL_EXTERNAL_DIFF") != "" {
+	if os.Getenv("KUBECTL_INTERACTIVE_DIFF") != "" {
 		cmd.Stdout = os.Stdout
 	} else {
 		cmd.Stdout = &raw

--- a/pkg/kubernetes/client/diff.go
+++ b/pkg/kubernetes/client/diff.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -43,7 +44,12 @@ func (k Kubectl) diff(data manifest.List, serverSide bool) (*string, error) {
 	cmd := k.ctl("diff", args...)
 
 	raw := bytes.Buffer{}
-	cmd.Stdout = &raw
+	// If using an external diff tool, let it keep the parent's stdout
+	if os.Getenv("KUBECTL_EXTERNAL_DIFF") != "" {
+		cmd.Stdout = os.Stdout
+	} else {
+		cmd.Stdout = &raw
+	}
 	cmd.Stderr = &fw
 	cmd.Stdin = strings.NewReader(data.String())
 	err := cmd.Run()

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -84,8 +84,8 @@ func Apply(baseDir string, opts ApplyOpts) error {
 			// This is not fatal, the diff is not strictly required
 			log.Println("Error diffing:", err)
 		case diff == nil:
-			// If using KUBECTL_EXTERNAL_DIFF, the stdout buffer is always empty
-			if os.Getenv("KUBECTL_EXTERNAL_DIFF") == "" {
+			// If using KUBECTL_INTERACTIVE_DIFF, the stdout buffer is always empty
+			if os.Getenv("KUBECTL_INTERACTIVE_DIFF") == "" {
 				tmp := "Warning: There are no differences. Your apply may not do anything at all."
 				diff = &tmp
 			}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -3,6 +3,7 @@ package tanka
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/fatih/color"
 
@@ -83,8 +84,11 @@ func Apply(baseDir string, opts ApplyOpts) error {
 			// This is not fatal, the diff is not strictly required
 			log.Println("Error diffing:", err)
 		case diff == nil:
-			tmp := "Warning: There are no differences. Your apply may not do anything at all."
-			diff = &tmp
+			// If using KUBECTL_EXTERNAL_DIFF, the stdout buffer is always empty
+			if os.Getenv("KUBECTL_EXTERNAL_DIFF") == "" {
+				tmp := "Warning: There are no differences. Your apply may not do anything at all."
+				diff = &tmp
+			}
 		}
 
 		// in case of non-fatal error diff may be nil


### PR DESCRIPTION
Interactive diff utilities such as vimdiff do not work unless kubectl is
started with the current TTY as stdout.

If the environment variable KUBECTL_EXTERNAL_DIFF is set, don't assign
the normal string buffer to stdout, use the parent's stdout instead.

Fixes #671