### PR TITLE
feature: add support for pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: tanka-format
+  name: tkfmt
+  description: Automatically format jsonnet files.
+  entry: tk
+  args: [fmt]
+  language: golang
+  files: \.(jsonnet|libsonnet)$
+  minimum_pre_commit_version: 2.10.1


### PR DESCRIPTION
This PR adds support for [pre-commit.com](https://pre-commit.com/) and `tk fmt` command specifically. One can use it either with `pre-commit` locally or [pre-commit.ci](https://pre-commit.ci/) by introducing `.pre-commit-config.yaml` at the root repository level, e.g.:

```yaml
repos:
  - repo: https://github.com/grafana/tanka
    rev: v0.20.1
    hooks:
      - id: tanka-format
```

See:
- https://pre-commit.com for more information
- https://pre-commit.com/hooks.html for more hooks
