### PR TITLE
Support a diff-strategy of "none" for "tk apply" to suppress diffing.

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -35,7 +35,7 @@ func applyCmd() *cli.Command {
 		Short: "apply the configuration to the cluster",
 		Args:  workflowArgs,
 		Predictors: complete.Flags{
-			"diff-strategy":  cli.PredictSet("native", "subset", "validate", "server"),
+			"diff-strategy":  cli.PredictSet("native", "subset", "validate", "server", "none"),
 			"apply-strategy": cli.PredictSet("client", "server"),
 		},
 	}

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -75,21 +75,23 @@ func Apply(baseDir string, opts ApplyOpts) error {
 	}
 	defer kube.Close()
 
-	// show diff
-	diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{Strategy: opts.DiffStrategy})
-	switch {
-	case err != nil:
-		// This is not fatal, the diff is not strictly required
-		log.Println("Error diffing:", err)
-	case diff == nil:
-		tmp := "Warning: There are no differences. Your apply may not do anything at all."
-		diff = &tmp
-	}
+	if opts.DiffStrategy != "none" {
+		// show diff
+		diff, err := kube.Diff(l.Resources, kubernetes.DiffOpts{Strategy: opts.DiffStrategy})
+		switch {
+		case err != nil:
+			// This is not fatal, the diff is not strictly required
+			log.Println("Error diffing:", err)
+		case diff == nil:
+			tmp := "Warning: There are no differences. Your apply may not do anything at all."
+			diff = &tmp
+		}
 
-	// in case of non-fatal error diff may be nil
-	if diff != nil {
-		b := term.Colordiff(*diff)
-		fmt.Print(b.String())
+		// in case of non-fatal error diff may be nil
+		if diff != nil {
+			b := term.Colordiff(*diff)
+			fmt.Print(b.String())
+		}
 	}
 
 	// prompt for confirmation


### PR DESCRIPTION
This pull request adds a diff strategy of `none` for `tk apply` that completely suppresses diffing before the apply operation.

The reason I'm submitting this is that I'm using Tanka to create a very large set of Kubernetes resources and it takes 5 to 10 minutes to perform the diff operation before getting to the apply stage.  Since I often use a `tk diff` myself first, before the `tk apply`, I don't need the diff that's part of `apply` in some cases.  Also, when our automated job runs to do a `tk apply`, it uses the `--dangerous-auto-approve` option, with no human present observe the diff output.  The 5 to 10 minute delay in this step of the automation makes the automation job run longer that desired, delaying the deployment of the things that come _after_ this step.

I would like to change some documentation to describe the `none` option to `tk apply`, but I don't see any good place to put that.  Any suggestion would be welcome.