### PR TITLE
Compare semvers when checking if existing chart is up-to-date

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -69,7 +69,7 @@ type Charts struct {
 
 // chartManifest represents a Helm chart's Chart.yaml
 type chartManifest struct {
-	Version string `yaml:"version"`
+	Version semver.Version `yaml:"version"`
 }
 
 // ChartDir returns the directory pulled charts are saved in
@@ -108,7 +108,7 @@ func (c Charts) Vendor() error {
 				return fmt.Errorf("unmarshalling chart manifest: %w", err)
 			}
 
-			if chartYAML.Version == r.Version.String() {
+			if chartYAML.Version.String() == r.Version.String() {
 				log.Printf(" %s@%s exists", r.Chart, r.Version.String())
 				continue
 			} else {


### PR DESCRIPTION
When chartfile.yaml requirements are parsed, version string is converted into a
semver.Version struct, dropping "optional" v prefix from the version. Match
this behaviour for Chart.yaml version so that they can be compared with each
other.

Closes #701