### PR TITLE
Adds support for contextNames in tk env subcommands

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -77,6 +77,13 @@ func envSetCmd() *cli.Command {
 			}
 			tmp.Spec.APIServer = server
 		}
+		// This ensures the environment is valid before setting it
+		if cmd.Flags().Changed("server-from-context") || cmd.Flags().Changed("context-name") {
+			l := tanka.LoadResult{Env: &tmp}
+			if _, err := l.Connect(); err != nil {
+				return err
+			}
+		}
 
 		cfg, err := tanka.Peek(path, tanka.Opts{})
 		if err != nil {
@@ -126,6 +133,13 @@ func envAddCmd() *cli.Command {
 				return fmt.Errorf("Resolving IP from context: %s", err)
 			}
 			cfg.Spec.APIServer = server
+		}
+		// This ensures the environment is valid before adding it
+		if cmd.Flags().Changed("server-from-context") || cmd.Flags().Changed("context-name") {
+			l := tanka.LoadResult{Env: cfg}
+			if _, err := l.Connect(); err != nil {
+				return err
+			}
 		}
 
 		if err := addEnv(args[0], cfg, *inline); err != nil {

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"k8s.io/utils/strings/slices"
 	"os"
 	"path/filepath"
 	"sort"
@@ -77,13 +78,6 @@ func envSetCmd() *cli.Command {
 			}
 			tmp.Spec.APIServer = server
 		}
-		// This ensures the environment is valid before setting it
-		if cmd.Flags().Changed("server-from-context") || cmd.Flags().Changed("context-name") {
-			l := tanka.LoadResult{Env: &tmp}
-			if _, err := l.Connect(); err != nil {
-				return err
-			}
-		}
 
 		cfg, err := tanka.Peek(path, tanka.Opts{})
 		if err != nil {
@@ -93,6 +87,10 @@ func envSetCmd() *cli.Command {
 		if tmp.Spec.APIServer != "" && tmp.Spec.APIServer != cfg.Spec.APIServer {
 			fmt.Printf("updated spec.apiServer (`%s` -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)
 			cfg.Spec.APIServer = tmp.Spec.APIServer
+		}
+		if tmp.Spec.ContextNames != nil && ! slices.Equal(tmp.Spec.ContextNames, cfg.Spec.ContextNames) {
+			fmt.Printf("updated spec.contextNames (`%v` -> `%v`)\n", cfg.Spec.ContextNames, tmp.Spec.ContextNames)
+			cfg.Spec.ContextNames = tmp.Spec.ContextNames
 		}
 		if tmp.Spec.Namespace != "" && tmp.Spec.Namespace != cfg.Spec.Namespace {
 			fmt.Printf("updated spec.namespace (`%s` -> `%s`)\n", cfg.Spec.Namespace, tmp.Spec.Namespace)
@@ -105,6 +103,12 @@ func envSetCmd() *cli.Command {
 		if tmp.Spec.InjectLabels != cfg.Spec.InjectLabels {
 			fmt.Printf("updated spec.injectLabels (`%t` -> `%t`)\n", cfg.Spec.InjectLabels, tmp.Spec.InjectLabels)
 			cfg.Spec.InjectLabels = tmp.Spec.InjectLabels
+		}
+
+		// This ensures the environment is valid before setting it
+		l := tanka.LoadResult{Env: cfg}
+		if _, err := l.Connect(); err != nil {
+			return err
 		}
 
 		if err := writeJSON(cfg, filepath.Join(path, "spec.json")); err != nil {

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -88,7 +88,7 @@ func envSetCmd() *cli.Command {
 			fmt.Printf("updated spec.apiServer (`%s` -> `%s`)\n", cfg.Spec.APIServer, tmp.Spec.APIServer)
 			cfg.Spec.APIServer = tmp.Spec.APIServer
 		}
-		if tmp.Spec.ContextNames != nil && ! slices.Equal(tmp.Spec.ContextNames, cfg.Spec.ContextNames) {
+		if tmp.Spec.ContextNames != nil && !slices.Equal(tmp.Spec.ContextNames, cfg.Spec.ContextNames) {
 			fmt.Printf("updated spec.contextNames (`%v` -> `%v`)\n", cfg.Spec.ContextNames, tmp.Spec.ContextNames)
 			cfg.Spec.ContextNames = tmp.Spec.ContextNames
 		}

--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -90,6 +90,7 @@ func cliCodeParser(fs *pflag.FlagSet) (func() map[string]string, func() map[stri
 func envSettingsFlags(env *v1alpha1.Environment, fs *pflag.FlagSet) {
 	fs.StringVar(&env.Spec.APIServer, "server", env.Spec.APIServer, "endpoint of the Kubernetes API")
 	fs.StringVar(&env.Spec.APIServer, "server-from-context", env.Spec.APIServer, "set the server to a known one from $KUBECONFIG")
+	fs.StringSliceVar(&env.Spec.ContextNames, "context-name", env.Spec.ContextNames, "valid context name for environment, can pass multiple, regex supported.")
 	fs.StringVar(&env.Spec.Namespace, "namespace", env.Spec.Namespace, "namespace to create objects in")
 	fs.StringVar(&env.Spec.DiffStrategy, "diff-strategy", env.Spec.DiffStrategy, "specify diff-strategy. Automatically detected otherwise.")
 	fs.BoolVar(&env.Spec.InjectLabels, "inject-labels", env.Spec.InjectLabels, "add tanka environment label to each created resource. Required for 'tk prune'.")


### PR DESCRIPTION
This compliments https://github.com/grafana/tanka/pull/674 and probably should have been in there to begin with. 

This PR adds support for `contextNames` using `tk env add` and `tk env set` commands. It leverages the `Connect` method to check validity of the resulting config.

Below are a few examples, including cases that would throw errors

```
(~/Code) Nash $ mkdir example-tk && cd example-tk
(~/Code/example-tk) Nash $ tk init
GET https://github.com/jsonnet-libs/k8s-libsonnet/archive/1942ec15993b5a273569bb9a59d522b01522d0db.tar.gz 200
GET https://github.com/grafana/jsonnet-libs/archive/73396f2821466dd8f91181e7ee4513e0a8ea45b3.tar.gz 200
Directory structure set up! Remember to configure the API endpoint:
`tk env set environments/default --server=https://127.0.0.1:6443`


(~/Code/example-tk) Nash $ tk env set environments/default --context-name "devwat-us-south.*" --server localhost --namespace default
updated spec.apiServer (`` -> `localhost`)
updated spec.contextNames (`[]` -> `[devwat-us-south.*]`)
Error: Your Environment's spec.json seems incomplete:
  * spec.apiServer|spec.contextNames: These fields are mutually exclusive, please only specify one.

Please see https://tanka.dev/config for reference

(~/Code/example-tk) Nash $ tk env set environments/default --context-name "devwat-us-south.*" --namespace default
updated spec.contextNames (`[]` -> `[devwat-us-south.*]`)
(~/Code/example-tk) Nash $ cat environments/default/spec.json
{
  "apiVersion": "tanka.dev/v1alpha1",
  "kind": "Environment",
  "metadata": {
    "name": "environments/default",
    "namespace": "environments/default/main.jsonnet"
  },
  "spec": {
    "apiServer": "",
    "contextNames": [
      "devwat-us-south.*"
    ],
    "namespace": "default",
    "resourceDefaults": {},
    "expectVersions": {}
  }
}

(~/Code/example-tk) Nash $ tk env set environments/default --server localhost --namespace default
updated spec.apiServer (`` -> `localhost`)
Error: Your Environment's spec.json seems incomplete:
  * spec.apiServer|spec.contextNames: These fields are mutually exclusive, please only specify one.

Please see https://tanka.dev/config for reference

(~/Code/example-tk) Nash $ tk env add example --context-name "devwat-us-south.*"
(~/Code/example-tk) Nash $ cat example/spec.json
{
  "apiVersion": "tanka.dev/v1alpha1",
  "kind": "Environment",
  "metadata": {
    "name": "example"
  },
  "spec": {
    "apiServer": "",
    "contextNames": [
      "devwat-us-south.*"
    ],
    "namespace": "default",
    "resourceDefaults": {},
    "expectVersions": {}
  }
}
(~/Code/example-tk) Nash $
```