### PR TITLE
Allow defining a custom dir for Helm Charts

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -69,6 +69,7 @@ type Charts struct {
 
 // chartManifest represents a Helm chart's Chart.yaml
 type chartManifest struct {
+	Name    string         `yaml:"name"`
 	Version semver.Version `yaml:"version"`
 }
 
@@ -95,6 +96,10 @@ func (c Charts) Vendor() error {
 	for _, r := range c.Manifest.Requires {
 		chartName := parseReqName(r.Chart)
 		chartPath := filepath.Join(dir, chartName)
+
+		if r.Directory != "" {
+			chartPath = filepath.Join(dir, r.Directory)
+		}
 
 		_, err := os.Stat(chartPath)
 		if err == nil {
@@ -129,8 +134,9 @@ func (c Charts) Vendor() error {
 			repositoriesUpdated = true
 		}
 		err = c.Helm.Pull(r.Chart, r.Version.String(), PullOpts{
-			Destination: dir,
-			Opts:        Opts{Repositories: c.Manifest.Repositories},
+			Destination:      dir,
+			ExtractDirectory: r.Directory,
+			Opts:             Opts{Repositories: c.Manifest.Repositories},
 		})
 		if err != nil {
 			return err
@@ -233,15 +239,23 @@ func write(c Chartfile, dest string) error {
 	return os.WriteFile(dest, data, 0644)
 }
 
-var chartExp = regexp.MustCompile(`\w+\/.+@.+`)
+// https://regex101.com/r/VAklNg/1
+var chartExp = regexp.MustCompile(`\w+\/.+@.+(\:.+)?`)
 
 // parseReq parses a requirement from a string of the format `repo/name@version`
 func parseReq(s string) (*Requirement, error) {
 	if !chartExp.MatchString(s) {
-		return nil, fmt.Errorf("not of form 'repo/chart@version'")
+		return nil, fmt.Errorf("not of form 'repo/chart@version(:path)'")
 	}
 
-	elems := strings.Split(s, "@")
+	elems := strings.Split(s, ":")
+	directory := ""
+	if len(elems) > 1 {
+		s = elems[0]
+		directory = elems[1]
+	}
+
+	elems = strings.Split(s, "@")
 	chart := elems[0]
 	ver, err := semver.NewVersion(elems[1])
 	if errors.Is(err, semver.ErrInvalidSemVer) {
@@ -251,8 +265,9 @@ func parseReq(s string) (*Requirement, error) {
 	}
 
 	return &Requirement{
-		Chart:   chart,
-		Version: *ver,
+		Chart:     chart,
+		Version:   *ver,
+		Directory: directory,
 	}, nil
 }
 

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -1,27 +1,13 @@
 package helm
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/grafana/tanka/pkg/kubernetes/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type fakeHelm struct{}
-
-func (f fakeHelm) Pull(chart, version string, opts PullOpts) error {
-	return nil
-}
-
-func (f fakeHelm) RepoUpdate(opts Opts) error {
-	return nil
-}
-
-func (f fakeHelm) Template(name, chart string, opts TemplateOpts) (manifest.List, error) {
-	return nil, nil
-}
 
 func TestAddRepos(t *testing.T) {
 	c, err := InitChartfile(filepath.Join(t.TempDir(), Filename))
@@ -40,18 +26,33 @@ func TestAddRepos(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
-	c, err := InitChartfile(filepath.Join(t.TempDir(), Filename))
+	tempDir := t.TempDir()
+	c, err := InitChartfile(filepath.Join(tempDir, Filename))
 	require.NoError(t, err)
-	c.Helm = &fakeHelm{}
 
-	err = c.Add([]string{"stable/package@1.0.0"})
+	err = c.Add([]string{"stable/prometheus@11.12.1"})
 	assert.NoError(t, err)
 
 	// Adding again the same chart
-	err = c.Add([]string{"stable/package@1.0.0"})
+	err = c.Add([]string{"stable/prometheus@11.12.1"})
 	assert.EqualError(t, err, "1 Chart(s) were skipped. Please check above logs for details")
 
-	// Update a version
-	err = c.Add([]string{"stable/package@1.1.0"})
+	// Add a chart with a specific extract directory
+	err = c.Add([]string{"stable/prometheus@11.12.0:prometheus-11.12.0"})
 	assert.NoError(t, err)
+
+	// Check file contents
+	listResult, err := os.ReadDir(filepath.Join(tempDir, "charts"))
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(listResult))
+	assert.Equal(t, "prometheus", listResult[0].Name())
+	assert.Equal(t, "prometheus-11.12.0", listResult[1].Name())
+
+	chartContent, err := os.ReadFile(filepath.Join(tempDir, "charts", "prometheus", "Chart.yaml"))
+	assert.NoError(t, err)
+	assert.Contains(t, string(chartContent), `version: 11.12.1`)
+
+	chartContent, err = os.ReadFile(filepath.Join(tempDir, "charts", "prometheus-11.12.0", "Chart.yaml"))
+	assert.NoError(t, err)
+	assert.Contains(t, string(chartContent), `version: 11.12.0`)
 }

--- a/pkg/helm/spec.go
+++ b/pkg/helm/spec.go
@@ -59,8 +59,9 @@ func (r Repos) Has(repo Repo) bool {
 // Requirement describes a single required Helm Chart.
 // Both, Chart and Version are required
 type Requirement struct {
-	Chart   string         `json:"chart"`
-	Version semver.Version `json:"version"`
+	Chart     string         `json:"chart"`
+	Version   semver.Version `json:"version"`
+	Directory string         `json:"directory,omitempty"`
 }
 
 // Requirements is an aggregate of all required Charts


### PR DESCRIPTION
This allows a chartfile to contain multiple versions of the same chart.

Example:

```yaml
directory: charts
repositories:
- name: flagger
  url: https://flagger.app
requires:
- chart: flagger/flagger
  directory: flagger-1.16.1
  version: 1.16.1
- chart: flagger/flagger
  directory: flagger-1.21.0
  version: 1.21.0
version: 1
```