### PR TITLE
spec.json: Add `omitempty` to apiServer and contextNames

### DIFF
--- a/pkg/spec/v1alpha1/environment.go
+++ b/pkg/spec/v1alpha1/environment.go
@@ -57,8 +57,8 @@ func (m Metadata) NameLabel() string {
 
 // Spec defines Kubernetes properties
 type Spec struct {
-	APIServer        string           `json:"apiServer"`
-	ContextNames     []string         `json:"contextNames"`
+	APIServer        string           `json:"apiServer,omitempty"`
+	ContextNames     []string         `json:"contextNames,omitempty"`
 	Namespace        string           `json:"namespace"`
 	DiffStrategy     string           `json:"diffStrategy,omitempty"`
 	ApplyStrategy    string           `json:"applyStrategy,omitempty"`


### PR DESCRIPTION
When doing `env list`, these attributes shouldn't show up if they aren't set
They are mutually exclusive