### PR TITLE
Charts: Check for output dir conflicts

### DIFF
--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -38,6 +38,11 @@ func TestAdd(t *testing.T) {
 	err = c.Add([]string{"stable/prometheus@11.12.1"})
 	assert.EqualError(t, err, "1 Chart(s) were skipped. Please check above logs for details")
 
+	// Adding a chart with a different version to the same path, causes a conflict
+	err = c.Add([]string{"stable/prometheus@11.12.0"})
+	assert.EqualError(t, err, `Output directory conflicts found:
+ - output directory "prometheus" is used twice, by charts "stable/prometheus@11.12.1" and "stable/prometheus@11.12.0"`)
+
 	// Add a chart with a specific extract directory
 	err = c.Add([]string{"stable/prometheus@11.12.0:prometheus-11.12.0"})
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/508

Whenever two charts will end up in the same dir, tanka will exit before doing anything

Ex, these two versions would end up in the flagger dir:
```yaml
directory: charts
repositories:
- name: flagger
  url: https://flagger.app
requires:
- chart: flagger/flagger
  version: 1.16.1
- chart: flagger/flagger
  version: 1.17.0
version: 1
```

```console
$ tk tool charts vendor
Error: Output directory conflicts found:
 - output directory "flagger" is used twice, by charts "flagger/flagger@1.16.1" and "flagger/flagger@1.17.0"
```

It checks in both `add` and `vendor` commands to handle the case where someone writes their YAML manually