### PR TITLE
Charts: Tighten validations

### DIFF
--- a/pkg/helm/spec.go
+++ b/pkg/helm/spec.go
@@ -59,6 +59,17 @@ func (r Repos) Has(repo Repo) bool {
 	return false
 }
 
+// Has reports whether one of the repos has the given name
+func (r Repos) HasName(repoName string) bool {
+	for _, x := range r {
+		if x.Name == repoName {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Requirement describes a single required Helm Chart.
 // Both, Chart and Version are required
 type Requirement struct {


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/691 which is mostly a failure of error messages imo

Instead of getting a `no such file`, the error is now: 
```console
$ tk tool charts add https://helm.releases.hashicorp.com/vault@0.19.0
Adding 1 Charts ...
 Skipping https://helm.releases.hashicorp.com/vault@0.19.0: not of form 'repo/chart@version(:path)' where repo contains no special characters.
Error: 1 Chart(s) were skipped. Please check above logs for details
```

Also, adding an invalid repo now prints out a relevant error message instead of failing in helm commands
```console
$ tk tool charts add-repo https://helm.releases.hashicorp.com  https://helm.releases.hashicorp.com
 Skipping https://helm.releases.hashicorp.com: invalid name. cannot contain any special characters.
Error: 1 Repo(s) were skipped. Please check above logs for details
```
