### PR TITLE
Export: Un-hide the memory ballast setting

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"runtime"
 
@@ -39,11 +38,7 @@ func exportCmd() *cli.Command {
 	parallel := cmd.Flags().IntP("parallel", "p", 8, "Number of environments to process in parallel")
 	cachePath := cmd.Flags().StringP("cache-path", "c", "", "Local file path where cached evaluations should be stored")
 	cacheEnvs := cmd.Flags().StringArrayP("cache-envs", "e", nil, "Regexes which define which environment should be cached (if caching is enabled)")
-
-	ballastBytes := cmd.Flags().Int("mem-ballast-size-bytes", 0, "(Experimental) Size of memory ballast to allocate.")
-	if err := cmd.Flags().MarkHidden("mem-ballast-size-bytes"); err != nil {
-		log.Fatalf("Could not mark flag as hidden: %s", err)
-	}
+	ballastBytes := cmd.Flags().Int("mem-ballast-size-bytes", 0, "Size of memory ballast to allocate. This may improve performance for large environments.")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())

--- a/docs/docs/exporting.md
+++ b/docs/docs/exporting.md
@@ -103,7 +103,7 @@ $ tk export exportDir environments/ -r -l team=infra
 
 _Read [this blog post](https://blog.twitch.tv/en/2019/04/10/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap/) for more information about memory ballasts._
 
-For large environments that have to load lots of data into memory when evaluation, a memory ballast can dramatically improve performance. This is exposed through the `--mem-ballast-size-bytes` flag on the export command.
+For large environments that load lots of data into memory on evaluation, a memory ballast can dramatically improve performance. This feature is exposed through the `--mem-ballast-size-bytes` flag on the export command.
 
 Anecdotally (Grafana Labs), environments that took around a minute to load were able to load in around 45 secs with a ballast of 5GB (`--mem-ballast-size-bytes=5368709120`). Decreasing the ballast size resulted in negative impact on performance, and increasing it more did not result in any noticeable impact.
 

--- a/docs/docs/exporting.md
+++ b/docs/docs/exporting.md
@@ -99,6 +99,14 @@ $ tk export exportDir environments/ --recursive
 $ tk export exportDir environments/ -r -l team=infra
 ```
 
+## Using a memory ballast
+
+_Read [this blog post](https://blog.twitch.tv/en/2019/04/10/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap/) for more information about memory ballasts._
+
+For large environments that have to load lots of data into memory when evaluation, a memory ballast can dramatically improve performance. This is exposed through the `--mem-ballast-size-bytes` flag on the export command.
+
+Anecdotally (Grafana Labs), environments that took around a minute to load were able to load in around 45 secs with a ballast of 5GB (`--mem-ballast-size-bytes=5368709120`). Decreasing the ballast size resulted in negative impact on performance, and increasing it more did not result in any noticeable impact.
+
 ## Caching
 
 Tanka can also cache the results of the export. This is useful if you often export the same files and want to avoid recomputing them. The cache key is calculated from the main file and all of its transitive imports, so any change to any file possibly used in an environment will invalidate the cache.


### PR DESCRIPTION
We've been using it for a [long while](https://github.com/grafana/tanka/pull/669) now, works very well!
Also documented it