### PR TITLE
Helm Charts: Fix `vendor --prune` for custom dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.22.1 (2022-06-06)
+## Unreleased
 
-### Bug Fixes
+### Bug Fixes/Enhancements
 
 - **helm**: Fix `vendor --prune` deleting charts with a custom directory
   **[#717](https://github.com/grafana/tanka/pull/717)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.22.1 (2022-06-06)
+
+### Bug Fixes
+
+- **helm**: Fix `vendor --prune` deleting charts with a custom directory
+  **[#717](https://github.com/grafana/tanka/pull/717)**
+
 ## 0.22.0 (2022-06-03)
 
 ### Features

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -107,13 +107,12 @@ func (c Charts) Vendor(prune bool) error {
 	repositoriesUpdated := false
 	log.Println("Vendoring...")
 	for _, r := range c.Manifest.Requires {
-		chartName := parseReqName(r.Chart)
-		chartPath := filepath.Join(dir, chartName)
-		expectedDirs[chartName] = true
-
+		chartSubDir := parseReqName(r.Chart)
 		if r.Directory != "" {
-			chartPath = filepath.Join(dir, r.Directory)
+			chartSubDir = r.Directory
 		}
+		chartPath := filepath.Join(dir, chartSubDir)
+		expectedDirs[chartSubDir] = true
 
 		_, err := os.Stat(chartPath)
 		if err == nil {

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -137,6 +137,10 @@ func TestPrune(t *testing.T) {
 			err = c.Add([]string{"stable/prometheus@11.12.1"})
 			require.NoError(t, err)
 
+			// Add a chart with a directory
+			err = c.Add([]string{"stable/prometheus@11.12.1:custom-dir"})
+			require.NoError(t, err)
+
 			// Add unrelated files and folders
 			err = os.WriteFile(filepath.Join(tempDir, "charts", "foo.txt"), []byte("foo"), 0644)
 			err = os.Mkdir(filepath.Join(tempDir, "charts", "foo"), 0755)
@@ -151,9 +155,11 @@ func TestPrune(t *testing.T) {
 			listResult, err := os.ReadDir(filepath.Join(tempDir, "charts"))
 			assert.NoError(t, err)
 			if prune {
-				assert.Equal(t, 1, len(listResult))
+				assert.Equal(t, 2, len(listResult))
+				assert.Equal(t, "custom-dir", listResult[0].Name())
+				assert.Equal(t, "prometheus", listResult[1].Name())
 			} else {
-				assert.Equal(t, 3, len(listResult))
+				assert.Equal(t, 4, len(listResult))
 				chartContent, err := os.ReadFile(filepath.Join(tempDir, "charts", "foo", "Chart.yaml"))
 				assert.NoError(t, err)
 				assert.Contains(t, string(chartContent), `foo`)


### PR DESCRIPTION
Charts with a custom directory defined are getting pruned 🤦