### PR TITLE
Helm Charts: Prevent vendor panic by adding validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **helm**: Fix `vendor --prune` deleting charts with a custom directory
   **[#717](https://github.com/grafana/tanka/pull/717)**
+- **helm**: Add validation at vendoring time for invalid chart names
+  **[#718](https://github.com/grafana/tanka/pull/718)**
 
 ## 0.22.0 (2022-06-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.22.1 (2022-06-06)
+
+### Bug Fixes
+
+- **helm**: Fix `vendor --prune` deleting charts with a custom directory
+  **[#717](https://github.com/grafana/tanka/pull/717)**
+
 ## 0.22.0 (2022-06-03)
 
 ### Features

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -98,7 +98,7 @@ func (c Charts) Vendor(prune bool) error {
 	}
 
 	// Check that there are no output conflicts before vendoring
-	if err := c.Manifest.Requires.CheckForOutputConflicts(); err != nil {
+	if err := c.Manifest.Requires.Validate(); err != nil {
 		return err
 	}
 
@@ -207,7 +207,7 @@ func (c *Charts) Add(reqs []string) error {
 		log.Println(" OK:", s)
 	}
 
-	if err := requirements.CheckForOutputConflicts(); err != nil {
+	if err := requirements.Validate(); err != nil {
 		return err
 	}
 
@@ -323,6 +323,9 @@ func parseReqRepo(s string) string {
 // parseReqName parses a name from a string of the format `repo/name`
 func parseReqName(s string) string {
 	elems := strings.SplitN(s, "/", 2)
+	if len(elems) == 1 {
+		return ""
+	}
 	name := elems[1]
 	return name
 }

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -107,13 +107,12 @@ func (c Charts) Vendor(prune bool) error {
 	repositoriesUpdated := false
 	log.Println("Vendoring...")
 	for _, r := range c.Manifest.Requires {
-		chartName := parseReqName(r.Chart)
-		chartPath := filepath.Join(dir, chartName)
-		expectedDirs[chartName] = true
-
+		chartSubDir := parseReqName(r.Chart)
 		if r.Directory != "" {
-			chartPath = filepath.Join(dir, r.Directory)
+			chartSubDir = r.Directory
 		}
+		chartPath := filepath.Join(dir, chartSubDir)
+		expectedDirs[chartSubDir] = true
 
 		_, err := os.Stat(chartPath)
 		if err == nil {

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -103,7 +103,7 @@ func TestAdd(t *testing.T) {
 
 	// Adding a chart with a different version to the same path, causes a conflict
 	err = c.Add([]string{"stable/prometheus@11.12.0"})
-	assert.EqualError(t, err, `Output directory conflicts found:
+	assert.EqualError(t, err, `Validation errors:
  - output directory "prometheus" is used twice, by charts "stable/prometheus@11.12.1" and "stable/prometheus@11.12.0"`)
 
 	// Add a chart with a specific extract directory
@@ -166,4 +166,19 @@ func TestPrune(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInvalidChartName(t *testing.T) {
+	tempDir := t.TempDir()
+	c, err := InitChartfile(filepath.Join(tempDir, Filename))
+	require.NoError(t, err)
+
+	c.Manifest.Requires = append(c.Manifest.Requires, Requirement{
+		Chart:   "noslash",
+		Version: *semver.MustParse("1.0.0"),
+	})
+
+	err = c.Vendor(false)
+	assert.EqualError(t, err, `Validation errors:
+ - Chart name "noslash" is not valid. Expecting a repo/name format.`)
 }

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -137,6 +137,10 @@ func TestPrune(t *testing.T) {
 			err = c.Add([]string{"stable/prometheus@11.12.1"})
 			require.NoError(t, err)
 
+			// Add a chart with a directory
+			err = c.Add([]string{"stable/prometheus@11.12.1:custom-dir"})
+			require.NoError(t, err)
+
 			// Add unrelated files and folders
 			err = os.WriteFile(filepath.Join(tempDir, "charts", "foo.txt"), []byte("foo"), 0644)
 			err = os.Mkdir(filepath.Join(tempDir, "charts", "foo"), 0755)
@@ -151,9 +155,11 @@ func TestPrune(t *testing.T) {
 			listResult, err := os.ReadDir(filepath.Join(tempDir, "charts"))
 			assert.NoError(t, err)
 			if prune {
-				assert.Equal(t, 1, len(listResult))
+				assert.Equal(t, 2, len(listResult))
+				assert.Equal(t, "custom-dir", listResult[0].Name())
+				assert.Equal(t, "prometheus", listResult[1].Name())
 			} else {
-				assert.Equal(t, 3, len(listResult))
+				assert.Equal(t, 4, len(listResult))
 				chartContent, err := os.ReadFile(filepath.Join(tempDir, "charts", "foo", "Chart.yaml"))
 				assert.NoError(t, err)
 				assert.Contains(t, string(chartContent), `foo`)

--- a/pkg/helm/spec.go
+++ b/pkg/helm/spec.go
@@ -100,11 +100,16 @@ func (r Requirements) Has(req Requirement) bool {
 	return false
 }
 
-func (r Requirements) CheckForOutputConflicts() error {
+func (r Requirements) Validate() error {
 	outputDirs := make(map[string]Requirement)
 	errs := make([]string, 0)
 
 	for _, req := range r {
+		if !strings.Contains(req.Chart, "/") {
+			errs = append(errs, fmt.Sprintf("Chart name %q is not valid. Expecting a repo/name format.", req.Chart))
+			continue
+		}
+
 		dir := req.Directory
 		if dir == "" {
 			dir = parseReqName(req.Chart)
@@ -116,7 +121,7 @@ func (r Requirements) CheckForOutputConflicts() error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("Output directory conflicts found:\n - " + strings.Join(errs, "\n - "))
+		return fmt.Errorf("Validation errors:\n - " + strings.Join(errs, "\n - "))
 	}
 
 	return nil


### PR DESCRIPTION
This one was pre-existing :)

Given this chartfile:
```yaml
repositories:
- name: prefect
  url: https://prefecthq.github.io/server/
requires:
- chart: prefect
  version: '2022.04.14'
version: 1
```

We get a panic because the name cannot be split into its two parts

It's not possible to add this dependency using the `add` command but given that we want to also support manual edits to the yaml file, additional validation can be nice