### PR TITLE
Helm Charts: Fix cross-device link error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   **[#717](https://github.com/grafana/tanka/pull/717)**
 - **helm**: Add validation at vendoring time for invalid chart names
   **[#718](https://github.com/grafana/tanka/pull/718)**
+- **helm**: Fix cross-device link error when tmp is mounted on a different device
+  **[#720](https://github.com/grafana/tanka/pull/720)**
 
 ## 0.22.0 (2022-06-03)
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -50,7 +50,8 @@ func (e ExecHelm) Pull(chart, version string, opts PullOpts) error {
 	}
 	defer os.Remove(repoFile)
 
-	tempDir, err := os.MkdirTemp("", "charts-pull")
+	// Pull to a temp dir within the destination directory (not /tmp) to avoid possible cross-device issues when renaming
+	tempDir, err := os.MkdirTemp(opts.Destination, ".pull-")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/719
By using `/tmp` as a pull target, we possibly pull to a different disk than the destination
This makes `os.Rename` impossible
To fix this, we can pull to a temporary dir within the destination instead