### PR TITLE
doc: update instructions for installing from source

### DIFF
--- a/docs/src/components/install/jb/go.mdx
+++ b/docs/src/components/install/jb/go.mdx
@@ -1,6 +1,6 @@
-If you happen to have a local [Go](https://golang.org) toolchain available, you can build from source using `go get`:
+If you happen to have a local [Go](https://golang.org) toolchain available, you can build from source using `go install`:
 
 ```bash
 $ cd /tmp
-$ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+$ go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 ```

--- a/docs/src/components/install/tk/go.mdx
+++ b/docs/src/components/install/tk/go.mdx
@@ -1,8 +1,8 @@
-If you happen to have a local [Go](https://golang.org) toolchain, you can also build Tanka from source using `go get`:
+If you happen to have a local [Go](https://golang.org) toolchain, you can also build Tanka from source using `go install`:
 
 ```bash
 $ cd /tmp
-$ GO111MODULE=on go get github.com/grafana/tanka/cmd/tk
+$ go install github.com/grafana/tanka/cmd/tk@latest
 ```
 
 If that does not work for whatever reason (Go modules, etc), clone and compile manually:


### PR DESCRIPTION
`go get` & `go install` behavior has changed since Go 1.17: https://go.dev/doc/go-get-install-deprecation