### PR TITLE
Docs: Fix broken links and redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   never see boilerplate again!
 - **:dart: Confidence**: Stop guessing and use `tk diff` to see what exactly will happen
 - **:telescope: Helm**: Vendor in, modify, and export [Helm charts reproducibly](https://tanka.dev/helm#helm-support)
-- **:rocket: Production ready**: Tanka deploys [Grafana Cloud](https://grafana.com/cloud) and many more production setups
+- **:rocket: Production ready**: Tanka deploys [Grafana Cloud](https://grafana.com/products/cloud/) and many more production setups
 
 <br />
 <p align="center">

--- a/docs/docs/exporting.md
+++ b/docs/docs/exporting.md
@@ -45,7 +45,7 @@ If that does not fit your need, you can provide your own pattern using the `--fo
 tk export promtail environments/promtail --format='{{.metadata.labels.app}}-{{.metadata.name}}-{{.kind}}'
 ```
 
-> The syntax is Go `text/template`. See https://golang.org/pkg/text/template/
+> The syntax is Go `text/template`. See <https://pkg.go.dev/text/template>
 > for reference.
 
 This would include the label named `app`, the `name` and `kind` of the resource:

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -39,7 +39,7 @@ available** and are not likely to be ever added.
 Tanka development has started at the time when kubecfg was a part of
 already-deprecated `ksonnet` project. Although these projects are similar, Tanka
 aims to provide continuity for `ksonnet` users, whereas `kubecfg` is (according
-to the project's [README.md](https://github.com/bitnami/kubecfg/blob/master/README.md))
+to the project's [README.md](https://github.com/vmware-archive/kubecfg/blob/main/README.md))
 really just a thin Kubernetes-specific wrapper around jsonnet evaluation.
 
 ## Why not Helm?

--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -25,7 +25,7 @@ jb install github.com/grafana/jsonnet-libs/tanka-util
 ```
 
 The following example shows how to extract the individual resources of the
-[`grafana`](https://hub.helm.sh/charts/grafana/grafana) Helm Chart:
+[`grafana`](https://artifacthub.io/packages/helm/grafana/grafana) Helm Chart:
 
 ```jsonnet
 local tanka = import "github.com/grafana/jsonnet-libs/tanka-util/main.libsonnet";

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -9,7 +9,7 @@ import { PlatformInstall, Tanka, Jb } from "../src/components/install"
 
 Tanka is distributed as a single binary called `tk`. It already includes the Jsonnet compiler, but requires some tools to be available:
 
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): Tanka
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/): Tanka
   uses `kubectl` to communicate to your cluster. This means `kubectl` must be
   available somewhere on your `$PATH`. If you ever have worked with Kubernetes
   before, this should be the case anyways.

--- a/docs/docs/jsonnet/native-functions.md
+++ b/docs/docs/jsonnet/native-functions.md
@@ -176,7 +176,7 @@ regexMatch(string regex, string s) boolean
 ```
 
 `regexMatch` returns whether the given string is matched by the given
-[RE2](https://golang.org/s/re2syntax) regular expression.
+[RE2](https://github.com/google/re2/wiki/Syntax) regular expression.
 
 ### Examples
 

--- a/docs/docs/jsonnet/overview.md
+++ b/docs/docs/jsonnet/overview.md
@@ -64,8 +64,8 @@ available as a `local` variable called `secret`.
 When using Tanka, it is also possible to directly import `.json` and `.yaml`
 files, as if they were a `.libsonnet`.
 
-Make sure to take also take a look on [Libraries](libraries.md) and
-[Vendoring](vendoring.md) to learn how to use `import` to re-use code.
+Make sure to also take a look at the libraries documentation to learn how to use `import` and re-use code.
+The documentation on [Tanka import paths](/libraries/import-paths) and [vendoring](/libraries/install-publish) are useful to understand how imports work in Tanka's context.
 
 ### Merging
 

--- a/docs/docs/kustomize.mdx
+++ b/docs/docs/kustomize.mdx
@@ -76,7 +76,7 @@ Tanka, like Jsonnet, is hermetic. It **always yields the same resources** when
 the project is strictly self-contained.
 
 Kustomize however has the ability to pull
-[resources](https://kubectl.docs.kubernetes.io/references/kustomize/resource/)
+[resources](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/resource/)
 from different sources at runtime, which violates above requirement. This is
 also apparent in the example above.
 

--- a/docs/docs/targets.md
+++ b/docs/docs/targets.md
@@ -34,7 +34,7 @@ multiple objects.
 ## Regular Expressions
 
 The argument passed to the `--target` flag is interpreted as a
-[RE2](https://golang.org/s/re2syntax) regular expression.
+[RE2](https://github.com/google/re2/wiki/Syntax) regular expression.
 
 This allows you to use all sorts of wildcards and other advanced matching
 functionality to select Kubernetes objects:

--- a/docs/docs/tutorial/jsonnet.mdx
+++ b/docs/docs/tutorial/jsonnet.mdx
@@ -47,10 +47,10 @@ When using Tanka, you apply **configuration** for an **Environment** to a
 Kubernetes **cluster**. An Environment is some logical group of pieces that form
 an application stack.
 
-[Grafana Labs](https://grafana.com) for example runs [Loki](https://grafana.com/loki),
+[Grafana Labs](https://grafana.com) for example runs [Loki](https://grafana.com/oss/loki/),
 [Cortex](https://cortexmetrics.io) and of course
-[Grafana](https://grafana.com/grafana) for our [Grafana
-Cloud](https://grafana.com/cloud) hosted offering. For each of these, we have a
+[Grafana](https://grafana.com/grafana/) for our [Grafana
+Cloud](https://grafana.com/products/cloud/) hosted offering. For each of these, we have a
 separate environment. Furthermore, we like to see changes to our code in
 separate `dev` setups to make sure they are all good for production usage – so
 we have `dev` and `prod` environments for each app as well, as `prod`


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/726
I ran a linkchecker (https://github.com/grafana/tanka/pull/737) which found a bunch of issues
It unfortunately has a bunch of unrelated errors so I'm not pushing it through but here are the fixes for broken links in the docs