### PR TITLE
Add new `--auto-approve=if-no-changes` option

### DIFF
--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -24,6 +24,18 @@ func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	return &v
 }
 
+func addApplyFlags(fs *pflag.FlagSet, opts *tanka.ApplyBaseOpts, autoApproveDeprecated *bool, autoApprove *string) {
+	fs.StringVar(&opts.DryRun, "dry-run", "", `--dry-run parameter to pass down to kubectl, must be "none", "server", or "client"`)
+	fs.BoolVar(&opts.Force, "force", false, "force applying (kubectl apply --force)")
+
+	// Parse the auto-approve flag (choice), still supporting the deprecated dangerous-auto-approve flag (boolean)
+	fs.BoolVar(autoApproveDeprecated, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
+	if err := fs.MarkDeprecated("dangerous-auto-approve", "use --auto-approve instead"); err != nil {
+		log.Fatalf("failed to mark deprecated flag: %s", err)
+	}
+	fs.StringVar(autoApprove, "auto-approve", "", "skip interactive approval. Only for automation! Allowed values: 'always', 'never', 'if-no-changes'")
+}
+
 func labelSelectorFlag(fs *pflag.FlagSet) func() labels.Selector {
 	labelSelector := fs.StringP("selector", "l", "", "Label selector. Uses the same syntax as kubectl does")
 

--- a/cmd/tk/workflow_test.go
+++ b/cmd/tk/workflow_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/tanka/pkg/tanka"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAutoApprove(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		autoApproveDeprecated bool
+		autoApproveString     string
+		expected              tanka.AutoApproveSetting
+		expectErr             error
+	}{
+		{
+			name:     "default",
+			expected: tanka.AutoApproveNever,
+		},
+		{
+			name:                  "deprecated bool set",
+			autoApproveDeprecated: true,
+			expected:              tanka.AutoApproveAlways,
+		},
+		{
+			name:                  "both values set",
+			autoApproveDeprecated: true,
+			autoApproveString:     "never",
+			expectErr:             errors.New("--dangerous-auto-approve and --auto-approve are mutually exclusive"),
+		},
+		{
+			name:              "always",
+			autoApproveString: "always",
+			expected:          tanka.AutoApproveAlways,
+		},
+		{
+			name:              "never",
+			autoApproveString: "never",
+			expected:          tanka.AutoApproveNever,
+		},
+		{
+			name:              "if-no-changes",
+			autoApproveString: "if-no-changes",
+			expected:          tanka.AutoApproveNoChanges,
+		},
+		{
+			name:              "bad value",
+			autoApproveString: "blabla",
+			expectErr:         errors.New("invalid value for --auto-approve: blabla"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := validateAutoApprove(tc.autoApproveDeprecated, tc.autoApproveString)
+			if tc.expectErr != nil {
+				assert.EqualError(t, err, tc.expectErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -12,14 +12,7 @@ import (
 
 // PruneOpts specify additional properties for the Prune action
 type PruneOpts struct {
-	Opts
-
-	// AutoApprove skips the interactive approval
-	AutoApprove bool
-	// Force ignores any warnings kubectl might have
-	Force bool
-	// DryRun string passed to kubectl as --dry-run=<DryRun>
-	DryRun string
+	ApplyBaseOpts
 }
 
 // Prune deletes all resources from the cluster, that are no longer present in
@@ -73,13 +66,15 @@ func Prune(baseDir string, opts PruneOpts) error {
 	}
 
 	// prompt for confirm
-	if opts.AutoApprove {
+	if opts.AutoApprove == AutoApproveAlways {
+		// Skip approval
 	} else if err := confirmPrompt("Pruning from", p.Env.Spec.Namespace, kube.Info()); err != nil {
 		return err
 	}
 
 	// delete resources
 	return kube.Delete(orphaned, kubernetes.DeleteOpts{
-		Force: opts.Force,
+		Force:  opts.Force,
+		DryRun: opts.DryRun,
 	})
 }


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/743 
Closes https://github.com/grafana/tanka/issues/693 
It replaces the `--dangerous-auto-approve` option. It has three values: `always`, `never` and `if-no-changes`

In this PR, I also create a common structure for args that are shared between `prune`, `delete` and `apply` Doing so, I found two bugs:
- Removed the `--validate` option on `delete`, it wasn't used
- Wired in `--dry-run` to the `prune` command, it was exposed but didn't make it to kubectl