### PR TITLE
`getSnippetHash`: Use regexp instead of parsing whole AST

### DIFF
--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -200,7 +200,10 @@ func findImportRecursiveRegexp(list map[string]bool, vm *jsonnet.VM, filename, c
 		if err != nil {
 			continue
 		}
-		abs, _ := filepath.Abs(foundAt)
+		abs, err := filepath.Abs(foundAt)
+		if err != nil {
+			return err
+		}
 
 		if list[abs] {
 			return nil

--- a/pkg/jsonnet/imports.go
+++ b/pkg/jsonnet/imports.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"sync"
 
@@ -17,6 +18,8 @@ import (
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/jsonnet/native"
 )
+
+var importsRegexp = regexp.MustCompile(`import(str)?\s+['"]([^'"%()]+)['"]`)
 
 // TransitiveImports returns all recursive imports of an environment
 func TransitiveImports(dir string) ([]string, error) {
@@ -155,9 +158,8 @@ var fileHashes sync.Map
 // and the content of all of its dependencies.
 // File hashes are cached in-memory to optimize multiple executions of this function in a process
 func getSnippetHash(vm *jsonnet.VM, path, data string) (string, error) {
-	node, _ := jsonnet.SnippetToAST(path, data)
 	result := map[string]bool{}
-	if err := importRecursive(result, vm, node, path, true); err != nil {
+	if err := findImportRecursiveRegexp(result, vm, path, data); err != nil {
 		return "", err
 	}
 	fileNames := []string{}
@@ -187,16 +189,31 @@ func getSnippetHash(vm *jsonnet.VM, path, data string) (string, error) {
 	return base64.URLEncoding.EncodeToString(fullHasher.Sum(nil)), nil
 }
 
-func uniqueStringSlice(s []string) []string {
-	seen := make(map[string]struct{}, len(s))
-	j := 0
-	for _, v := range s {
-		if _, ok := seen[v]; ok {
+// findImportRecursiveRegexp does the same as `importRecursive` but uses a regexp
+// rather than parsing the AST of all files. This is much faster, but can lead to
+// false positives (e.g. if a string contains `import "foo"`).
+func findImportRecursiveRegexp(list map[string]bool, vm *jsonnet.VM, filename, content string) error {
+	matches := importsRegexp.FindAllStringSubmatch(content, -1)
+
+	for _, match := range matches {
+		importContents, foundAt, err := vm.ImportData(filename, match[2])
+		if err != nil {
 			continue
 		}
-		seen[v] = struct{}{}
-		s[j] = v
-		j++
+		abs, _ := filepath.Abs(foundAt)
+
+		if list[abs] {
+			return nil
+		}
+		list[abs] = true
+
+		if match[1] == "str" {
+			continue
+		}
+
+		if err := findImportRecursiveRegexp(list, vm, abs, importContents); err != nil {
+			return err
+		}
 	}
-	return s[:j]
+	return nil
 }


### PR DESCRIPTION
When calculating the env hash to use as cache keys, we don't need an exact list of imports 
Therefore, to improve performance, we can replace the current strategy of using the AST by a regexp strategy. 
This new strategy can lead to false positives (e.g. a string containing import 'foo') but this is not an issue for the hashing function. 
All that matters is that the hash is consistent and accounts for all files (no false negatives)

On actual huge real-life environments, I have seen improvements of up to 95% (from 2s to 100ms)