### PR TITLE
Add `golangci-lint` with default linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 .PHONY: lint test static install uninstall cross
+GOPATH := $(shell go env GOPATH)
 VERSION := $(shell git describe --tags --dirty --always)
 BIN_DIR := $(GOPATH)/bin
 GOX := $(BIN_DIR)/gox
+GOLINTER := $(GOPATH)/bin/golangci-lint
 
-lint:
+$(GOLINTER):
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+
+lint: $(GOLINTER)
 	test -z $$(gofmt -s -l cmd/ pkg/ | tee /dev/stderr)
 	go vet ./...
+	$(GOLINTER) run
 
 test:
 	go test ./...

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -6,16 +6,12 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/go-clix/cli"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/grafana/tanka/pkg/tanka"
 )
 
-// describing variables
-var (
-	verbose     = false
-	interactive = terminal.IsTerminal(int(os.Stdout.Fd()))
-)
+var interactive = term.IsTerminal(int(os.Stdout.Fd()))
 
 func main() {
 	log.SetFlags(0)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,8 @@ require (
 	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.1
 	github.com/thoas/go-funk v0.9.2
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/apimachinery v0.23.6
@@ -43,7 +44,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	k8s.io/klog/v2 v2.40.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -166,22 +166,17 @@ func TestPrune(t *testing.T) {
 			require.NoError(t, err)
 
 			// Add a chart
-			err = c.Add([]string{"stable/prometheus@11.12.1"})
-			require.NoError(t, err)
+			require.NoError(t, c.Add([]string{"stable/prometheus@11.12.1"}))
 
 			// Add a chart with a directory
-			err = c.Add([]string{"stable/prometheus@11.12.1:custom-dir"})
-			require.NoError(t, err)
+			require.NoError(t, c.Add([]string{"stable/prometheus@11.12.1:custom-dir"}))
 
 			// Add unrelated files and folders
-			err = os.WriteFile(filepath.Join(tempDir, "charts", "foo.txt"), []byte("foo"), 0644)
-			err = os.Mkdir(filepath.Join(tempDir, "charts", "foo"), 0755)
-			require.NoError(t, err)
-			err = os.WriteFile(filepath.Join(tempDir, "charts", "foo", "Chart.yaml"), []byte("foo"), 0644)
-			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(tempDir, "charts", "foo.txt"), []byte("foo"), 0644))
+			require.NoError(t, os.Mkdir(filepath.Join(tempDir, "charts", "foo"), 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(tempDir, "charts", "foo", "Chart.yaml"), []byte("foo"), 0644))
 
-			err = c.Vendor(prune)
-			require.NoError(t, err)
+			require.NoError(t, c.Vendor(prune))
 
 			// Check if files are pruned
 			listResult, err := os.ReadDir(filepath.Join(tempDir, "charts"))

--- a/pkg/jsonnet/jpath/dirs_test.go
+++ b/pkg/jsonnet/jpath/dirs_test.go
@@ -99,7 +99,7 @@ func TestDirs(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer os.Chdir(origDir)
+			defer func() { require.NoError(t, os.Chdir(origDir)) }()
 
 			// go to testdata
 			require.NoError(t, os.Chdir(c.data))

--- a/pkg/jsonnet/lint.go
+++ b/pkg/jsonnet/lint.go
@@ -3,7 +3,7 @@ package jsonnet
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/gobwas/glob"
@@ -69,7 +69,7 @@ func Lint(fds []string, opts *LintOpts) error {
 
 			vm.Importer(NewExtendedImporter(jpaths))
 
-			content, _ := ioutil.ReadFile(file)
+			content, _ := os.ReadFile(file)
 			failed := linter.LintSnippet(vm, buf, []linter.Snippet{{FileName: file, Code: string(content)}})
 			resultCh <- result{failed: failed, output: buf.String()}
 		}

--- a/pkg/kubernetes/client/kubectl.go
+++ b/pkg/kubernetes/client/kubectl.go
@@ -77,7 +77,7 @@ func (k Kubectl) Namespaces() (map[string]bool, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrap(err, string(serr.Bytes()))
+		return nil, errors.Wrap(err, serr.String())
 	}
 
 	var list manifest.Manifest

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
-
 	"github.com/Masterminds/semver"
 
 	"github.com/grafana/tanka/pkg/kubernetes/client"
@@ -85,11 +83,4 @@ type DiffOpts struct {
 // Info about the client, etc.
 func (k *Kubernetes) Info() client.Info {
 	return k.ctl.Info()
-}
-
-func objectspec(m manifest.Manifest) string {
-	return fmt.Sprintf("%s/%s",
-		m.Kind(),
-		m.Metadata().Name(),
-	)
 }

--- a/pkg/process/data_test.go
+++ b/pkg/process/data_test.go
@@ -3,10 +3,11 @@ package process
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // testData holds data for tests
@@ -16,7 +17,8 @@ type testData struct {
 }
 
 func loadFixture(name string) testData {
-	filename := "./testdata/td" + strings.Title(name) + ".jsonnet"
+	caser := cases.Title(language.English)
+	filename := "./testdata/td" + caser.String(name) + ".jsonnet"
 
 	vm := jsonnet.MakeVM(jsonnet.Opts{
 		ImportPaths: []string{"./testdata"},

--- a/pkg/process/data_test.go
+++ b/pkg/process/data_test.go
@@ -3,11 +3,10 @@ package process
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	"github.com/grafana/tanka/pkg/jsonnet"
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 // testData holds data for tests
@@ -17,8 +16,7 @@ type testData struct {
 }
 
 func loadFixture(name string) testData {
-	caser := cases.Title(language.English)
-	filename := "./testdata/td" + caser.String(name) + ".jsonnet"
+	filename := filepath.Join("./testdata", name)
 
 	vm := jsonnet.MakeVM(jsonnet.Opts{
 		ImportPaths: []string{"./testdata"},
@@ -40,27 +38,27 @@ func loadFixture(name string) testData {
 // testDataRegular is a regular output of jsonnet without special things, but it
 // is nested.
 func testDataRegular() testData {
-	return loadFixture("regular")
+	return loadFixture("tdRegular.jsonnet")
 }
 
 // testDataFlat is a flat manifest that does not need reconciliation
 func testDataFlat() testData {
-	return loadFixture("flat")
+	return loadFixture("tdFlat.jsonnet")
 }
 
 // testDataPrimitive is an invalid manifest, because it ends with a primitive
 // without including required fields
 func testDataPrimitive() testData {
-	return loadFixture("invalidPrimitive")
+	return loadFixture("tdInvalidPrimitive.jsonnet")
 }
 
 // testDataDeep is super deeply nested on multiple levels
 func testDataDeep() testData {
-	return loadFixture("deep")
+	return loadFixture("tdDeep.jsonnet")
 }
 
 // testDataArray is an array of (deeply nested) dicts that should be fully
 // flattened
 func testDataArray() testData {
-	return loadFixture("array")
+	return loadFixture("tdArray.jsonnet")
 }

--- a/pkg/process/filter.go
+++ b/pkg/process/filter.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Filter returns all elements of the list that match at least one expression
@@ -105,7 +107,8 @@ type ErrBadExpr struct {
 }
 
 func (e ErrBadExpr) Error() string {
-	return fmt.Sprintf("%s.\nSee https://tanka.dev/output-filtering/#regular-expressions for details on regular expressions.", strings.Title(e.inner.Error()))
+	caser := cases.Title(language.English)
+	return fmt.Sprintf("%s.\nSee https://tanka.dev/output-filtering/#regular-expressions for details on regular expressions.", caser.String(e.inner.Error()))
 }
 
 // NexMatcher is a matcher that inverts the original behaviour

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -75,10 +75,10 @@ func TestProcess(t *testing.T) {
 		},
 		{
 			name: "unwrap-list",
-			deep: loadFixture("list").Deep,
+			deep: loadFixture("tdList.jsonnet").Deep,
 			flat: manifest.List{
-				loadFixture("list").Flat["foo.items[0]"],
-				loadFixture("list").Flat["foo.items[1]"],
+				loadFixture("tdList.jsonnet").Flat["foo.items[0]"],
+				loadFixture("tdList.jsonnet").Flat["foo.items[1]"],
 			},
 		},
 		{

--- a/pkg/tanka/format.go
+++ b/pkg/tanka/format.go
@@ -49,7 +49,7 @@ func FormatFiles(fds []string, opts *FormatOpts) ([]string, error) {
 	}
 
 	// print each file?
-	printFn := func(...interface{}) { return }
+	printFn := func(...interface{}) {}
 	if opts.PrintNames {
 		printFn = func(i ...interface{}) { fmt.Println(i...) }
 	}

--- a/pkg/tanka/load_test.go
+++ b/pkg/tanka/load_test.go
@@ -182,7 +182,7 @@ func TestLoadEnvironmentFallbackToName(t *testing.T) {
 	require.NoError(t, err)
 	err = os.Chdir("./testdata/cases/multiple-inline-envs")
 	require.NoError(t, err)
-	defer os.Chdir(cwd)
+	defer func() { require.NoError(t, os.Chdir(cwd)) }()
 
 	// Partial match two environments
 	_, err = Load("env1", Opts{})


### PR DESCRIPTION
Just an initial go at fixing some minor code issues.

Some linters (like `revive`) will find lots of things so I'm starting with an initial basic run