### PR TITLE
Use `zerolog` instead of `log`

### DIFF
--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -31,7 +31,7 @@ func addApplyFlags(fs *pflag.FlagSet, opts *tanka.ApplyBaseOpts, autoApproveDepr
 	// Parse the auto-approve flag (choice), still supporting the deprecated dangerous-auto-approve flag (boolean)
 	fs.BoolVar(autoApproveDeprecated, "dangerous-auto-approve", false, "skip interactive approval. Only for automation!")
 	if err := fs.MarkDeprecated("dangerous-auto-approve", "use --auto-approve instead"); err != nil {
-		log.Fatalf("failed to mark deprecated flag: %s", err)
+		log.Fatal().Msgf("failed to mark deprecated flag: %s", err)
 	}
 	fs.StringVar(autoApprove, "auto-approve", "", "skip interactive approval. Only for automation! Allowed values: 'always', 'never', 'if-no-changes'")
 }
@@ -43,7 +43,7 @@ func labelSelectorFlag(fs *pflag.FlagSet) func() labels.Selector {
 		if *labelSelector != "" {
 			selector, err := labels.Parse(*labelSelector)
 			if err != nil {
-				log.Fatalf("Could not parse selector (-l) %s", *labelSelector)
+				log.Fatal().Msgf("Could not parse selector (-l) %s", *labelSelector)
 			}
 			return selector
 		}
@@ -79,7 +79,7 @@ func cliCodeParser(fs *pflag.FlagSet) (func() map[string]string, func() map[stri
 			for _, s := range *code {
 				split := strings.SplitN(s, "=", 2)
 				if len(split) != 2 {
-					log.Fatalf(kind+"-code argument has wrong format: `%s`. Expected `key=<code>`", s)
+					log.Fatal().Msgf(kind+"-code argument has wrong format: `%s`. Expected `key=<code>`", s)
 				}
 				m[split[0]] = split[1]
 			}
@@ -87,7 +87,7 @@ func cliCodeParser(fs *pflag.FlagSet) (func() map[string]string, func() map[stri
 			for _, s := range *str {
 				split := strings.SplitN(s, "=", 2)
 				if len(split) != 2 {
-					log.Fatalf(kind+"-str argument has wrong format: `%s`. Expected `key=<value>`", s)
+					log.Fatal().Msgf(kind+"-str argument has wrong format: `%s`. Expected `key=<value>`", s)
 				}
 				m[split[0]] = fmt.Sprintf(`"%s"`, split[1])
 			}

--- a/cmd/tk/fmt.go
+++ b/cmd/tk/fmt.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 
 	"github.com/go-clix/cli"
@@ -58,7 +57,7 @@ func fmtCmd() *cli.Command {
 		case *stdout:
 			outFn = func(name, content string) error {
 				fmt.Printf("// %s\n%s", name, content)
-				log.Println() // some spacing
+				fmt.Fprintln(os.Stderr) // some spacing
 				return nil
 			}
 		}
@@ -75,20 +74,20 @@ func fmtCmd() *cli.Command {
 		}
 
 		if *verbose {
-			log.Println()
+			fmt.Fprintln(os.Stderr)
 		}
 
 		switch {
 		case *test && len(changed) > 0:
-			log.Println("The following files are not properly formatted:")
+			fmt.Fprintln(os.Stderr, "The following files are not properly formatted:")
 			for _, s := range changed {
-				log.Println(s)
+				fmt.Fprintln(os.Stderr, s)
 			}
 			os.Exit(ExitStatusDiff)
 		case len(changed) == 0:
-			log.Println("All discovered files are already formatted. No changes were made")
+			fmt.Fprintln(os.Stderr, "All discovered files are already formatted. No changes were made")
 		case len(changed) > 0:
-			log.Printf("Formatted %v files", len(changed))
+			fmt.Fprintf(os.Stderr, "Formatted %v files", len(changed))
 		}
 
 		return nil

--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -68,7 +67,7 @@ func initCmd() *cli.Command {
 		if doInstall {
 			if err := installK8sLib(version); err != nil {
 				// This is not fatal, as most of Tanka will work anyways
-				log.Println("Installing k.libsonnet:", err)
+				fmt.Println("Installing k.libsonnet:", err)
 				failed = true
 			}
 		}
@@ -79,7 +78,7 @@ func initCmd() *cli.Command {
 			fmt.Println("Directory structure set up! Remember to configure the API endpoint:\n`tk env set environments/default --server=https://127.0.0.1:6443`")
 		}
 		if failed {
-			log.Println("Errors occurred while initializing the project. Check the above logs for details.")
+			fmt.Println("Errors occurred while initializing the project. Check the above logs for details.")
 		}
 
 		return nil

--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,10 +52,10 @@ func jpathCmd() *cli.Command {
 
 		if *debug {
 			// log to debug info to stderr
-			log.Println("main:", entrypoint)
-			log.Println("rootDir:", root)
-			log.Println("baseDir:", base)
-			log.Println("jpath:", jsonnetpath)
+			fmt.Fprintln(os.Stderr, "main:", entrypoint)
+			fmt.Fprintln(os.Stderr, "rootDir:", root)
+			fmt.Fprintln(os.Stderr, "baseDir:", base)
+			fmt.Fprintln(os.Stderr, "jpath:", jsonnetpath)
 		}
 
 		// print export JSONNET_PATH to stdout

--- a/cmd/tk/toolCharts.go
+++ b/cmd/tk/toolCharts.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -133,7 +132,7 @@ func chartsInitCmd() *cli.Command {
 			return err
 		}
 
-		log.Printf("Success! New Chartfile created at '%s'", path)
+		fmt.Fprintf(os.Stderr, "Success! New Chartfile created at '%s'", path)
 		return nil
 	}
 

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/go-clix/cli"
@@ -203,7 +202,7 @@ func diffCmd() *cli.Command {
 		}
 
 		if changes == nil {
-			log.Println("No differences.")
+			fmt.Fprintln(os.Stderr, "No differences.")
 			os.Exit(ExitStatusClean)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/karrick/godirwalk v1.16.1
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
+	github.com/rs/zerolog v1.28.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -46,6 +47,7 @@ github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL9
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -144,6 +146,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
+github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/grafana/tanka/pkg/kubernetes/manifest"
@@ -180,7 +180,7 @@ func deletePreviouslyExportedManifests(path string, envs []*v1alpha1.Environment
 	manifestFilePath := filepath.Join(path, manifestFile)
 	manifestContent, err := os.ReadFile(manifestFilePath)
 	if errors.Is(err, fs.ErrNotExist) {
-		log.Printf("Warning: No manifest file found at %s, skipping deletion of previously exported manifests\n", manifestFilePath)
+		log.Warn().Msgf("No manifest file found at %s, skipping deletion of previously exported manifests\n", manifestFilePath)
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/tanka/export_test.go
+++ b/pkg/tanka/export_test.go
@@ -2,13 +2,12 @@ package tanka
 
 import (
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/grafana/tanka/pkg/jsonnet"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
@@ -125,7 +124,7 @@ func TestExportEnvironments(t *testing.T) {
 }
 
 func BenchmarkExportEnvironmentsWithReplaceEnvs(b *testing.B) {
-	log.SetOutput(io.Discard)
+	zerolog.SetGlobalLevel(zerolog.Disabled)
 	tempDir := b.TempDir()
 	require.NoError(b, os.Chdir("testdata"))
 	defer func() { require.NoError(b, os.Chdir("..")) }()

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -2,7 +2,6 @@ package tanka
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/grafana/tanka/pkg/spec"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 // environmentExtCode is the extCode ID `tk.env` uses underneath
@@ -44,7 +44,7 @@ func Load(path string, opts Opts) (*LoadResult, error) {
 func LoadEnvironment(path string, opts Opts) (*v1alpha1.Environment, error) {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		log.Printf("Path %q does not exist, trying to use it as an environment name", path)
+		log.Info().Msgf("Path %q does not exist, trying to use it as an environment name", path)
 		opts.Name = path
 		path = "."
 	} else if err != nil {

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -2,7 +2,6 @@ package tanka
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 const defaultParallelism = 8
@@ -89,7 +89,7 @@ type parallelOut struct {
 
 func parallelWorker(jobsCh <-chan parallelJob, outCh chan parallelOut) {
 	for job := range jobsCh {
-		log.Printf("Loading %s from %s", job.opts.Name, job.path)
+		log.Debug().Str("name", job.opts.Name).Str("path", job.path).Msg("Loading environment")
 		startTime := time.Now()
 
 		env, err := LoadEnvironment(job.path, job.opts)
@@ -98,6 +98,6 @@ func parallelWorker(jobsCh <-chan parallelJob, outCh chan parallelOut) {
 		}
 		outCh <- parallelOut{env: env, err: err}
 
-		log.Printf("Loaded %s from %s, time elapsed: %s", job.opts.Name, job.path, time.Since(startTime))
+		log.Debug().Str("name", job.opts.Name).Str("path", job.path).Dur("time", time.Since(startTime)).Msg("Finished loading environment")
 	}
 }

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -2,7 +2,7 @@ package tanka
 
 import (
 	"fmt"
-	"log"
+	"os"
 
 	"github.com/fatih/color"
 
@@ -36,7 +36,7 @@ func Prune(baseDir string, opts PruneOpts) error {
 	}
 
 	if len(orphaned) == 0 {
-		log.Println("Nothing found to prune.")
+		fmt.Fprintln(os.Stderr, "Nothing found to prune.")
 		return nil
 	}
 
@@ -60,9 +60,9 @@ func Prune(baseDir string, opts PruneOpts) error {
 		warning := color.New(color.FgHiYellow, color.Bold).FprintfFunc()
 		warning(color.Error, "WARNING: This will delete following namespaces and all resources in them:\n")
 		for _, ns := range namespaces {
-			log.Printf(" - %s\n", ns)
+			fmt.Fprintf(os.Stderr, " - %s\n", ns)
 		}
-		log.Println("")
+		fmt.Fprintln(os.Stderr, "")
 	}
 
 	// prompt for confirm

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -2,10 +2,10 @@ package tanka
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/grafana/tanka/pkg/spec"
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+	"github.com/rs/zerolog/log"
 )
 
 // StaticLoader loads an environment from a static file called `spec.json`.
@@ -88,7 +88,7 @@ func parseStaticSpec(path string) (*v1alpha1.Environment, error) {
 		switch err.(type) {
 		// the config includes deprecated fields
 		case spec.ErrDeprecated:
-			log.Println(err)
+			log.Warn().Err(err).Msg("encountered deprecated fields in spec.json")
 		// spec.json missing. we can still work with the default value
 		case spec.ErrNoSpec:
 			return env, nil

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -2,10 +2,10 @@ package tanka
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/rs/zerolog/log"
 
 	"github.com/grafana/tanka/pkg/kubernetes"
 	"github.com/grafana/tanka/pkg/kubernetes/client"
@@ -103,7 +103,7 @@ func Apply(baseDir string, opts ApplyOpts) error {
 		switch {
 		case err != nil:
 			// This is not fatal, the diff is not strictly required
-			log.Println("Error diffing:", err)
+			log.Error().Err(err).Msg("error diffing")
 		case diff == nil:
 			noChanges = true
 			// If using KUBECTL_INTERACTIVE_DIFF, the stdout buffer is always empty


### PR DESCRIPTION
Exposes a `--log-level` arg on every command
Replaces all `log` uses with either `fmt.Fprint(os.Stderr)` or zerolog calls

Benefits:
- We're currently mixing actual logs (that should have a level/are purely informational) and things that we want to print to stderr (possibly parsed by user). Using zerolog and fmt is more deliberate in meaning
- Logs can be disabled or turned on using the `--log-level` option
- We'll be able to add more verbose logs without potentially annoying people. An example is the "Loading environment" messages that the export command now prints. I shifted that to debug
- Will allow for trace level logs. Ex: https://github.com/grafana/tanka/issues/751, logs from the underlying `kubectl` exec or helm