### PR TITLE
Additional logging + improvements to logging

### DIFF
--- a/cmd/tk/lint.go
+++ b/cmd/tk/lint.go
@@ -27,7 +27,12 @@ func lintCmd() *cli.Command {
 
 	exclude := cmd.Flags().StringSliceP("exclude", "e", []string{"**/.*", ".*", "**/vendor/**", "vendor/**"}, "globs to exclude")
 	parallelism := cmd.Flags().IntP("parallelism", "n", 4, "amount of workers")
-	verbose := cmd.Flags().BoolP("verbose", "v", false, "print each checked file")
+
+	// this is now always sent as debug logs
+	cmd.Flags().BoolP("verbose", "v", false, "print each checked file")
+	if err := cmd.Flags().MarkDeprecated("verbose", "logs are sent to debug now, this is unused"); err != nil {
+		panic(err)
+	}
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		globs := make([]glob.Glob, len(*exclude))
@@ -39,7 +44,7 @@ func lintCmd() *cli.Command {
 			globs[i] = g
 		}
 
-		return jsonnet.Lint(args, &jsonnet.LintOpts{Excludes: globs, PrintNames: *verbose, Parallelism: *parallelism})
+		return jsonnet.Lint(args, &jsonnet.LintOpts{Excludes: globs, Parallelism: *parallelism})
 	}
 
 	return cmd

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -138,7 +138,7 @@ func (c Charts) Vendor(prune bool) error {
 			}
 
 			if chartYAML.Version.String() == r.Version.String() {
-				log.Info().Msgf(" %s exists", r)
+				log.Info().Msgf("%s exists", r)
 				continue
 			} else {
 				log.Info().Msgf("Removing %s", r)
@@ -174,7 +174,7 @@ func (c Charts) Vendor(prune bool) error {
 			return err
 		}
 
-		log.Info().Msgf(" %s@%s downloaded", r.Chart, r.Version.String())
+		log.Info().Msgf("%s@%s downloaded", r.Chart, r.Version.String())
 	}
 
 	if prune {
@@ -202,7 +202,7 @@ func (c Charts) Vendor(prune bool) error {
 // Add adds every Chart in reqs to the Manifest after validation, and runs
 // Vendor afterwards
 func (c *Charts) Add(reqs []string) error {
-	log.Printf("Adding %v Charts ...", len(reqs))
+	log.Info().Msgf("Adding %v Charts ...", len(reqs))
 
 	// parse new charts, append in memory
 	requirements := c.Manifest.Requires
@@ -219,7 +219,7 @@ func (c *Charts) Add(reqs []string) error {
 		}
 
 		requirements = append(requirements, *r)
-		log.Info().Msgf(" OK: %s", s)
+		log.Info().Msgf("OK: %s", s)
 	}
 
 	if err := requirements.Validate(); err != nil {
@@ -239,7 +239,7 @@ func (c *Charts) Add(reqs []string) error {
 	}
 
 	// worked fine? vendor it
-	log.Printf("Added %v Charts to helmfile.yaml. Vendoring ...", added)
+	log.Info().Msgf("Added %v Charts to helmfile.yaml. Vendoring ...", added)
 	return c.Vendor(false)
 }
 
@@ -258,7 +258,7 @@ func (c *Charts) AddRepos(repos ...Repo) error {
 
 		c.Manifest.Repositories = append(c.Manifest.Repositories, r)
 		added++
-		log.Info().Msgf(" OK: %s", r.Name)
+		log.Info().Msgf("OK: %s", r.Name)
 	}
 
 	// write out
@@ -346,5 +346,5 @@ func parseReqName(s string) string {
 }
 
 func skip(s string, err error) {
-	log.Printf(" Skipping %s: %s.", s, err)
+	log.Info().Msgf("Skipping %s: %s.", s, err)
 }

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -98,6 +98,6 @@ func parallelWorker(jobsCh <-chan parallelJob, outCh chan parallelOut) {
 		}
 		outCh <- parallelOut{env: env, err: err}
 
-		log.Debug().Str("name", job.opts.Name).Str("path", job.path).Dur("time", time.Since(startTime)).Msg("Finished loading environment")
+		log.Debug().Str("name", job.opts.Name).Str("path", job.path).Dur("duration_ms", time.Since(startTime)).Msg("Finished loading environment")
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/grafana/tanka/pull/766
- Shift linting name logging to debug logging. Instead of sending everything to stdout, we can now have a cleaner "report"
- Missed some `log.Printf`(alias for Debug) in helm code, shifted that to info logs
- Added some caching logs, whether or not it's a cache hit + time elasped to calculate hash
- Changed `time` for `duration_ms` in env loading log. This conflicts with the log time