### PR TITLE
Exit with a non-zero status on cmd execution errors

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
 	"github.com/go-clix/cli"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/term"
 
 	"github.com/grafana/tanka/pkg/tanka"
@@ -71,6 +71,6 @@ func main() {
 
 	// Run!
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		log.Fatal().Msgf("Error: %s", err)
 	}
 }


### PR DESCRIPTION
This PR attempts to address a behaviour change that made it via https://github.com/grafana/tanka/pull/766

We were able to identify this issue at GrafanaLabs because we run Tanka in our CI pipelines and on errors, Tanka was still exiting with 0, executing the subsequent steps of the pipeline.