### PR TITLE
tk: Format logs with the console log formatter if outputting to a tty

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -12,7 +12,8 @@ import (
 	"github.com/grafana/tanka/pkg/tanka"
 )
 
-var interactive = term.IsTerminal(int(os.Stderr.Fd()))
+var stdoutIsTTY = term.IsTerminal(int(os.Stdout.Fd()))
+var stderrIsTTY = term.IsTerminal(int(os.Stderr.Fd()))
 
 func main() {
 	rootCmd := &cli.Command{
@@ -21,7 +22,7 @@ func main() {
 		Version: tanka.CurrentVersion,
 	}
 
-	if interactive {
+	if stderrIsTTY {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
 

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -12,13 +12,17 @@ import (
 	"github.com/grafana/tanka/pkg/tanka"
 )
 
-var interactive = term.IsTerminal(int(os.Stdout.Fd()))
+var interactive = term.IsTerminal(int(os.Stderr.Fd()))
 
 func main() {
 	rootCmd := &cli.Command{
 		Use:     "tk",
 		Short:   "tanka <3 jsonnet",
 		Version: tanka.CurrentVersion,
+	}
+
+	if interactive {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
 
 	addCommandsWithLogLevel := func(cmds ...*cli.Command) {

--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -27,7 +27,7 @@ func fPageln(r io.Reader) error {
 		pager = "less --RAW-CONTROL-CHARS --quit-if-one-screen --no-init"
 	}
 
-	if interactive && pager != "" {
+	if stdoutIsTTY && pager != "" {
 		cmd := exec.Command("sh", "-c", pager)
 		cmd.Stdin = r
 		cmd.Stdout = os.Stdout

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -235,7 +235,7 @@ func showCmd() *cli.Command {
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-		if !interactive && !*allowRedirect {
+		if !stdoutIsTTY && !*allowRedirect {
 			fmt.Fprintln(os.Stderr, `Redirection of the output of tk show is discouraged and disabled by default.
 If you want to export .yaml files for use with other tools, try 'tk export'.
 Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)


### PR DESCRIPTION
Since the switch to structured logging in
cc213234f1e103764095e99a3ea974ca71c037cc we now output evaluation errors
all on one line, with escaped newlines:

```
{"level":"fatal","time":"2022-10-07T12:50:42+01:00","message":"Error: evaluating jsonnet: RUNTIME ERROR: function expected 3 positional argument(s), but got 4\n\t/home/laney/temp/tk/environments/default/main.jsonnet:3:14-56\tobject <anonymous>\n\tField \"bar\"\t\n\tDuring manifestation\t\n"}
```

It's pretty unreadable. Instead, what we can do is turn on zerolog's
console writer when we're running interactively (precisely, when stderr
is a tty). Then the above message becomes:

```
12:52PM FTL Error: evaluating jsonnet: RUNTIME ERROR: function expected 3 positional argument(s), but got 4
	/home/laney/temp/tk/environments/default/main.jsonnet:3:14-56	object <anonymous>
	Field "bar"
	During manifestation
```

which is legible again.
