### PR TITLE
Revert to fmt.Print for error logging

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/go-clix/cli"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"golang.org/x/term"
 
 	"github.com/grafana/tanka/pkg/tanka"
@@ -71,6 +71,7 @@ func main() {
 
 	// Run!
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal().Msgf("Error: %s", err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
When an error occurs, it is ultimately brought to the `main.go` file where it is printed for the user (or machine) 
Using log.Fatal garbles the error by not rendering newlines

This reverts https://github.com/grafana/tanka/pull/774 but adds an os.Exit(1) which is an alternative fix to what the PR did