### PR TITLE
`tk tool importers`: Cache the full result

### DIFF
--- a/pkg/jsonnet/find_importers_test.go
+++ b/pkg/jsonnet/find_importers_test.go
@@ -98,6 +98,9 @@ func BenchmarkFindImporters(b *testing.B) {
 	expectedImporters := []string{filepath.Join(tempDir, "main.jsonnet")}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		importersCache = make(map[string][]string)
+		jsonnetFilesCache = make(map[string]map[string]*cachedJsonnetFile)
+		symlinkCache = make(map[string]string)
 		importers, err := FindImporterForFiles(tempDir, []string{filepath.Join(tempDir, "file10.libsonnet")})
 
 		require.NoError(b, err)


### PR DESCRIPTION
I hadn't done it before because the benefit was minimal. 
However, I've found out that for very heavily used libraries (used by hundreds/thousands of files), it does help 
For example, for [`ksonnet-util`](https://github.com/grafana/jsonnet-libs/tree/master/ksonnet-util) which we use everywhere, compute time goes from ~13s to ~6s