### PR TITLE
Fix typo on merge-strategy option's help

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -44,7 +44,7 @@ func exportCmd() *cli.Command {
 	if err := cmd.Flags().MarkDeprecated("merge", "use --merge-strategy=fail-on-conflicts instead"); err != nil {
 		panic(err)
 	}
-	mergeStrategy := cmd.Flags().String("merge-strategy", "", "What to do when exporting to an existing directory. The default setting is to disallow exporting to an existing directory. Values: 'fail-on-conficts', 'replace-envs'")
+	mergeStrategy := cmd.Flags().String("merge-strategy", "", "What to do when exporting to an existing directory. The default setting is to disallow exporting to an existing directory. Values: 'fail-on-conflicts', 'replace-envs'")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())


### PR DESCRIPTION
Just that, fixing a typo that I realised was there because I copy-pasted it from the console and was struggling to figure out why my tanka execution was failing :facepalm: . Let's try to avoid that to other users.