### PR TITLE
Deploy website to Github Pages

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -1,0 +1,45 @@
+# .github/workflows/preview.yml
+name: Deploy Github Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: ci-${{ github.ref }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install and Build
+        working-directory: docs
+        env:
+          # Main: https://tanka.dev/
+          # PRs: https://grafana.github.io/tanka/pr-preview/pr-{number}/
+          PATH_PREFIX: "${{ github.event_name == 'pull_request' && format('/tanka/pr-preview/pr-{0}', github.event.number) || '' }}"
+        run: |
+          yarn install
+          yarn build
+
+      - name: Deploy main
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with: 
+          clean-exclude: pr-preview/
+          folder: ./docs/public/
+
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./docs/public/

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,6 +1,7 @@
 const path = require("path")
 
 module.exports = {
+  pathPrefix: process.env.PATH_PREFIX || "",
   siteMetadata: {
     title: `Grafana Tanka`,
     description: `Flexible, reusable and concise configuration for Kubernetes`,

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,10 +34,10 @@
   ],
   "license": "Apache v2",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "dev": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve --prefix-paths",
     "clean": "gatsby clean"
   }
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,0 @@
-[build]
-  base = "docs/"
-  publish = "docs/public"
-  command = "yarn build"
-


### PR DESCRIPTION
This gets rid of netlify which we don't really need and is blocking PRs like https://github.com/grafana/tanka/pull/783 This contains two different parts:
- A step that deploys to a preview for PRs
- A step that deploys on a push to main

**NOTE: Netlify is failing on this PR as well, I will remove the Netlify webhook once this is deployed and I've validated it works**