### PR TITLE
Github pages: PR path fix

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -25,8 +25,8 @@ jobs:
         working-directory: docs
         env:
           # Main: https://tanka.dev/
-          # PRs: https://grafana.github.io/tanka/pr-preview/pr-{number}/
-          PATH_PREFIX: "${{ github.event_name == 'pull_request' && format('/tanka/pr-preview/pr-{0}', github.event.number) || '' }}"
+          # PRs: https://tanka.dev/pr-preview/pr-{number}/
+          PATH_PREFIX: "${{ github.event_name == 'pull_request' && format('/pr-preview/pr-{0}', github.event.number) || '' }}"
         run: |
           yarn install
           yarn build


### PR DESCRIPTION
When DNS is setup in Github pages, the URLs (ex: https://grafana.github.io/tanka/pr-preview/pr-783/) now always redirect to the tanka.dev DNS name 
So it becomes: https://tanka.dev/pr-preview/pr-783/ 
Therefore, the path prefix is now wrong

Everything else is now running fine without Netlify!