### PR TITLE
Support forcing color output on/off

### DIFF
--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -24,6 +24,10 @@ func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	return &v
 }
 
+func addDiffFlags(fs *pflag.FlagSet, opts *tanka.DiffBaseOpts) {
+	fs.StringVar(&opts.Color, "color", "auto", `controls color in diff output, must be "auto", "always", or "never"`)
+}
+
 func addApplyFlags(fs *pflag.FlagSet, opts *tanka.ApplyBaseOpts, autoApproveDeprecated *bool, autoApprove *string) {
 	fs.StringVar(&opts.DryRun, "dry-run", "", `--dry-run parameter to pass down to kubectl, must be "none", "server", or "client"`)
 	fs.BoolVar(&opts.Force, "force", false, "force applying (kubectl apply --force)")

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -40,8 +40,6 @@ type ApplyBaseOpts struct {
 }
 
 type DiffBaseOpts struct {
-	// ForceColor enables color output even if stdout is not a terminal
-	ForceColor bool
 	// Color controls color output
 	Color string
 }

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -29,6 +29,7 @@ const (
 
 type ApplyBaseOpts struct {
 	Opts
+	DiffBaseOpts
 
 	// AutoApprove skips the interactive approval
 	AutoApprove AutoApproveSetting
@@ -36,6 +37,13 @@ type ApplyBaseOpts struct {
 	DryRun string
 	// Force ignores any warnings kubectl might have
 	Force bool
+}
+
+type DiffBaseOpts struct {
+	// ForceColor enables color output even if stdout is not a terminal
+	ForceColor bool
+	// Color controls color output
+	Color string
 }
 
 // ApplyOpts specify additional properties for the Apply action
@@ -152,6 +160,7 @@ func confirmPrompt(action, namespace string, info client.Info) error {
 
 // DiffOpts specify additional properties for the Diff action
 type DiffOpts struct {
+	DiffBaseOpts
 	Opts
 
 	// Strategy must be one of "native", "validate", "subset" or "server"


### PR DESCRIPTION
Closes #798

Introduce flag `--color` to control the colorization of diff output.

Add flag to all commands that can output colorized diff text:
- `diff`
- `apply`
- `prune`

`--color` has 3 allowed values:
- `auto` (default): colorize if stdout is a terminal (current behavior)
- `always`: always colorize output
- `never`: never colorize output

Example: `--color=always`
![tk-diff-color-always](https://user-images.githubusercontent.com/41255671/210906777-080f977e-ddd5-4ddd-9a24-aee4b40ccd47.png)

Example: `--color=never`
![tk-diff-color-never](https://user-images.githubusercontent.com/41255671/210906839-a6079326-9ab4-4a14-bd9f-93fd38937739.png)
