### PR TITLE
Add notice to find changelogs in the Github release page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+For releases from v0.24.0 forward, you can find the changelog in Github releases: https://github.com/grafana/tanka/releases
+
 ## 0.23.1 (2022-09-28)
 
 ### Bug Fixes/Enhancements


### PR DESCRIPTION
It's tedious to create a changelog and push it to main, especially since Github releases can auto-generate decent changelogs from PRs. I propose to use Github releases from now on