### PR TITLE
docs: update override method for tanka

### DIFF
--- a/docs/docs/libraries/overriding.md
+++ b/docs/docs/libraries/overriding.md
@@ -78,7 +78,7 @@ In your environments folder (e.g. `/environments/default`):
 $ jb init
 
 # install the updated dependency
-$ jb init github.com/foo/bar@v2
+$ jb install github.com/foo/bar@v2
 ```
 
 > **Tip**: You don't need to install everything into the new `vendor/`, as


### PR DESCRIPTION
`jb init <dependency>` leads to:

```
Error parsing commandline arguments: unexpected github.com/grafana/loki/production/ksonnet/loki@v2.7.2
jb: error: unexpected github.com/grafana/loki/production/ksonnet/loki@v2.7.2
```
