### PR TITLE
Add benchmark for Extract + small speed improvement

### DIFF
--- a/pkg/process/extract.go
+++ b/pkg/process/extract.go
@@ -128,7 +128,11 @@ func (e ErrorPrimitiveReached) Error() string {
 // kubernetes resource by verifying the presence of apiVersion and kind. These
 // two fields are required for kubernetes to accept any resource.
 func isKubernetesManifest(obj objx.Map) bool {
-	return true &&
-		obj.Get("apiVersion").IsStr() && obj.Get("apiVersion").Str() != "" &&
-		obj.Get("kind").IsStr() && obj.Get("kind").Str() != ""
+	if apiVersion := obj.Get("apiVersion"); !apiVersion.IsStr() || apiVersion.Str() == "" {
+		return false
+	}
+	if kind := obj.Get("kind"); !kind.IsStr() || kind.Str() == "" {
+		return false
+	}
+	return true
 }

--- a/pkg/process/extract_test.go
+++ b/pkg/process/extract_test.go
@@ -62,6 +62,7 @@ func BenchmarkExtract(b *testing.B) {
 		}
 		b.Run(c.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
+				// nolint:errcheck
 				Extract(c.data.Deep)
 			}
 		})

--- a/pkg/process/extract_test.go
+++ b/pkg/process/extract_test.go
@@ -7,50 +7,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtract(t *testing.T) {
-	tests := []struct {
-		name string
-		data testData
-		err  error
-	}{
-		{
-			name: "regular",
-			data: testDataRegular(),
-		},
-		{
-			name: "flat",
-			data: testDataFlat(),
-		},
-		{
-			name: "primitive",
-			data: testDataPrimitive(),
-			err:  ErrorPrimitiveReached{path: ".service", key: "note", primitive: "invalid because apiVersion and kind are missing"},
-		},
-		{
-			name: "deep",
-			data: testDataDeep(),
-		},
-		{
-			name: "array",
-			data: testDataArray(),
-		},
-		{
-			name: "nil",
-			data: func() testData {
-				d := testDataRegular()
-				d.Deep.(map[string]interface{})["disabledObject"] = nil
-				return d
-			}(),
-			err: nil, // we expect no error, just the result of testDataRegular
-		},
-	}
+var extractTestCases = []struct {
+	name string
+	data testData
+	err  error
+}{
+	{
+		name: "regular",
+		data: testDataRegular(),
+	},
+	{
+		name: "flat",
+		data: testDataFlat(),
+	},
+	{
+		name: "primitive",
+		data: testDataPrimitive(),
+		err:  ErrorPrimitiveReached{path: ".service", key: "note", primitive: "invalid because apiVersion and kind are missing"},
+	},
+	{
+		name: "deep",
+		data: testDataDeep(),
+	},
+	{
+		name: "array",
+		data: testDataArray(),
+	},
+	{
+		name: "nil",
+		data: func() testData {
+			d := testDataRegular()
+			d.Deep.(map[string]interface{})["disabledObject"] = nil
+			return d
+		}(),
+		err: nil, // we expect no error, just the result of testDataRegular
+	},
+}
 
-	for _, c := range tests {
+func TestExtract(t *testing.T) {
+	for _, c := range extractTestCases {
 		t.Run(c.name, func(t *testing.T) {
 			extracted, err := Extract(c.data.Deep)
 
 			require.Equal(t, c.err, err)
 			assert.EqualValues(t, c.data.Flat, extracted)
+		})
+	}
+}
+
+func BenchmarkExtract(b *testing.B) {
+	for _, c := range extractTestCases {
+		if c.err != nil {
+			continue
+		}
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Extract(c.data.Deep)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I'm working in that area, and will modify more things. Setting up a benchmark before going further

Bench results from that small change in the extraction func:
From `go test -benchmem -run=^$ -bench ^BenchmarkExtract$ github.com/grafana/tanka/pkg/process -count=10`

```
name               old time/op    new time/op    delta
Extract/regular-8    16.6µs ±20%    14.7µs ±19%  -11.47%  (p=0.019 n=10+10)
Extract/flat-8       7.09µs ±16%    6.18µs ±12%  -12.81%  (p=0.001 n=9+10)
Extract/deep-8       39.6µs ±13%    34.9µs ±13%  -11.92%  (p=0.000 n=9+9)
Extract/array-8      54.0µs ±27%    46.0µs ±13%  -14.68%  (p=0.006 n=10+9)
Extract/nil-8        17.6µs ±24%    13.8µs ± 6%  -21.48%  (p=0.000 n=10+8)

name               old alloc/op   new alloc/op   delta
Extract/regular-8    2.35kB ± 0%    2.22kB ± 0%   -5.44%  (p=0.000 n=10+10)
Extract/flat-8       1.06kB ± 0%    1.00kB ± 0%   -6.02%  (p=0.000 n=10+10)
Extract/deep-8       7.99kB ± 0%    7.74kB ± 0%   -3.20%  (p=0.000 n=10+10)
Extract/array-8      8.87kB ± 0%    8.55kB ± 0%   -3.61%  (p=0.000 n=10+10)
Extract/nil-8        2.38kB ± 0%    2.26kB ± 0%   -5.37%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
Extract/regular-8      45.0 ± 0%      41.0 ± 0%   -8.89%  (p=0.000 n=10+10)
Extract/flat-8         19.0 ± 0%      17.0 ± 0%  -10.53%  (p=0.000 n=10+10)
Extract/deep-8          130 ± 0%       122 ± 0%   -6.15%  (p=0.000 n=10+10)
Extract/array-8         153 ± 0%       143 ± 0%   -6.54%  (p=0.000 n=10+10)
Extract/nil-8          46.0 ± 0%      42.0 ± 0%   -8.70%  (p=0.000 n=10+10)
```