### PR TITLE
Improved manifest extraction errors

### DIFF
--- a/pkg/process/data_test.go
+++ b/pkg/process/data_test.go
@@ -52,6 +52,16 @@ func testDataPrimitive() testData {
 	return loadFixture("tdInvalidPrimitive.jsonnet")
 }
 
+// testBadKindType is an invalid manifest, because it has an invalid `kind` value
+func testBadKindType() testData {
+	return loadFixture("tdBadKindType.jsonnet")
+}
+
+// testMissingAttribute is an invalid manifest, because it is missing the `kind`
+func testMissingAttribute() testData {
+	return loadFixture("tdMissingAttribute.jsonnet")
+}
+
 // testDataDeep is super deeply nested on multiple levels
 func testDataDeep() testData {
 	return loadFixture("tdDeep.jsonnet")

--- a/pkg/process/extract.go
+++ b/pkg/process/extract.go
@@ -135,12 +135,12 @@ func (e ErrorPrimitiveReached) Error() string {
 	container, _ := yaml.Marshal(e.containingObj)
 
 	return fmt.Sprintf(`recursion ended on key %q of type %T which does not belong to a valid Kubernetes object
-instead, it an attribute of the following object:
+instead, it an attribute of the following object (at path %s):
 
 %s
 
 this object is not a valid Kubernetes object because: %s
-`, e.key, e.primitive, container, e.containingObjErr)
+`, e.key, e.primitive, e.path, container, e.containingObjErr)
 }
 
 // isKubernetesManifest attempts to infer whether the given object is a valid

--- a/pkg/process/extract_test.go
+++ b/pkg/process/extract_test.go
@@ -23,20 +23,15 @@ var extractTestCases = []struct {
 	{
 		name: "primitive",
 		data: testDataPrimitive(),
-		errMessage: `recursion ended on key "note" of type string which does not belong to a valid Kubernetes object
-instead, it an attribute of the following object (at path .service):
+		errMessage: `found invalid Kubernetes object (at .service): missing attribute "apiVersion"
 
 note: invalid because apiVersion and kind are missing
-
-
-this object is not a valid Kubernetes object because: missing attribute "apiVersion"
 `,
 	},
 	{
 		name: "missing kind",
 		data: testMissingAttribute(),
-		errMessage: `recursion ended on key "apiVersion" of type string which does not belong to a valid Kubernetes object
-instead, it an attribute of the following object (at path .service):
+		errMessage: `found invalid Kubernetes object (at .service): missing attribute "kind"
 
 apiVersion: v1
 spec:
@@ -46,16 +41,12 @@ spec:
           targetPort: 8080
     selector:
         app: deep
-
-
-this object is not a valid Kubernetes object because: missing attribute "kind"
 `,
 	},
 	{
 		name: "bad kind",
 		data: testBadKindType(),
-		errMessage: `recursion ended on key "apiVersion" of type string which does not belong to a valid Kubernetes object
-instead, it an attribute of the following object (at path .deployment):
+		errMessage: `found invalid Kubernetes object (at .deployment): attribute "kind" is not a string, it is a float64
 
 apiVersion: apps/v1
 kind: 3000
@@ -70,9 +61,6 @@ spec:
         metadata:
             labels:
                 app: grafana
-
-
-this object is not a valid Kubernetes object because: attribute "kind" is not a string, it is a float64
 `,
 	},
 	{

--- a/pkg/process/extract_test.go
+++ b/pkg/process/extract_test.go
@@ -103,10 +103,10 @@ func TestExtract(t *testing.T) {
 				require.Error(t, err)
 				assert.Equal(t, c.errMessage, err.Error())
 				return
-			} else {
-				require.NoError(t, err)
-				assert.EqualValues(t, c.data.Flat, extracted)
 			}
+
+			require.NoError(t, err)
+			assert.EqualValues(t, c.data.Flat, extracted)
 		})
 	}
 }

--- a/pkg/process/extract_test.go
+++ b/pkg/process/extract_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 var extractTestCases = []struct {
-	name string
-	data testData
-	err  error
+	name       string
+	data       testData
+	errMessage string
 }{
 	{
 		name: "regular",
@@ -23,7 +23,57 @@ var extractTestCases = []struct {
 	{
 		name: "primitive",
 		data: testDataPrimitive(),
-		err:  ErrorPrimitiveReached{path: ".service", key: "note", primitive: "invalid because apiVersion and kind are missing"},
+		errMessage: `recursion ended on key "note" of type string which does not belong to a valid Kubernetes object
+instead, it an attribute of the following object:
+
+note: invalid because apiVersion and kind are missing
+
+
+this object is not a valid Kubernetes object because: missing attribute "apiVersion"
+`,
+	},
+	{
+		name: "missing kind",
+		data: testMissingAttribute(),
+		errMessage: `recursion ended on key "apiVersion" of type string which does not belong to a valid Kubernetes object
+instead, it an attribute of the following object:
+
+apiVersion: v1
+spec:
+    ports:
+        - port: 80
+          protocol: TCP
+          targetPort: 8080
+    selector:
+        app: deep
+
+
+this object is not a valid Kubernetes object because: missing attribute "kind"
+`,
+	},
+	{
+		name: "bad kind",
+		data: testBadKindType(),
+		errMessage: `recursion ended on key "apiVersion" of type string which does not belong to a valid Kubernetes object
+instead, it an attribute of the following object:
+
+apiVersion: apps/v1
+kind: 3000
+metadata:
+    name: grafana
+spec:
+    replicas: 1
+    template:
+        containers:
+            - image: grafana/grafana
+              name: grafana
+        metadata:
+            labels:
+                app: grafana
+
+
+this object is not a valid Kubernetes object because: attribute "kind" is not a string, it is a float64
+`,
 	},
 	{
 		name: "deep",
@@ -40,7 +90,7 @@ var extractTestCases = []struct {
 			d.Deep.(map[string]interface{})["disabledObject"] = nil
 			return d
 		}(),
-		err: nil, // we expect no error, just the result of testDataRegular
+		errMessage: "", // we expect no error, just the result of testDataRegular
 	},
 }
 
@@ -49,15 +99,21 @@ func TestExtract(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			extracted, err := Extract(c.data.Deep)
 
-			require.Equal(t, c.err, err)
-			assert.EqualValues(t, c.data.Flat, extracted)
+			if c.errMessage != "" {
+				require.Error(t, err)
+				assert.Equal(t, c.errMessage, err.Error())
+				return
+			} else {
+				require.NoError(t, err)
+				assert.EqualValues(t, c.data.Flat, extracted)
+			}
 		})
 	}
 }
 
 func BenchmarkExtract(b *testing.B) {
 	for _, c := range extractTestCases {
-		if c.err != nil {
+		if c.errMessage != "" {
 			continue
 		}
 		b.Run(c.name, func(b *testing.B) {

--- a/pkg/process/extract_test.go
+++ b/pkg/process/extract_test.go
@@ -24,7 +24,7 @@ var extractTestCases = []struct {
 		name: "primitive",
 		data: testDataPrimitive(),
 		errMessage: `recursion ended on key "note" of type string which does not belong to a valid Kubernetes object
-instead, it an attribute of the following object:
+instead, it an attribute of the following object (at path .service):
 
 note: invalid because apiVersion and kind are missing
 
@@ -36,7 +36,7 @@ this object is not a valid Kubernetes object because: missing attribute "apiVers
 		name: "missing kind",
 		data: testMissingAttribute(),
 		errMessage: `recursion ended on key "apiVersion" of type string which does not belong to a valid Kubernetes object
-instead, it an attribute of the following object:
+instead, it an attribute of the following object (at path .service):
 
 apiVersion: v1
 spec:
@@ -55,7 +55,7 @@ this object is not a valid Kubernetes object because: missing attribute "kind"
 		name: "bad kind",
 		data: testBadKindType(),
 		errMessage: `recursion ended on key "apiVersion" of type string which does not belong to a valid Kubernetes object
-instead, it an attribute of the following object:
+instead, it an attribute of the following object (at path .deployment):
 
 apiVersion: apps/v1
 kind: 3000

--- a/pkg/process/testdata/tdBadKindType.jsonnet
+++ b/pkg/process/testdata/tdBadKindType.jsonnet
@@ -1,0 +1,12 @@
+local deployment = (import './resources.jsonnet').deployment;
+
+{
+  deep: {
+    deployment: deployment {
+      kind: 3000,
+    },
+  },
+  flat: {
+    '.deployment': deployment,
+  },
+}

--- a/pkg/process/testdata/tdMissingAttribute.jsonnet
+++ b/pkg/process/testdata/tdMissingAttribute.jsonnet
@@ -1,0 +1,21 @@
+{
+  deep: {
+    deploy: (import './resources.jsonnet').deployment,
+    service: {
+      // Missing kind
+      apiVersion: 'v1',
+      spec: {
+        selector: {
+          app: 'deep',
+        },
+        ports: [
+          {
+            protocol: 'TCP',
+            port: 80,
+            targetPort: 8080,
+          },
+        ],
+      },
+    },
+  },
+}


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/817

This is something that comes up quite often in our internal environments 
When a data structure is not a Kubernetes manifest, the error makes it hard to find out why

This adds a reason, and context for why the object we found isn't a Kubernetes object 

In the issue linked above, the error was:
```
>> tk show environments/default
Error: got an error while extracting env `environments/default`: recursion did not resolve in a valid Kubernetes object.  In path `.grafana.deployment` found key `apiVersion` of type `string` instead.
```

It is now:
```
>> tk show environments/default
Error: got an error while extracting env `environments/default`: found invalid Kubernetes object (at .grafana.deployment): attribute "kind" is not a string, it is a float64

apiVersion: apps/v1
kind: 3000
metadata:
    name: grafana
spec:
    selector:
        matchLabels:
            name: grafana
    template:
        metadata:
            labels:
                name: grafana
        spec:
            containers:
                - image: grafana/grafana
                  name: grafana
                  ports:
                    - containerPort: 3000
                      name: ui
```

More verbose, but it actually helps the user find the error