### PR TITLE
Add the `--log-level` option to nested commands

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -25,10 +25,11 @@ func envCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "env [action]",
 		Short: "manipulate environments",
-		Args:  cli.ArgsMin(2),
+		Args:  cli.ArgsMin(1), // Make sure we print out the help if no subcommand is given, `tk env` is not valid
 	}
 
-	cmd.AddCommand(
+	addCommandsWithLogLevelOption(
+		cmd,
 		envAddCmd(),
 		envSetCmd(),
 		envListCmd(),

--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -20,10 +20,11 @@ func toolCmd() *cli.Command {
 	cmd := &cli.Command{
 		Short: "handy utilities for working with jsonnet",
 		Use:   "tool [command]",
-		Args:  cli.ArgsMin(2),
+		Args:  cli.ArgsMin(1), // Make sure we print out the help if no subcommand is given, `tk tool` is not valid
 	}
 
-	cmd.AddCommand(
+	addCommandsWithLogLevelOption(
+		cmd,
 		jpathCmd(),
 		importsCmd(),
 		importersCmd(),
@@ -35,7 +36,7 @@ func toolCmd() *cli.Command {
 func jpathCmd() *cli.Command {
 	cmd := &cli.Command{
 		Short: "export JSONNET_PATH for use with other jsonnet tools",
-		Use:   "jpath [<file/dir>]",
+		Use:   "jpath <file/dir>",
 		Args:  workflowArgs,
 	}
 

--- a/cmd/tk/toolCharts.go
+++ b/cmd/tk/toolCharts.go
@@ -14,9 +14,11 @@ func chartsCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "charts",
 		Short: "Declarative vendoring of Helm Charts",
+		Args:  cli.ArgsMin(1), // Make sure we print out the help if no subcommand is given, `tk tool charts` is not valid
 	}
 
-	cmd.AddCommand(
+	addCommandsWithLogLevelOption(
+		cmd,
 		chartsInitCmd(),
 		chartsAddCmd(),
 		chartsAddRepoCmd(),


### PR DESCRIPTION
Fixes https://github.com/grafana/tanka/issues/810
`--log-level` should now be usable in every command, including `env`, `tool` and `tool charts`

Also added some consistency around the arg validation of root commands (`env`, `tool` and `charts`)