### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - directory: /
+    open-pull-requests-limit: 5
+    package-ecosystem: gomod
+    schedule:
+      interval: weekly
+
+  - directory: /docs
+    open-pull-requests-limit: 5
+    package-ecosystem: npm
+    schedule:
+      interval: weekly
+
+  - directory: /
+    open-pull-requests-limit: 5
+    package-ecosystem: docker
+    schedule:
+      interval: weekly
+    
+  - directory: /
+    open-pull-requests-limit: 5
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Following on from #836, we can now keep our golang version up to date automatically. Let's turn on dependabot for all our deps.