### PR TITLE
publish-page: Give write permissions explicitly

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -50,4 +50,5 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: rossjrw/pr-preview-action@v1
         with:
+          deploy-repository: ${{ github.event.pull_request.head.repo.full_name }}
           source-dir: ./docs/public/

--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -12,6 +12,10 @@ on:
       - synchronize
       - closed
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency: ci-${{ github.ref }}
 
 jobs:


### PR DESCRIPTION
Dependabot PRs are failing this check, giving a red X in the status that makes it hard to see whether they passed CI or not. Also, we want this to work for updates to the yarn stuff.
    
Then because we do that, we lose the default permissions for other types too. Specifically, the pr-preview-action needs to comment which is  `pull-requests: write`. So set that too.