### PR TITLE
helm: Set `includeCrds` to true by default

### DIFF
--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -79,8 +79,6 @@ The following options control how the command is invoked:
     values: {
       persistence: { enabled: true }
     },
-    // Equivalent to: --include-crds; only relevant for Helm v3+.
-    includeCrds: true,
     // Equivalent to: --api-versions v1 --api-versions apps/v1
     apiVersions: ['v1', 'apps/v1']
     // Equivalent to: --kube-version v1.20.0
@@ -90,6 +88,17 @@ The following options control how the command is invoked:
 }
 ```
 
+Tanka will install Custom Resource Definitions (CRDs) automatically, if the
+Helm Chart requires them and ships them in `crds/`. This is equivalent to `helm
+template --include-crds`. This can be disabled using `includeCrds: false`:
+
+```jsonnet
+{
+  grafana: helm.template("grafana", "./charts/grafana", {
+    includeCrds: false
+  })
+}
+```
 
 ## Vendoring Helm Charts
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -21,6 +21,9 @@ type Helm interface {
 
 	// Template returns the individual resources of a Helm Chart
 	Template(name, chart string, opts TemplateOpts) (manifest.List, error)
+
+	// ChartExists checks if a chart exists in the provided calledFromPath
+	ChartExists(chart string, opts *JsonnetOpts) (string, error)
 }
 
 // PullOpts are additional, non-required options for Helm.Pull
@@ -101,6 +104,17 @@ func (e ExecHelm) RepoUpdate(opts Opts) error {
 	}
 
 	return nil
+}
+
+func (e ExecHelm) ChartExists(chart string, opts *JsonnetOpts) (string, error) {
+	// resolve the Chart relative to the caller
+	callerDir := filepath.Dir(opts.CalledFrom)
+	chart = filepath.Join(callerDir, chart)
+	if _, err := os.Stat(chart); err != nil {
+		return "", fmt.Errorf("helmTemplate: Failed to find a chart at '%s': %s. See https://tanka.dev/helm#failed-to-find-chart", chart, err)
+	}
+
+	return chart, nil
 }
 
 // cmd returns a prepared exec.Cmd to use the `helm` binary

--- a/pkg/helm/jsonnet_test.go
+++ b/pkg/helm/jsonnet_test.go
@@ -1,0 +1,163 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+)
+
+const calledFrom = "/my/path/here"
+
+type MockHelm struct {
+	mock.Mock
+}
+
+// fulfill the Helm interface
+func (m *MockHelm) Pull(chart, version string, opts PullOpts) error {
+	args := m.Called(chart, version, opts)
+	return args.Error(0)
+}
+
+func (m *MockHelm) RepoUpdate(opts Opts) error {
+	args := m.Called(opts)
+	return args.Error(0)
+}
+
+func (m *MockHelm) Template(name, chart string, opts TemplateOpts) (manifest.List, error) {
+	args := m.Called(name, chart, opts)
+
+	// figure out what arguments `helm template` would be called with and save
+	// them
+	execHelm := &ExecHelm{}
+	cmdArgs := execHelm.templateCommandArgs(name, chart, opts)
+	m.TestData().Set("templateCommandArgs", cmdArgs)
+
+	return args.Get(0).(manifest.List), args.Error(1)
+}
+
+func (m *MockHelm) ChartExists(chart string, opts *JsonnetOpts) (string, error) {
+	args := m.Called(chart, opts)
+	return args.String(0), args.Error(1)
+}
+
+func callNativeFucntion(t *testing.T, templateOpts TemplateOpts, parameters []interface{}) []string {
+	t.Helper()
+
+	helmMock := &MockHelm{}
+
+	helmMock.On(
+		"ChartExists",
+		"chart",
+		mock.AnythingOfType("*helm.JsonnetOpts")).
+		Return("/full/chart/path", nil).
+		Once()
+
+	// this verifies that the helmMock.Template() method is called with the
+	// correct arguments, i.e. includeCrds: true is set by default
+	helmMock.On("Template", "name", "/full/chart/path", templateOpts).
+		Return(manifest.List{}, nil).
+		Once()
+
+	nf := NativeFunc(helmMock)
+	require.NotNil(t, nf)
+
+	params := []string{
+		"name",
+		"chart",
+	}
+
+	opts := make(map[string]interface{})
+	opts["calledFrom"] = calledFrom
+
+	// params + opts
+	paramsInterface := make([]interface{}, 3)
+	paramsInterface[0] = params[0]
+	paramsInterface[1] = params[1]
+	paramsInterface[2] = opts
+
+	_, err := nf.Func(parameters)
+
+	require.NoError(t, err)
+
+	helmMock.AssertExpectations(t)
+
+	return helmMock.TestData().Get("templateCommandArgs").StringSlice()
+}
+
+// TestDefaultCommandineFlagsIncludeCrds tests that the includeCrds flag is set
+// to true by default
+func TestDefaultCommandineFlagsIncludeCrds(t *testing.T) {
+	kubeVersion := "1.18.0"
+
+	// we will check that the template function is called with these options,
+	// i.e. that includeCrds got set to true. This is not us passing an input,
+	// we are asserting here that the template function is called with these
+	// options.
+	templateOpts := TemplateOpts{
+		KubeVersion: kubeVersion,
+		IncludeCRDs: true,
+	}
+
+	params := []string{
+		"name",
+		"chart",
+	}
+
+	// we do not set includeCrds here, so it should be true by default
+	opts := make(map[string]interface{})
+	opts["calledFrom"] = calledFrom
+	opts["kubeVersion"] = kubeVersion
+
+	// params + opts
+	paramsInterface := make([]interface{}, 3)
+	paramsInterface[0] = params[0]
+	paramsInterface[1] = params[1]
+	paramsInterface[2] = opts
+
+	args := callNativeFucntion(t, templateOpts, paramsInterface)
+
+	// finally check that the actual command line arguments we will pass to
+	// `helm template` contain the --include-crds flag
+	require.Contains(t, args, "--include-crds")
+}
+
+// TestIncludeCrdsFalse tests that the includeCrds flag is can be set to false,
+// and this makes it to the helm.Template() method call
+func TestIncludeCrdsFalse(t *testing.T) {
+	kubeVersion := "1.18.0"
+
+	// we will check that the template function is called with these options,
+	// i.e. that includeCrds got set to false. This is not us passing an input,
+	// we are asserting here that the template function is called with these
+	// options.
+	templateOpts := TemplateOpts{
+		KubeVersion: kubeVersion,
+		IncludeCRDs: false,
+	}
+
+	params := []string{
+		"name",
+		"chart",
+	}
+
+	// we explicitly set includeCrds to false here
+	opts := make(map[string]interface{})
+	opts["calledFrom"] = calledFrom
+	opts["kubeVersion"] = kubeVersion
+	opts["includeCRDs"] = false
+
+	// params + opts
+	paramsInterface := make([]interface{}, 3)
+	paramsInterface[0] = params[0]
+	paramsInterface[1] = params[1]
+	paramsInterface[2] = opts
+
+	args := callNativeFucntion(t, templateOpts, paramsInterface)
+
+	// finally check that the actual command line arguments we will pass to
+	// `helm template` don't contain the --include-crds flag
+	require.NotContains(t, args, "--include-crds")
+}

--- a/pkg/helm/jsonnet_test.go
+++ b/pkg/helm/jsonnet_test.go
@@ -43,7 +43,7 @@ func (m *MockHelm) ChartExists(chart string, opts *JsonnetOpts) (string, error) 
 	return args.String(0), args.Error(1)
 }
 
-func callNativeFucntion(t *testing.T, templateOpts TemplateOpts, parameters []interface{}) []string {
+func callNativeFunction(t *testing.T, templateOpts TemplateOpts, parameters []interface{}) []string {
 	t.Helper()
 
 	helmMock := &MockHelm{}
@@ -117,7 +117,7 @@ func TestDefaultCommandineFlagsIncludeCrds(t *testing.T) {
 	paramsInterface[1] = params[1]
 	paramsInterface[2] = opts
 
-	args := callNativeFucntion(t, templateOpts, paramsInterface)
+	args := callNativeFunction(t, templateOpts, paramsInterface)
 
 	// finally check that the actual command line arguments we will pass to
 	// `helm template` contain the --include-crds flag
@@ -155,7 +155,7 @@ func TestIncludeCrdsFalse(t *testing.T) {
 	paramsInterface[1] = params[1]
 	paramsInterface[2] = opts
 
-	args := callNativeFucntion(t, templateOpts, paramsInterface)
+	args := callNativeFunction(t, templateOpts, paramsInterface)
 
 	// finally check that the actual command line arguments we will pass to
 	// `helm template` don't contain the --include-crds flag

--- a/pkg/helm/jsonnet_test.go
+++ b/pkg/helm/jsonnet_test.go
@@ -147,7 +147,7 @@ func TestIncludeCrdsFalse(t *testing.T) {
 	opts := make(map[string]interface{})
 	opts["calledFrom"] = calledFrom
 	opts["kubeVersion"] = kubeVersion
-	opts["includeCRDs"] = false
+	opts["includeCrds"] = false
 
 	// params + opts
 	paramsInterface := make([]interface{}, 3)

--- a/pkg/helm/jsonnet_test.go
+++ b/pkg/helm/jsonnet_test.go
@@ -87,7 +87,7 @@ func callNativeFunction(t *testing.T, expectedHelmTemplateOptions TemplateOpts, 
 
 // TestDefaultCommandineFlagsIncludeCrds tests that the includeCrds flag is set
 // to true by default
-func TestDefaultCommandineFlagsIncludeCrds(t *testing.T) {
+func TestDefaultCommandLineFlagsIncludeCrds(t *testing.T) {
 	kubeVersion := "1.18.0"
 
 	// we will check that the template function is called with these options,

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -10,13 +10,18 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-// Template expands a Helm Chart into a regular manifest.List using the `helm
-// template` command
-func (e ExecHelm) Template(name, chart string, opts TemplateOpts) (manifest.List, error) {
+func (e ExecHelm) templateCommandArgs(name, chart string, opts TemplateOpts) []string {
 	args := []string{name, chart,
 		"--values", "-", // values from stdin
 	}
 	args = append(args, opts.Flags()...)
+	return args
+}
+
+// Template expands a Helm Chart into a regular manifest.List using the `helm
+// template` command
+func (e ExecHelm) Template(name, chart string, opts TemplateOpts) (manifest.List, error) {
+	args := e.templateCommandArgs(name, chart, opts)
 
 	cmd := e.cmd("template", args...)
 	var buf bytes.Buffer


### PR DESCRIPTION
This is what `helm install` does. With Helm 3, we aren't installing CRDs by default any more and we expect this to be what most Tanka + Helm users want.

Closes: #829