### PR TITLE
`tool importers`: Fix case where environment-adjacent imports were not found

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -85,7 +85,7 @@ local docker(arch, depends_on=[]) =
       go('benchmark', [
         'go test -bench=. -benchmem -count=6 -run=^$ ./... | tee bench-pr.txt',
         'git fetch origin main',
-        'git checkout main',
+        'git reset --hard origin/main',
         'go test -bench=. -benchmem -count=6 -run=^$ ./... | tee bench-main.txt',
         'go install golang.org/x/perf/cmd/...@latest',
         'benchstat bench-main.txt bench-pr.txt',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -64,7 +64,7 @@ steps:
 - commands:
   - go test -bench=. -benchmem -count=6 -run=^$ ./... | tee bench-pr.txt
   - git fetch origin main
-  - git checkout main
+  - git reset --hard origin/main
   - go test -bench=. -benchmem -count=6 -run=^$ ./... | tee bench-main.txt
   - go install golang.org/x/perf/cmd/...@latest
   - benchstat bench-main.txt bench-pr.txt
@@ -306,6 +306,6 @@ kind: secret
 name: dockerhub_password
 ---
 kind: signature
-hmac: 060bcec4c9fbea042e7b70478a9ea0255de0f1e245f3dd031b02d7ca83ef5067
+hmac: f0dfa2a5202af05dbfca14e09d1c66222bf6d670d77b5f41b66d696985e89fb7
 
 ...

--- a/cmd/tk/tool.go
+++ b/cmd/tk/tool.go
@@ -139,6 +139,15 @@ func importersCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "importers <file> <file...>",
 		Short: "list all environments that either directly or transitively import the given files",
+		Long: `list all environments that either directly or transitively import the given files
+
+As optimization,
+if the file is not a vendored (located at <tk-root>/vendor/) or a lib file (located at <tk-root>/lib/), we assume:
+- it is used in a Tanka environment
+- it will not be imported by any lib or vendor files
+- the environment base (closest main file in parent dirs) will be considered an importer
+- if no base is found, all main files in child dirs will be considered importers
+`,
 		Args: cli.Args{
 			Validator: cli.ArgsMin(1),
 			Predictor: complete.PredictFiles("*"),

--- a/pkg/jsonnet/find_importers.go
+++ b/pkg/jsonnet/find_importers.go
@@ -263,7 +263,6 @@ func findImporters(root string, searchForFile string, chain map[string]struct{})
 	// If we've found a vendored file, check that it's not overridden by a vendored file in the environment root
 	// In that case, we only want to keep the environment vendored file
 	var filteredImporters []string
-	rootVendor := filepath.Join(root, "vendor")
 	if strings.HasPrefix(searchForFile, rootVendor) {
 		for _, importer := range importers {
 			relativePath, err := filepath.Rel(rootVendor, searchForFile)

--- a/pkg/jsonnet/find_importers.go
+++ b/pkg/jsonnet/find_importers.go
@@ -49,6 +49,10 @@ func FindImporterForFiles(root string, files []string) ([]string, error) {
 			return nil, err
 		}
 		for _, importer := range newImporters {
+			importer, err = evalSymlinks(importer)
+			if err != nil {
+				return nil, err
+			}
 			importers[importer] = struct{}{}
 		}
 	}
@@ -154,7 +158,43 @@ func findImporters(root string, searchForFile string, chain map[string]struct{})
 	var importers []string
 	var intermediateImporters []string
 
+	// If the file is not a vendored or a lib file, we assume:
+	// - it is used in a Tanka environment
+	// - it will not be imported by any lib or vendor files
+	// - the environment base (closest main file in parent dirs) will be considered an importer
+	// - if no base is found, all main files in child dirs will be considered importers
+	rootVendor := filepath.Join(root, "vendor")
+	rootLib := filepath.Join(root, "lib")
+	searchedFileIsLibOrVendored := strings.HasPrefix(searchForFile, rootVendor) || strings.HasPrefix(searchForFile, rootLib)
+	if !searchedFileIsLibOrVendored {
+		searchedDir := filepath.Dir(searchForFile)
+		searchedFileEntrypoint, err := jpath.Entrypoint(searchedDir)
+		if err == nil && searchedFileEntrypoint != "" {
+			importers = append(importers, searchedFileEntrypoint)
+		} else {
+			files, err := FindFiles(searchedDir, nil)
+			if err != nil {
+				return nil, err
+			}
+			for _, file := range files {
+				if filepath.Base(file) == jpath.DefaultEntrypoint {
+					importers = append(importers, file)
+				}
+			}
+		}
+	}
+
 	for jsonnetFilePath, jsonnetFileContent := range jsonnetFiles {
+		if len(jsonnetFileContent.Imports) == 0 {
+			continue
+		}
+
+		if !searchedFileIsLibOrVendored && (strings.HasPrefix(jsonnetFilePath, rootVendor) || strings.HasPrefix(jsonnetFilePath, rootLib)) {
+			// Skip the file if it's a vendored or lib file and the searched file is an environment file
+			// Libs and vendored files cannot import environment files
+			continue
+		}
+
 		isImporter := false
 		// For all imports in all jsonnet files, check if they import the file we're looking for
 		for _, importPath := range jsonnetFileContent.Imports {

--- a/pkg/jsonnet/find_importers_test.go
+++ b/pkg/jsonnet/find_importers_test.go
@@ -136,6 +136,13 @@ func findImportersTestCases(t testing.TB) []findImportersTestCase {
 			},
 			expectedImporters: nil,
 		},
+		{
+			name:  "imported file in lib relative to env",
+			files: []string{"testdata/findImporters/environments/lib-import-relative-to-env/file-to-import.libsonnet"},
+			expectedImporters: []string{
+				absPath(t, "testdata/findImporters/environments/lib-import-relative-to-env/folder1/folder2/main.jsonnet"),
+			},
+		},
 	}
 }
 
@@ -164,7 +171,8 @@ func TestFindImportersForFiles(t *testing.T) {
 
 func BenchmarkFindImporters(b *testing.B) {
 	// Create a very large and complex project
-	tempDir := b.TempDir()
+	tempDir, err := filepath.EvalSymlinks(b.TempDir())
+	require.NoError(b, err)
 	generateTestProject(b, tempDir, 100, false)
 
 	// Run the benchmark

--- a/pkg/jsonnet/testdata/findImporters/environments/lib-import-relative-to-env/README.md
+++ b/pkg/jsonnet/testdata/findImporters/environments/lib-import-relative-to-env/README.md
@@ -1,0 +1,6 @@
+# Explanation
+
+This tests the weird case where relative imports can be resolved either from the place where they are defined or from the main.jsonnet being run.
+The code has to consider all files within the environment context as being potentially imported and used by itself
+
+*Note that this is not a good practice, but Tanka's behavior should be consistent with the Jsonnet interpreter*

--- a/pkg/jsonnet/testdata/findImporters/environments/lib-import-relative-to-env/file-to-import.libsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/lib-import-relative-to-env/file-to-import.libsonnet
@@ -1,0 +1,3 @@
+{
+  attribute: 'test',
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/lib-import-relative-to-env/folder1/folder2/main.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/lib-import-relative-to-env/folder1/folder2/main.jsonnet
@@ -1,0 +1,5 @@
+local lib = import 'imports-relative-to-env/main.libsonnet';
+
+{
+  attribute: lib.attribute,
+}

--- a/pkg/jsonnet/testdata/findImporters/lib/imports-relative-to-env/main.libsonnet
+++ b/pkg/jsonnet/testdata/findImporters/lib/imports-relative-to-env/main.libsonnet
@@ -1,0 +1,3 @@
+// See environments/lib-import-relative-to-env/README.md for more information.
+
+import '../../file-to-import.libsonnet'


### PR DESCRIPTION
Following some issues, it is safer to consider all files with an environment as being imported by that env 
The particular issue I'm fixing happens when a library uses a relative import (unresolvable by itself) but that resolves to an env file when evaluated in that context

Example:

- in `lib/my-lib/main.libsonnet`: `import my-file.libsonnet` but `my-file.libsonnet` doesn't exist in that lib
- in `env/myenv`: have `my-file.libsonnet` exist and `import "my-lib/main.libsonnet"`. This evaluates correctly because the lib import is found in the env
- The issue here is that if you run `tool importers env/myenv/my-file.libsonnet`, it will find nothing

I initially tried to do something smarter where I keep references of all imports that were made in files that are imported by each environment and then try to resolve those imports in the env context. However, it was even more complex than it is currently and extremely slow (you essentially have to test a combination of every main.jsonnet file and everyone of their respective imports)