### PR TITLE
`tool importers`: Local vendor should override global vendor

### DIFF
--- a/pkg/jsonnet/find_importers.go
+++ b/pkg/jsonnet/find_importers.go
@@ -226,9 +226,12 @@ func findImporters(root string, searchForFile string, chain map[string]struct{})
 	rootVendor := filepath.Join(root, "vendor")
 	if strings.HasPrefix(searchForFile, rootVendor) {
 		for _, importer := range importers {
-			relativePath := strings.TrimPrefix(searchForFile, rootVendor)
-			relativePath = strings.TrimPrefix(relativePath, "/")
-			if _, ok := jsonnetFilesCache[root][filepath.Join(filepath.Dir(importer), "vendor", relativePath)]; !ok {
+			relativePath, err := filepath.Rel(rootVendor, searchForFile)
+			if err != nil {
+				return nil, err
+			}
+			vendoredFileInEnvironment := filepath.Join(filepath.Dir(importer), "vendor", relativePath)
+			if _, ok := jsonnetFilesCache[root][vendoredFileInEnvironment]; !ok {
 				filteredImporters = append(filteredImporters, importer)
 			}
 		}

--- a/pkg/jsonnet/find_importers_test.go
+++ b/pkg/jsonnet/find_importers_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,8 +32,9 @@ func findImportersTestCases(t testing.TB) []findImportersTestCase {
 
 	return []findImportersTestCase{
 		{
-			name:  "no files",
-			files: []string{},
+			name:              "no files",
+			files:             []string{},
+			expectedImporters: nil,
 		},
 		{
 			name:        "invalid file",
@@ -118,6 +120,22 @@ func findImportersTestCases(t testing.TB) []findImportersTestCase {
 				absPath(t, "testdata/findImporters/environments/relative-import/main.jsonnet"),
 			},
 		},
+		{
+			name: "vendor override in env: override vendor used",
+			files: []string{
+				"testdata/findImporters/environments/vendor-override-in-env/vendor/vendor-override-in-env/main.libsonnet",
+			},
+			expectedImporters: []string{
+				absPath(t, "testdata/findImporters/environments/vendor-override-in-env/main.jsonnet"),
+			},
+		},
+		{
+			name: "vendor override in env: global vendor unused",
+			files: []string{
+				"testdata/findImporters/vendor/vendor-override-in-env/main.libsonnet",
+			},
+			expectedImporters: nil,
+		},
 	}
 }
 
@@ -129,6 +147,10 @@ func TestFindImportersForFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
 	for _, file := range files {
+		// Skip non-main files
+		if filepath.Base(file) != jpath.DefaultEntrypoint {
+			continue
+		}
 		_, err := EvaluateFile(file, Opts{})
 		require.NoError(t, err, "failed to eval %s", file)
 	}

--- a/pkg/jsonnet/testdata/findImporters/environments/vendor-override-in-env/main.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/vendor-override-in-env/main.jsonnet
@@ -1,0 +1,4 @@
+{
+  assert self.imported.test == 'env-vendor',
+  imported: (import 'vendor-override-in-env/main.libsonnet'),
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/vendor-override-in-env/vendor/vendor-override-in-env/main.libsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/vendor-override-in-env/vendor/vendor-override-in-env/main.libsonnet
@@ -1,0 +1,3 @@
+{
+  test: 'env-vendor',
+}

--- a/pkg/jsonnet/testdata/findImporters/vendor/vendor-override-in-env/main.libsonnet
+++ b/pkg/jsonnet/testdata/findImporters/vendor/vendor-override-in-env/main.libsonnet
@@ -1,0 +1,3 @@
+{
+  test: 'global-vendor',
+}


### PR DESCRIPTION
Currently, if a file is pulled from a local vendor overriding a global vendor, the global vendor will still show up as an imported file 
This fixes the issue by removing the global vendored lib as imported files when there exists a locally vendored file with the same name