### PR TITLE
add support for kustomize build flags

### DIFF
--- a/pkg/kustomize/build.go
+++ b/pkg/kustomize/build.go
@@ -10,10 +10,18 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+func (k ExecKustomize) buildCommandArgs(path string, opts BuildOpts) []string {
+	args := []string{path}
+	args = append(args, opts.Flags()...)
+	return args
+}
+
 // Build expands a Kustomize into a regular manifest.List using the `kustomize
 // build` command
-func (k ExecKustomize) Build(path string) (manifest.List, error) {
-	cmd := k.cmd("build", path)
+func (k ExecKustomize) Build(path string, opts BuildOpts) (manifest.List, error) {
+	args := k.buildCommandArgs(path, opts)
+
+	cmd := k.cmd("build", args...)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr
@@ -37,4 +45,46 @@ func (k ExecKustomize) Build(path string) (manifest.List, error) {
 	}
 
 	return list, nil
+}
+
+// BuildOpts are additional, non-required options for Kustomize.Build
+type BuildOpts struct {
+	// enable kustomize plugins
+	EnableAlphaPlugins bool
+	// enable support for exec functions (raw executables); do not use for untrusted configs! (Alpha)
+	EnableExec bool
+	// Enable use of the Helm chart inflator generator.
+	EnableHelm bool
+	// enable support for starlark functions. (Alpha)
+	EnableStar bool
+	// if set to 'LoadRestrictionsNone', local kustomizations may load files from outside their root.
+	// This does, however, break the relocatability of the kustomization. (default "LoadRestrictionsRootOnly")
+	LoadRestrictor string
+}
+
+// Flags returns all options as their respective `kustomize build` flag equivalent
+func (b BuildOpts) Flags() []string {
+	var flags []string
+
+	if b.EnableAlphaPlugins {
+		flags = append(flags, "--enable-alpha-plugins")
+	}
+
+	if b.EnableExec {
+		flags = append(flags, "--enable-exec")
+	}
+
+	if b.EnableHelm {
+		flags = append(flags, "--enable-helm")
+	}
+
+	if b.EnableStar {
+		flags = append(flags, "--enable-star")
+	}
+
+	if b.LoadRestrictor != "" {
+		flags = append(flags, "--load-restrictor="+b.LoadRestrictor)
+	}
+
+	return flags
 }

--- a/pkg/kustomize/jsonnet.go
+++ b/pkg/kustomize/jsonnet.go
@@ -14,6 +14,8 @@ import (
 // JsonnetOpts are additional properties the consumer of the native func might
 // pass.
 type JsonnetOpts struct {
+	BuildOpts
+
 	// CalledFrom is the file that calls kustomizeBuild. This is used to find the
 	// vendored Kustomize relative to this file
 	CalledFrom string `json:"calledFrom"`

--- a/pkg/kustomize/jsonnet.go
+++ b/pkg/kustomize/jsonnet.go
@@ -53,7 +53,7 @@ func NativeFunc(k Kustomize) *jsonnet.NativeFunction {
 			}
 
 			// render resources
-			list, err := k.Build(actualPath)
+			list, err := k.Build(actualPath, opts.BuildOpts)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -10,7 +10,7 @@ import (
 // Kustomize provides high level access to some Kustomize operations
 type Kustomize interface {
 	// Build returns the individual resources of a Kustomize
-	Build(path string) (manifest.List, error)
+	Build(path string, opts BuildOpts) (manifest.List, error)
 }
 
 // ExecKustomize is a Kustomize implementation powered by the `kustomize`


### PR DESCRIPTION
## What

Add support for specifying kustomize build flags. Supports most of the plugin-related flags from the output of `kustomize build --help` for kustomize v5.0.1:

```
$ kustomize build --help
[...]

Flags:
      --as-current-user          use the uid and gid of the command executor to run the function in the container
      --enable-alpha-plugins     enable kustomize plugins
      --enable-exec              enable support for exec functions (raw executables); do not use for untrusted configs! (Alpha)
      --enable-helm              Enable use of the Helm chart inflator generator.
      --enable-star              enable support for starlark functions. (Alpha)
  -e, --env stringArray          a list of environment variables to be used by functions
      --helm-command string      helm command (path to executable) (default "helm")
  -h, --help                     help for build
      --load-restrictor string   if set to 'LoadRestrictionsNone', local kustomizations may load files from outside their root. This does, however, break the relocatability of the kustomization. (default "LoadRestrictionsRootOnly")
      --mount stringArray        a list of storage options read from the filesystem
      --network                  enable network access for functions that declare it
      --network-name string      the docker network to run the container in (default "bridge")
  -o, --output string            If specified, write output to this path.

Global Flags:
      --stack-trace   print a stack-trace on error
```

Followed a similar approach for how extra command line flags are passed to helm.

## Why

I want to migrate to Tanka from my custom in-house build system based on kustomize. My current system relies on several Kustomize plugins, e.g. [https://github.com/viaduct-ai/kustomize-sops](KSOPS). However, the current kustomize support in Tanka doesn't allow me to specify the command-line flags that I need when I run Kustomize, so it's cumbersome-to-impossible to wrap my existing configurations and bring them into the Tanka ecosystem.

I realise that there are security implications by allowing these flags to be specified in jsonnetland. An alternative approach would be environment variables, [similar to how the kustomize and helm executables can be specified](https://tanka.dev/env-vars).
For example, `TANKA_KUSTOMIZE_ENABLE_ALPHA_PLUGINS`, `TANKA_KUSTOMIZE_ENABLE_EXEC`, `TANKA_KUSTOMIZE_LOAD_RESTRICTOR`.

If this warrants further discussion I'm happy to create an issue 😄 