### PR TITLE
Build with Golang 1.20

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,6 +1,6 @@
 local vault = import 'vault.libsonnet';
 
-local golang = 'golang:1.19';
+local golang = 'golang:1.20';
 
 local volumes = [{ name: 'gopath', temp: {} }];
 local mounts = [{ name: 'gopath', path: '/go' }];
@@ -122,7 +122,7 @@ local docker(arch, depends_on=[]) =
       ]),
       {
         name: 'manifest',
-        image: 'plugins/manifest',
+        image: 'plugins/manifest:1.4.0',
         settings: {
           ignore_missing: true,
           spec: '.drone/docker-manifest.tmpl',
@@ -141,7 +141,7 @@ local docker(arch, depends_on=[]) =
   pipeline('manifest') {
     steps: [{
       name: 'manifest',
-      image: 'plugins/manifest',
+      image: 'plugins/manifest:1.4.0',
       settings: {
         auto_tag: true,
         ignore_missing: true,

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -304,3 +304,8 @@ get:
   path: infra/data/ci/docker_hub
 kind: secret
 name: dockerhub_password
+---
+kind: signature
+hmac: 060bcec4c9fbea042e7b70478a9ea0255de0f1e245f3dd031b02d7ca83ef5067
+
+...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -4,7 +4,7 @@ name: check
 steps:
 - commands:
   - go mod download
-  image: golang:1.19
+  image: golang:1.20
   name: download
   volumes:
   - name: gopath
@@ -17,7 +17,7 @@ steps:
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
   - make lint
-  image: golang:1.19
+  image: golang:1.20
   name: lint
   volumes:
   - name: gopath
@@ -30,7 +30,7 @@ steps:
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
   - make test
-  image: golang:1.19
+  image: golang:1.20
   name: test
   volumes:
   - name: gopath
@@ -43,7 +43,7 @@ steps:
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
   - make cross
-  image: golang:1.19
+  image: golang:1.20
   name: build
   volumes:
   - name: gopath
@@ -68,7 +68,7 @@ steps:
   - go test -bench=. -benchmem -count=6 -run=^$ ./... | tee bench-main.txt
   - go install golang.org/x/perf/cmd/...@latest
   - benchstat bench-main.txt bench-pr.txt
-  image: golang:1.19
+  image: golang:1.20
   name: benchmark
   volumes:
   - name: gopath
@@ -87,7 +87,7 @@ name: release
 steps:
 - commands:
   - git fetch origin --tags
-  image: golang:1.19
+  image: golang:1.20
   name: fetch-tags
   volumes:
   - name: gopath
@@ -100,7 +100,7 @@ steps:
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
   - make cross
-  image: golang:1.19
+  image: golang:1.20
   name: cross
   volumes:
   - name: gopath
@@ -151,7 +151,7 @@ platform:
 steps:
 - commands:
   - git fetch origin --tags
-  image: golang:1.19
+  image: golang:1.20
   name: fetch-tags
   volumes:
   - name: gopath
@@ -164,7 +164,7 @@ steps:
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
   - make static
-  image: golang:1.19
+  image: golang:1.20
   name: static
   volumes:
   - name: gopath
@@ -197,7 +197,7 @@ platform:
 steps:
 - commands:
   - git fetch origin --tags
-  image: golang:1.19
+  image: golang:1.20
   name: fetch-tags
   volumes:
   - name: gopath
@@ -210,7 +210,7 @@ steps:
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
   - make static
-  image: golang:1.19
+  image: golang:1.20
   name: static
   volumes:
   - name: gopath
@@ -242,12 +242,12 @@ steps:
 - commands:
   - git fetch origin --tags
   - echo "main-$(git describe --tags)" > .tags
-  image: golang:1.19
+  image: golang:1.20
   name: fetch-tags
   volumes:
   - name: gopath
     path: /go
-- image: plugins/manifest
+- image: plugins/manifest:1.4.0
   name: manifest
   settings:
     ignore_missing: true
@@ -269,7 +269,7 @@ depends_on:
 kind: pipeline
 name: manifest
 steps:
-- image: plugins/manifest
+- image: plugins/manifest:1.4.0
   name: manifest
   settings:
     auto_tag: true
@@ -304,8 +304,3 @@ get:
   path: infra/data/ci/docker_hub
 kind: secret
 name: dockerhub_password
----
-kind: signature
-hmac: 2cd20dcbb7e3f252b5379266c5dab621d1c379ae0ceac878be66974b3cae3b79
-
-...

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOX := $(BIN_DIR)/gox
 GOLINTER := $(GOPATH)/bin/golangci-lint
 
 $(GOLINTER):
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
 lint: $(GOLINTER)
 	$(GOLINTER) run

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -114,11 +114,7 @@ func envSetCmd() *cli.Command {
 			return err
 		}
 
-		if err := writeJSON(cfg, filepath.Join(path, "spec.json")); err != nil {
-			return err
-		}
-
-		return nil
+		return writeJSON(cfg, filepath.Join(path, "spec.json"))
 	}
 	return cmd
 }
@@ -149,11 +145,7 @@ func envAddCmd() *cli.Command {
 			}
 		}
 
-		if err := addEnv(args[0], cfg, *inline); err != nil {
-			return err
-		}
-
-		return nil
+		return addEnv(args[0], cfg, *inline)
 	}
 	return cmd
 }

--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -38,11 +38,7 @@ func evalCmd() *cli.Command {
 			return err
 		}
 
-		if err := pageln(string(out)); err != nil {
-			return err
-		}
-
-		return nil
+		return pageln(string(out))
 	}
 
 	return cmd

--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -33,9 +33,7 @@ func fPageln(r io.Reader) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		if err := cmd.Run(); err != nil {
-			// Fallthrough on failure so that the contents of the reader are copied to stdout.
-		} else {
+		if err := cmd.Run(); err == nil {
 			return nil
 		}
 	}

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -140,11 +140,11 @@ func (c Charts) Vendor(prune bool) error {
 			if chartYAML.Version.String() == r.Version.String() {
 				log.Info().Msgf("%s exists", r)
 				continue
-			} else {
-				log.Info().Msgf("Removing %s", r)
-				if err := os.RemoveAll(chartPath); err != nil {
-					return err
-				}
+			}
+
+			log.Info().Msgf("Removing %s", r)
+			if err := os.RemoveAll(chartPath); err != nil {
+				return err
 			}
 		} else if chartDirExists {
 			// If the chart dir exists but the manifest doesn't, we'll clear it out and re-download the chart

--- a/pkg/jsonnet/importer.go
+++ b/pkg/jsonnet/importer.go
@@ -68,7 +68,7 @@ func (i *ExtendedImporter) Import(importedFrom, importedPath string) (contents j
 }
 
 // tkLoader provides `tk.libsonnet` from memory (builtin)
-func tkLoader(importedFrom, importedPath string) (contents *jsonnet.Contents, foundAt string, err error) {
+func tkLoader(_, importedPath string) (contents *jsonnet.Contents, foundAt string, err error) {
 	if importedPath != "tk" {
 		return nil, "", nil
 	}

--- a/pkg/kubernetes/client/apply.go
+++ b/pkg/kubernetes/client/apply.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Test-ability: isolate applyCtl to build and return exec.Cmd from ApplyOpts
-func (k Kubectl) applyCtl(data manifest.List, opts ApplyOpts) *exec.Cmd {
+func (k Kubectl) applyCtl(_ manifest.List, opts ApplyOpts) *exec.Cmd {
 	argv := []string{"-f", "-"}
 	serverSide := (opts.ApplyStrategy == "server")
 	if serverSide {

--- a/pkg/process/filter.go
+++ b/pkg/process/filter.go
@@ -116,7 +116,7 @@ type NegMatcher struct {
 	exp Matcher
 }
 
-func (n NegMatcher) MatchString(s string) bool {
+func (n NegMatcher) MatchString(_ string) bool {
 	return true
 }
 

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -37,12 +37,12 @@ func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment
 		names := make([]string, 0, len(envs))
 		for _, e := range envs {
 			// If there's a full match on the given name, use this environment
-			if name := e.Metadata().Name(); name == opts.Name {
+			name := e.Metadata().Name()
+			if name == opts.Name {
 				envs = manifest.List{e}
 				break
-			} else {
-				names = append(names, name)
 			}
+			names = append(names, name)
 		}
 		if len(envs) > 1 {
 			sort.Strings(names)

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -66,10 +66,10 @@ func Prune(baseDir string, opts PruneOpts) error {
 	}
 
 	// prompt for confirm
-	if opts.AutoApprove == AutoApproveAlways {
-		// Skip approval
-	} else if err := confirmPrompt("Pruning from", p.Env.Spec.Namespace, kube.Info()); err != nil {
-		return err
+	if opts.AutoApprove != AutoApproveAlways {
+		if err := confirmPrompt("Pruning from", p.Env.Spec.Namespace, kube.Info()); err != nil {
+			return err
+		}
 	}
 
 	// delete resources

--- a/pkg/tanka/static.go
+++ b/pkg/tanka/static.go
@@ -27,7 +27,7 @@ func (s StaticLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment,
 	return config, nil
 }
 
-func (s StaticLoader) Peek(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
+func (s StaticLoader) Peek(path string, _ LoaderOpts) (*v1alpha1.Environment, error) {
 	config, err := parseStaticSpec(path)
 	if err != nil {
 		return nil, err

--- a/pkg/tanka/workflow.go
+++ b/pkg/tanka/workflow.go
@@ -127,10 +127,10 @@ func Apply(baseDir string, opts ApplyOpts) error {
 	}
 
 	// prompt for confirmation
-	if opts.AutoApprove == AutoApproveAlways || (noChanges && opts.AutoApprove == AutoApproveNoChanges) || opts.DryRun != "" {
-		// Skip approval
-	} else if err := confirmPrompt("Applying to", l.Env.Spec.Namespace, kube.Info()); err != nil {
-		return err
+	if opts.AutoApprove != AutoApproveAlways && !(noChanges && opts.AutoApprove == AutoApproveNoChanges) && opts.DryRun == "" {
+		if err := confirmPrompt("Applying to", l.Env.Spec.Namespace, kube.Info()); err != nil {
+			return err
+		}
 	}
 
 	return kube.Apply(l.Resources, kubernetes.ApplyOpts{
@@ -230,10 +230,10 @@ func Delete(baseDir string, opts DeleteOpts) error {
 	}
 
 	// prompt for confirmation
-	if opts.AutoApprove == AutoApproveAlways || opts.DryRun != "" {
-		// Skip approval
-	} else if err := confirmPrompt("Deleting from", l.Env.Spec.Namespace, kube.Info()); err != nil {
-		return err
+	if opts.AutoApprove != AutoApproveAlways && opts.DryRun == "" {
+		if err := confirmPrompt("Deleting from", l.Env.Spec.Namespace, kube.Info()); err != nil {
+			return err
+		}
 	}
 
 	return kube.Delete(l.Resources, kubernetes.DeleteOpts{


### PR DESCRIPTION
- The go version was upgraded here: https://github.com/grafana/tanka/pull/836/files but not actually in the Drone config where Tanka is actually built
- Bump golangci-lint, it crashed with 1.20
- Fix new linting errors from new version
- Lock the `plugins/manifest` Drone plugin to v1.4.0. They broke the latest version