### PR TITLE
Helm: Support OCI

### DIFF
--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -223,6 +223,26 @@ $ tk tool charts vendor
 
 Optionally, you can also pass the `--prune` flag to remove vendored charts that are no longer in the chartfile.
 
+#### OCI Registry Support
+
+Tanka supports pulling charts from OCI registries. To use one, the chart name must be split into two parts: the registry and the chart name. 
+
+As example, if you wanted to pull the `oci://public.ecr.aws/karpenter/karpenter:v0.27.3` image, your chartfile would look like this:
+
+```yaml
+version: 1
+directory: charts
+repositories:
+- name: karpenter
+  url: oci://public.ecr.aws/karpenter
+requires:
+- chart: karpenter/karpenter
+  directory: v0.27.3
+  version: v0.27.3
+```
+
+_Registry login is not supported yet._
+
 ## Troubleshooting
 
 ### Helm executable missing

--- a/pkg/helm/spec.go
+++ b/pkg/helm/spec.go
@@ -3,8 +3,6 @@ package helm
 import (
 	"fmt"
 	"strings"
-
-	"github.com/Masterminds/semver"
 )
 
 const (
@@ -73,9 +71,9 @@ func (r Repos) HasName(repoName string) bool {
 // Requirement describes a single required Helm Chart.
 // Both, Chart and Version are required
 type Requirement struct {
-	Chart     string         `json:"chart"`
-	Version   semver.Version `json:"version"`
-	Directory string         `json:"directory,omitempty"`
+	Chart     string `json:"chart"`
+	Version   string `json:"version"`
+	Directory string `json:"directory,omitempty"`
 }
 
 func (r Requirement) String() string {
@@ -83,7 +81,7 @@ func (r Requirement) String() string {
 	if dir == "" {
 		dir = parseReqName(r.Chart)
 	}
-	return fmt.Sprintf("%s@%s (dir: %s)", r.Chart, r.Version.String(), dir)
+	return fmt.Sprintf("%s@%s (dir: %s)", r.Chart, r.Version, dir)
 }
 
 // Requirements is an aggregate of all required Charts
@@ -115,7 +113,7 @@ func (r Requirements) Validate() error {
 			dir = parseReqName(req.Chart)
 		}
 		if previous, ok := outputDirs[dir]; ok {
-			errs = append(errs, fmt.Sprintf(`output directory %q is used twice, by charts "%s@%s" and "%s@%s"`, dir, previous.Chart, previous.Version.String(), req.Chart, req.Version.String()))
+			errs = append(errs, fmt.Sprintf(`output directory %q is used twice, by charts "%s@%s" and "%s@%s"`, dir, previous.Chart, previous.Version, req.Chart, req.Version))
 		}
 		outputDirs[dir] = req
 	}


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/830 

To support OCI registries for Helm charts:
- we need to pass the full URL when pulling those charts
- versioning is not necessarily semver now
- the `repo update` cmd is a no-op for OCI packages but still necessary for Helm repositories