### PR TITLE
Helm: remove the experimental warning

### DIFF
--- a/docs/docs/helm.mdx
+++ b/docs/docs/helm.mdx
@@ -12,8 +12,6 @@ well maintained application definitions for Kubernetes.
 Even though Grafana Tanka uses the [Jsonnet language](/jsonnet/overview) for
 resource definition, you can still consume Helm resources, as described below.
 
-> **Warning:** Keep in mind this feature is considered EXPERIMENTAL
-
 ## Consuming Helm Charts from Jsonnet
 
 Helm support is provided using the


### PR DESCRIPTION
At GrafanaLabs we have been using this feature since its introduction in 2020. We consider this feature stable thus removing the experimental warning.