### PR TITLE
eval: Allow map key as expression

### DIFF
--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/go-clix/cli"
 
@@ -25,7 +24,7 @@ func evalCmd() *cli.Command {
 			JsonnetOpts: getJsonnetOpts(),
 		}
 		if *evalPattern != "" {
-			jsonnetOpts.EvalScript = fmt.Sprintf(tanka.PatternEvalScript, *evalPattern)
+			jsonnetOpts.EvalScript = tanka.PatternEvalScript(*evalPattern)
 		}
 		raw, err := tanka.Eval(args[0], jsonnetOpts)
 

--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -51,7 +51,12 @@ function(%s)
 	return raw, nil
 }
 
-const PatternEvalScript = "main.%s"
+func PatternEvalScript(expr string) string {
+	if strings.HasPrefix(expr, "[") {
+		return fmt.Sprintf("main%s", expr)
+	}
+	return fmt.Sprintf("main.%s", expr)
+}
 
 // MetadataEvalScript finds the Environment object (without its .data object)
 const MetadataEvalScript = `

--- a/pkg/tanka/evaluators_test.go
+++ b/pkg/tanka/evaluators_test.go
@@ -31,3 +31,21 @@ func TestEvalJsonnet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `"foovalue"`, strings.TrimSpace(json))
 }
+
+func TestEvalJsonnetWithExpression(t *testing.T) {
+	exprs := []string{`["testCase"]`, "testCase"}
+
+	for _, expr := range exprs {
+		t.Run(expr, func(t *testing.T) {
+			opts := jsonnet.Opts{
+				EvalScript: PatternEvalScript(expr),
+			}
+
+			// This will fail intermittently if TLAs are passed as positional
+			// parameters.
+			json, err := evalJsonnet("testdata/cases/object", opts)
+			assert.NoError(t, err)
+			assert.Equal(t, `"object"`, strings.TrimSpace(json))
+		})
+	}
+}


### PR DESCRIPTION
If the first level trying to eval has characters like `-` or `.` in them, it's currently impossible to eval 
With this PR, we can do `-e '["my-key"]'`