### PR TITLE
Reuse VMs when possible

### DIFF
--- a/pkg/jsonnet/imports_test.go
+++ b/pkg/jsonnet/imports_test.go
@@ -53,7 +53,7 @@ func BenchmarkGetSnippetHash(b *testing.B) {
 			// Create a VM. It's important to reuse the same VM
 			// While there is a caching mechanism that normally shouldn't be shared in a benchmark iteration,
 			// it's useful to evaluate its impact here, because the caching will also improve the evaluation performance afterwards.
-			vm := MakeVM(Opts{ImportPaths: []string{tempDir}})
+			vm := VMPool.Get(Opts{ImportPaths: []string{tempDir}})
 			content, err := os.ReadFile(filepath.Join(tempDir, "main.jsonnet"))
 			require.NoError(b, err)
 

--- a/pkg/jsonnet/lint.go
+++ b/pkg/jsonnet/lint.go
@@ -106,14 +106,15 @@ func lintWithRecover(file string) (buf bytes.Buffer, success bool) {
 		return
 	}
 
-	vm := MakeVM(Opts{})
 	jpaths, _, _, err := jpath.Resolve(file, true)
 	if err != nil {
 		fmt.Fprintf(&buf, "got an error getting jpath for %s: %v\n\n", file, err)
 		return
 	}
+	opts := Opts{ImportPaths: jpaths}
+	vm := VMPool.Get(opts)
+	defer VMPool.Release(vm, opts)
 
-	vm.Importer(NewExtendedImporter(jpaths))
 	failed := linter.LintSnippet(vm, &buf, []linter.Snippet{{FileName: file, Code: string(content)}})
 	return buf, !failed
 }

--- a/pkg/process/data_test.go
+++ b/pkg/process/data_test.go
@@ -18,7 +18,7 @@ type testData struct {
 func loadFixture(name string) testData {
 	filename := filepath.Join("./testdata", name)
 
-	vm := jsonnet.MakeVM(jsonnet.Opts{
+	vm := jsonnet.VMPool.Get(jsonnet.Opts{
 		ImportPaths: []string{"./testdata"},
 	})
 


### PR DESCRIPTION
Whenever ext code and imports are unchanged, VMs have a cache that can be useful for future evaluations. This PR adds a dumb pool that keeps the latest VM that was used for that same eval path.

I also added a shuffling of envs, so that the likelihood of reusing a VM is higher. When envs are done evaluating, their VM is put back in the pool (with an enriched cache from their eval). 

An important thing to note is that VMs cannot be used concurrently, so we need to remove them from the pool when they are used.