### PR TITLE
Clamp thread count to number of envs to export

### DIFF
--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -31,7 +31,7 @@ func parallelLoadEnvironments(envs []*v1alpha1.Environment, opts parallelOpts) (
 	}
 
 	if opts.Parallelism > len(envs) {
-		log.Info().Int("parallelism", opts.Parallelism).Int("envs", len(envs)).Msg("Reducing parallelism to number of environments")
+		log.Info().Int("parallelism", opts.Parallelism).Int("envs", len(envs)).Msg("Reducing parallelism to match number of environments")
 		opts.Parallelism = len(envs)
 	}
 

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -30,6 +30,11 @@ func parallelLoadEnvironments(envs []*v1alpha1.Environment, opts parallelOpts) (
 		opts.Parallelism = defaultParallelism
 	}
 
+	if opts.Parallelism > len(envs) {
+		log.Info().Int("parallelism", opts.Parallelism).Int("envs", len(envs)).Msg("Reducing parallelism to number of environments")
+		opts.Parallelism = len(envs)
+	}
+
 	for i := 0; i < opts.Parallelism; i++ {
 		go parallelWorker(jobsCh, outCh)
 	}


### PR DESCRIPTION
No need to launch 32 workers if we have two envs to export!