### PR TITLE
inline-environments-doc: fix typo with `a` -> `as`

### DIFF
--- a/docs/docs/inline-environments.mdx
+++ b/docs/docs/inline-environments.mdx
@@ -59,7 +59,7 @@ The original files look like this:
 }
 ```
 
-Converting is a simple as bringing in the `spec.json` into `main.jsonnet` and
+Converting is as simple as bringing in the `spec.json` into `main.jsonnet` and
 moving the original `main.jsonnet` scope into the `data:` element.
 
 ```jsonnet


### PR DESCRIPTION
Came across small typo when reading docs. I imagine this should read `as simple as` instead of `a simple as`.