### PR TITLE
Jsonnet: Add binary jsonnet implementation

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -32,6 +32,7 @@ local make(target) = go(target, [
   '  rm -f helm-v3.9.0-linux-amd64.tar.gz',
   'fi',
   'cp linux-amd64/helm /usr/local/bin/helm',
+  'go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0',
   'make ' + target,
 ]);
 
@@ -83,6 +84,7 @@ local docker(arch, depends_on=[]) =
     },
     steps: [
       go('benchmark', [
+        'go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0',
         'go test -bench=. -benchmem -count=6 -run=^$ ./... | tee bench-pr.txt',
         'git fetch origin main',
         'git reset --hard origin/main',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -16,6 +16,7 @@ steps:
   - '  rm -f helm-v3.9.0-linux-amd64.tar.gz'
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
+  - go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
   - make lint
   image: golang:1.20
   name: lint
@@ -29,6 +30,7 @@ steps:
   - '  rm -f helm-v3.9.0-linux-amd64.tar.gz'
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
+  - go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
   - make test
   image: golang:1.20
   name: test
@@ -42,6 +44,7 @@ steps:
   - '  rm -f helm-v3.9.0-linux-amd64.tar.gz'
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
+  - go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
   - make cross
   image: golang:1.20
   name: build
@@ -62,6 +65,7 @@ node:
   type: no-parallel
 steps:
 - commands:
+  - go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
   - go test -bench=. -benchmem -count=6 -run=^$ ./... | tee bench-pr.txt
   - git fetch origin main
   - git reset --hard origin/main
@@ -99,6 +103,7 @@ steps:
   - '  rm -f helm-v3.9.0-linux-amd64.tar.gz'
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
+  - go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
   - make cross
   image: golang:1.20
   name: cross
@@ -163,6 +168,7 @@ steps:
   - '  rm -f helm-v3.9.0-linux-amd64.tar.gz'
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
+  - go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
   - make static
   image: golang:1.20
   name: static
@@ -209,6 +215,7 @@ steps:
   - '  rm -f helm-v3.9.0-linux-amd64.tar.gz'
   - fi
   - cp linux-amd64/helm /usr/local/bin/helm
+  - go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
   - make static
   image: golang:1.20
   name: static
@@ -306,6 +313,6 @@ kind: secret
 name: dockerhub_password
 ---
 kind: signature
-hmac: f0dfa2a5202af05dbfca14e09d1c66222bf6d670d77b5f41b66d696985e89fb7
+hmac: d6e20fdf35f6a2177b563a0db363b55872b276a880165349685c1f6aa1641495
 
 ...

--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -22,7 +22,7 @@ func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
 	fs.StringVar(&v.name, "name", "", "string that only a single inline environment contains in its name")
 	fs.StringSliceVarP(&v.targets, "target", "t", nil, "Regex filter on '<kind>/<name>'. See https://tanka.dev/output-filtering")
-	fs.StringVar(&v.jsonnetImplementation, "jsonnet-implementation", "go", "Use `go` to use native go-jsonnet implementation and `binary:<path>` to delegate evaluation to a binary (with the same API as the regular `jsonnet` binary)")
+	fs.StringVar(&v.jsonnetImplementation, "jsonnet-implementation", "go", "Use `go` to use native go-jsonnet implementation and `binary:<path>` to delegate evaluation to a binary (with the same API as the regular `jsonnet` binary, see the BinaryImplementation docstrings for more details)")
 	return &v
 }
 

--- a/pkg/jsonnet/implementations/binary/impl.go
+++ b/pkg/jsonnet/implementations/binary/impl.go
@@ -1,0 +1,62 @@
+package binary
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+
+	"github.com/grafana/tanka/pkg/jsonnet/implementations/types"
+)
+
+type JsonnetBinaryRunner struct {
+	binPath string
+	args    []string
+}
+
+func (r *JsonnetBinaryRunner) EvaluateAnonymousSnippet(snippet string) (string, error) {
+	cmd := exec.Command(r.binPath, append(r.args, "-e", snippet)...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("error running anonymous snippet: %w\n%s", err, string(out))
+	}
+
+	return string(out), nil
+}
+
+func (r *JsonnetBinaryRunner) EvaluateFile(filename string) (string, error) {
+	cmd := exec.Command(r.binPath, append(r.args, filename)...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("error running file %s: %w\n%s", filename, err, string(out))
+	}
+
+	return string(out), nil
+}
+
+// JsonnetBinaryImplementation runs Jsonnet in a subprocess. It doesn't support native functions.
+type JsonnetBinaryImplementation struct {
+	BinPath string
+}
+
+func (i *JsonnetBinaryImplementation) MakeEvaluator(importPaths []string, extCode map[string]string, tlaCode map[string]string, maxStack int) types.JsonnetEvaluator {
+	args := []string{}
+	for _, p := range importPaths {
+		args = append(args, "-J", p)
+	}
+	if maxStack > 0 {
+		args = append(args, "--max-stack", strconv.Itoa(maxStack))
+	}
+	for k, v := range extCode {
+		args = append(args, "--ext-code", k+"="+v)
+	}
+	for k, v := range tlaCode {
+		args = append(args, "--tla-code", k+"="+v)
+	}
+
+	return &JsonnetBinaryRunner{
+		binPath: i.BinPath,
+		args:    args,
+	}
+}

--- a/pkg/jsonnet/implementations/binary/impl.go
+++ b/pkg/jsonnet/implementations/binary/impl.go
@@ -36,6 +36,14 @@ func (r *JsonnetBinaryRunner) EvaluateFile(filename string) (string, error) {
 }
 
 // JsonnetBinaryImplementation runs Jsonnet in a subprocess. It doesn't support native functions.
+// The interface of the binary has to compatible with the official Jsonnet CLI.
+// It has to support the following flags:
+// -J <path> for specifying import paths
+// --ext-code <name>=<value> for specifying external variables
+// --tla-code <name>=<value> for specifying top-level arguments
+// --max-stack <value> for specifying the maximum stack size
+// -e <code> for evaluating code snippets
+// <filename> positional arg for evaluating files
 type JsonnetBinaryImplementation struct {
 	BinPath string
 }


### PR DESCRIPTION
_waiting for https://github.com/grafana/tanka/pull/917_

This allows users to specify `binary:<path>` as their jsonnet implementation.

When doing so, Tanka will evaluate jsonnet by invoking the given binary.