### PR TITLE
Jsonnet: Move the `JsonnetImplentation` option upwards

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -62,9 +62,10 @@ func exportCmd() *cli.Command {
 			Format:    *format,
 			Extension: *extension,
 			Opts: tanka.Opts{
-				JsonnetOpts: getJsonnetOpts(),
-				Filters:     filters,
-				Name:        vars.name,
+				JsonnetImplementation: vars.jsonnetImplementation,
+				JsonnetOpts:           getJsonnetOpts(),
+				Filters:               filters,
+				Name:                  vars.name,
 			},
 			Selector:         getLabelSelector(),
 			Parallelism:      *parallel,

--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -13,14 +13,16 @@ import (
 )
 
 type workflowFlagVars struct {
-	name    string
-	targets []string
+	name                  string
+	targets               []string
+	jsonnetImplementation string
 }
 
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
 	fs.StringVar(&v.name, "name", "", "string that only a single inline environment contains in its name")
 	fs.StringSliceVarP(&v.targets, "target", "t", nil, "Regex filter on '<kind>/<name>'. See https://tanka.dev/output-filtering")
+	fs.StringVar(&v.jsonnetImplementation, "jsonnet-implementation", "go", "Use `go` to use native go-jsonnet implementation and `binary:<path>` to delegate evaluation to a binary (with the same API as the regular `jsonnet` binary)")
 	return &v
 }
 
@@ -58,14 +60,12 @@ func labelSelectorFlag(fs *pflag.FlagSet) func() labels.Selector {
 func jsonnetFlags(fs *pflag.FlagSet) func() tanka.JsonnetOpts {
 	getExtCode, getTLACode := cliCodeParser(fs)
 	maxStack := fs.Int("max-stack", 0, "Jsonnet VM max stack. The default value is the value set in the go-jsonnet library. Increase this if you get: max stack frames exceeded")
-	jsonnetImplementation := fs.String("jsonnet-implementation", "go", "Only go is supported for now.")
 
 	return func() tanka.JsonnetOpts {
 		return tanka.JsonnetOpts{
-			MaxStack:              *maxStack,
-			ExtCode:               getExtCode(),
-			TLACode:               getTLACode(),
-			JsonnetImplementation: *jsonnetImplementation,
+			MaxStack: *maxStack,
+			ExtCode:  getExtCode(),
+			TLACode:  getTLACode(),
 		}
 	}
 }

--- a/cmd/tk/status.go
+++ b/cmd/tk/status.go
@@ -25,8 +25,9 @@ func statusCmd() *cli.Command {
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		status, err := tanka.Status(args[0], tanka.Opts{
-			JsonnetOpts: getJsonnetOpts(),
-			Name:        vars.name,
+			JsonnetImplementation: vars.jsonnetImplementation,
+			JsonnetOpts:           getJsonnetOpts(),
+			Name:                  vars.name,
 		})
 		if err != nil {
 			return err

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -114,6 +114,7 @@ func applyCmd() *cli.Command {
 		opts.Filters = filters
 		opts.JsonnetOpts = getJsonnetOpts()
 		opts.Name = vars.name
+		opts.JsonnetImplementation = vars.jsonnetImplementation
 
 		return tanka.Apply(args[0], opts)
 	}
@@ -200,6 +201,7 @@ func deleteCmd() *cli.Command {
 		opts.Filters = filters
 		opts.JsonnetOpts = getJsonnetOpts()
 		opts.Name = vars.name
+		opts.JsonnetImplementation = vars.jsonnetImplementation
 
 		return tanka.Delete(args[0], opts)
 	}
@@ -238,6 +240,7 @@ func diffCmd() *cli.Command {
 		opts.Filters = filters
 		opts.JsonnetOpts = getJsonnetOpts()
 		opts.Name = vars.name
+		opts.JsonnetImplementation = vars.jsonnetImplementation
 
 		changes, err := tanka.Diff(args[0], opts)
 		if err != nil {
@@ -291,9 +294,10 @@ Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
 		}
 
 		pretty, err := tanka.Show(args[0], tanka.Opts{
-			JsonnetOpts: getJsonnetOpts(),
-			Filters:     filters,
-			Name:        vars.name,
+			JsonnetOpts:           getJsonnetOpts(),
+			Filters:               filters,
+			Name:                  vars.name,
+			JsonnetImplementation: vars.jsonnetImplementation,
 		})
 
 		if err != nil {

--- a/pkg/jsonnet/eval.go
+++ b/pkg/jsonnet/eval.go
@@ -32,13 +32,12 @@ func (i *InjectedCode) Set(key, value string) {
 
 // Opts are additional properties for the Jsonnet VM
 type Opts struct {
-	JsonnetImplementation string
-	MaxStack              int
-	ExtCode               InjectedCode
-	TLACode               InjectedCode
-	ImportPaths           []string
-	EvalScript            string
-	CachePath             string
+	MaxStack    int
+	ExtCode     InjectedCode
+	TLACode     InjectedCode
+	ImportPaths []string
+	EvalScript  string
+	CachePath   string
 
 	CachePathRegexes []*regexp.Regexp
 }

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -103,13 +103,13 @@ func List(path string, opts Opts) ([]*v1alpha1.Environment, error) {
 }
 
 func getJsonnetImplementation(path string, opts Opts) (types.JsonnetImplementation, error) {
-	switch opts.JsonnetOpts.JsonnetImplementation {
+	switch opts.JsonnetImplementation {
 	case "go", "":
 		return &goimpl.JsonnetGoImplementation{
 			Path: path,
 		}, nil
 	default:
-		return nil, fmt.Errorf("unknown jsonnet implementation: %s", opts.JsonnetOpts.JsonnetImplementation)
+		return nil, fmt.Errorf("unknown jsonnet implementation: %s", opts.JsonnetImplementation)
 	}
 }
 

--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -42,16 +42,16 @@ func parallelLoadEnvironments(envs []*v1alpha1.Environment, opts parallelOpts) (
 	for _, env := range envs {
 		o := opts.Opts
 
+		if o.JsonnetImplementation == "" {
+			o.JsonnetImplementation = env.Spec.ExportJsonnetImplementation
+		}
+
 		// TODO: This is required because the map[string]string in here is not
 		// concurrency-safe. Instead of putting this burden on the caller, find
 		// a way to handle this inside the jsonnet package. A possible way would
 		// be to make the jsonnet package less general, more tightly coupling it
 		// to Tanka workflow thus being able to handle such cases
 		o.JsonnetOpts = o.JsonnetOpts.Clone()
-
-		if o.JsonnetOpts.JsonnetImplementation == "" {
-			o.JsonnetOpts.JsonnetImplementation = env.Spec.ExportJsonnetImplementation
-		}
 
 		o.Name = env.Metadata.Name
 		path := env.Metadata.Namespace

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -18,6 +18,7 @@ type JsonnetOpts = jsonnet.Opts
 // Opts specify general, optional properties that apply to all actions
 type Opts struct {
 	JsonnetOpts
+	JsonnetImplementation string
 
 	// Filters are used to optionally select a subset of the resources
 	Filters process.Matchers


### PR DESCRIPTION
Since Iain's change (https://github.com/grafana/tanka/pull/914#discussion_r1304611891) to my PR, the JsonnetImplementation option is not used in the `jsonnet` package, so the `jsonnet` package doesn't need to know about it

This removes the option there and shift it up to the `tanka.Opts` struct which is where the jsonnet implementation to use is determined