### PR TITLE
Fix Jsonnet implementation override

### DIFF
--- a/pkg/tanka/parallel.go
+++ b/pkg/tanka/parallel.go
@@ -42,7 +42,11 @@ func parallelLoadEnvironments(envs []*v1alpha1.Environment, opts parallelOpts) (
 	for _, env := range envs {
 		o := opts.Opts
 
-		if o.JsonnetImplementation == "" {
+		if env.Spec.ExportJsonnetImplementation != "" {
+			log.Trace().
+				Str("name", env.Metadata.Name).
+				Str("implementation", env.Spec.ExportJsonnetImplementation).
+				Msg("Using custom Jsonnet implementation")
 			o.JsonnetImplementation = env.Spec.ExportJsonnetImplementation
 		}
 


### PR DESCRIPTION
In the case of an export, the Jsonnet implementation set in specific environments should override the one set globally with the CLI args.

Currently, `o.JsonnetImplementation` is almost never empty since the default is `go`