### PR TITLE
fix(kubernetes-client): Match context & cluster names exactly

### DIFF
--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -58,7 +58,7 @@ func ContextFromName(contextName string) (*Cluster, *Context, error) {
 		return nil, nil, err
 	}
 
-	err = find(contexts, "name", contextName, &context)
+	err = find(contexts, "name", fmt.Sprintf("^%s$", contextName), &context)
 	if err == ErrorNoMatch {
 		return nil, nil, ErrorNoContext(contextName)
 	} else if err != nil {
@@ -70,7 +70,7 @@ func ContextFromName(contextName string) (*Cluster, *Context, error) {
 		return nil, nil, err
 	}
 
-	err = find(clusters, "name", context.Context.Cluster, &cluster)
+	err = find(clusters, "name", fmt.Sprintf("^%s$", context.Context.Cluster), &cluster)
 	if err == ErrorNoMatch {
 		return nil, nil, ErrorNoCluster(contextName)
 	} else if err != nil {
@@ -161,7 +161,7 @@ func IPFromContext(name string) (ip string, err error) {
 		return "", err
 	}
 
-	err = find(contexts, "name", name, &context)
+	err = find(contexts, "name", fmt.Sprintf("^%s$", name), &context)
 	if err == ErrorNoMatch {
 		return "", ErrorNoContext(name)
 	} else if err != nil {
@@ -176,7 +176,7 @@ func IPFromContext(name string) (ip string, err error) {
 	}
 
 	clusterName := context.Context.Cluster
-	err = find(clusters, "name", clusterName, &cluster)
+	err = find(clusters, "name", fmt.Sprintf("^%s$", clusterName), &cluster)
 	if err == ErrorNoMatch {
 		return "", fmt.Errorf("no cluster named `%s` as required by context `%s` was found. Please check your $KUBECONFIG", clusterName, name)
 	} else if err != nil {


### PR DESCRIPTION
Fixes #947 

Looks like the context and cluster names are not yet matched exactly within the ContextFromName function (and the cluster name is not matched exactly in other places). This PR changes that.

This only leads to mis-matches if there are name candidates where the expected name is a suffix of others and at least one of these is lexically sorted before the expected name:

```
expected: docker
candidates:
- docker
- abc-docker
- bcd-docker
match: abc-docker (because lexcially before docker and has expected name as substring)
```

vs.

```
expected: docker
candidates:
- docker
- test-docker
- dummy-docker
match: docker
```

I'm not sure if the endpoint in `IPFromContext` should also be matched exactly and so I didn't touch that one yet 🙂 