### PR TITLE
extract: Don't crash when the error is not an `ErrorPrimitiveReached`

### DIFF
--- a/pkg/process/extract.go
+++ b/pkg/process/extract.go
@@ -89,7 +89,11 @@ func walkObj(obj objx.Map, extracted map[string]manifest.Manifest, path trace) e
 		}
 		err := walkJSON(obj[key], extracted, path)
 		if err != nil {
-			return err.(ErrorPrimitiveReached).WithContainingObj(obj, manifestErr)
+			if err, ok := err.(ErrorPrimitiveReached); ok {
+				return err.WithContainingObj(obj, manifestErr)
+			}
+
+			return err
 		}
 	}
 

--- a/pkg/tanka/testdata/test-export-envs-broken/static-env/main.jsonnet
+++ b/pkg/tanka/testdata/test-export-envs-broken/static-env/main.jsonnet
@@ -1,0 +1,17 @@
+{
+  deployment: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'foo',
+    },
+  },
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      // Error, this should be a string
+      name: true,
+    },
+  },
+}

--- a/pkg/tanka/testdata/test-export-envs-broken/static-env/spec.json
+++ b/pkg/tanka/testdata/test-export-envs-broken/static-env/spec.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "static",
+    "labels": {
+      "type": "static"
+    }
+  },
+  "spec": {
+    "apiServer": "https://localhost",
+    "namespace": "static"
+  }
+}


### PR DESCRIPTION
When there's an invalid Kubernetes object, we can get a `*manifest.SchemaError` here, for example. We currently panic, but instead we should return the error so it can be displayed properly.

Closes: #960 