### PR TITLE
feat: add support for overriding environment label (#824)

### DIFF
--- a/pkg/kubernetes/apply.go
+++ b/pkg/kubernetes/apply.go
@@ -63,8 +63,13 @@ See https://tanka.dev/garbage-collection for more details`)
 	// get all resources matching our label
 	start = time.Now()
 	log.Info().Msg("fetching resources previously created by this env")
+
+	nameLabel, err := k.Env.NameLabel()
+	if err != nil {
+		return nil, err
+	}
 	matched, err := k.ctl.GetByLabels("", kinds, map[string]string{
-		process.LabelEnvironment: k.Env.Metadata.NameLabel(),
+		process.LabelEnvironment: nameLabel,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -116,7 +116,10 @@ func TestProcess(t *testing.T) {
 
 			if env.Spec.InjectLabels {
 				for i, m := range c.flat {
-					m.Metadata().Labels()[LabelEnvironment] = env.Metadata.NameLabel()
+					nameLabel, err := env.NameLabel()
+					require.NoError(t, err)
+
+					m.Metadata().Labels()[LabelEnvironment] = nameLabel
 					c.flat[i] = m
 				}
 			}

--- a/pkg/spec/v1alpha1/environment_test.go
+++ b/pkg/spec/v1alpha1/environment_test.go
@@ -1,0 +1,131 @@
+package v1alpha1
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvironmentNameLabel(t *testing.T) {
+	type testCase struct {
+		name                 string
+		inputEnvironment     *Environment
+		expectedLabelPreHash string
+		expectError          bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "Default environment label hash",
+			inputEnvironment: &Environment{
+				Spec: Spec{
+					Namespace: "default",
+				},
+				Metadata: Metadata{
+					Name:      "environments/a-nice-go-test",
+					Namespace: "main.jsonnet",
+				},
+			},
+			expectedLabelPreHash: "environments/a-nice-go-test:main.jsonnet",
+		},
+		{
+			name: "Overriden single nested field",
+			inputEnvironment: &Environment{
+				Spec: Spec{
+					Namespace: "default",
+					TankaEnvLabelFromFields: []string{
+						".metadata.name",
+					},
+				},
+				Metadata: Metadata{
+					Name: "environments/another-nice-go-test",
+				},
+			},
+			expectedLabelPreHash: "environments/another-nice-go-test",
+		},
+		{
+			name: "Overriden multiple nested field",
+			inputEnvironment: &Environment{
+				Spec: Spec{
+					Namespace: "default",
+					TankaEnvLabelFromFields: []string{
+						".metadata.name",
+						".spec.namespace",
+					},
+				},
+				Metadata: Metadata{
+					Name: "environments/another-nice-go-test",
+				},
+			},
+			expectedLabelPreHash: "environments/another-nice-go-test:default",
+		},
+		{
+			name: "Override field of map type",
+			inputEnvironment: &Environment{
+				Spec: Spec{
+					TankaEnvLabelFromFields: []string{
+						".metadata.labels.project",
+					},
+				},
+				Metadata: Metadata{
+					Name: "environments/another-nice-go-test",
+					Labels: map[string]string{
+						"project": "an-equally-nice-project",
+					},
+				},
+			},
+			expectedLabelPreHash: "an-equally-nice-project",
+		},
+		{
+			name: "Label value not primitive type",
+			inputEnvironment: &Environment{
+				Spec: Spec{
+					TankaEnvLabelFromFields: []string{
+						".metadata",
+					},
+				},
+				Metadata: Metadata{
+					Name: "environments/another-nice-go-test",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Attempted descent past non-object like type",
+			inputEnvironment: &Environment{
+				Spec: Spec{
+					TankaEnvLabelFromFields: []string{
+						".metadata.name.nonExistent",
+					},
+				},
+				Metadata: Metadata{
+					Name: "environments/not-an-object",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedLabelHashParts := sha256.Sum256([]byte(tc.expectedLabelPreHash))
+			expectedLabelHashChars := []rune(hex.EncodeToString(expectedLabelHashParts[:]))
+			expectedLabelHash := string(expectedLabelHashChars[:48])
+			actualLabelHash, err := tc.inputEnvironment.NameLabel()
+
+			if tc.expectedLabelPreHash != "" {
+				assert.Equal(t, expectedLabelHash, actualLabelHash)
+			} else {
+				assert.Equal(t, "", actualLabelHash)
+			}
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/spec/v1alpha1/environment_test.go
+++ b/pkg/spec/v1alpha1/environment_test.go
@@ -31,7 +31,7 @@ func TestEnvironmentNameLabel(t *testing.T) {
 			expectedLabelPreHash: "environments/a-nice-go-test:main.jsonnet",
 		},
 		{
-			name: "Overriden single nested field",
+			name: "Overridden single nested field",
 			inputEnvironment: &Environment{
 				Spec: Spec{
 					Namespace: "default",
@@ -46,7 +46,7 @@ func TestEnvironmentNameLabel(t *testing.T) {
 			expectedLabelPreHash: "environments/another-nice-go-test",
 		},
 		{
-			name: "Overriden multiple nested field",
+			name: "Overridden multiple nested field",
 			inputEnvironment: &Environment{
 				Spec: Spec{
 					Namespace: "default",

--- a/pkg/spec/v1alpha1/reflect_utils.go
+++ b/pkg/spec/v1alpha1/reflect_utils.go
@@ -1,0 +1,89 @@
+package v1alpha1
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func getDeepFieldAsString(obj interface{}, keyPath []string) (string, error) {
+	if !isSupportedType(obj, []reflect.Kind{reflect.Struct, reflect.Pointer, reflect.Map}) {
+		return "", errors.New("intermediary objects must be object types")
+	}
+
+	objValue := reflectValue(obj)
+	objType := objValue.Type()
+
+	var nextFieldValue reflect.Value
+
+	switch objType.Kind() {
+	case reflect.Struct, reflect.Pointer:
+		fieldsCount := objType.NumField()
+
+		for i := 0; i < fieldsCount; i++ {
+			candidateType := objType.Field(i)
+			candidateValue := objValue.Field(i)
+			jsonTag := candidateType.Tag.Get("json")
+
+			if strings.Split(jsonTag, ",")[0] == keyPath[0] {
+				nextFieldValue = candidateValue
+				break
+			}
+		}
+
+	case reflect.Map:
+		for _, key := range objValue.MapKeys() {
+			nextFieldValue = objValue.MapIndex(key)
+		}
+	}
+
+	if len(keyPath) == 1 {
+		return getReflectValueAsString(nextFieldValue)
+	}
+
+	if nextFieldValue.Type().Kind() == reflect.Pointer {
+		nextFieldValue = nextFieldValue.Elem()
+	}
+
+	return getDeepFieldAsString(nextFieldValue.Interface(), keyPath[1:])
+}
+
+func getReflectValueAsString(val reflect.Value) (string, error) {
+	switch val.Type().Kind() {
+	case reflect.String:
+		return val.String(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(val.Int(), 10), nil
+	case reflect.Float32:
+		return strconv.FormatFloat(val.Float(), 'f', -1, 32), nil
+	case reflect.Float64:
+		return strconv.FormatFloat(val.Float(), 'f', -1, 64), nil
+	case reflect.Bool:
+		return strconv.FormatBool(val.Bool()), nil
+	default:
+		return "", errors.New("unsupported value type")
+	}
+}
+
+func reflectValue(obj interface{}) reflect.Value {
+	var val reflect.Value
+
+	if reflect.TypeOf(obj).Kind() == reflect.Pointer {
+		val = reflect.ValueOf(obj).Elem()
+	} else {
+		val = reflect.ValueOf(obj)
+	}
+
+	return val
+}
+
+func isSupportedType(obj interface{}, types []reflect.Kind) bool {
+	for _, t := range types {
+		if reflect.TypeOf(obj).Kind() == t {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This change looks to add support for the environment label override from fields that #824 requested.
This allows users to alter the label themselves which allows a workaround of the issue described in #824.

As this is my first time contributing, I've not fully tidied this PR up yet as I want to get feedback from the maintainers on whether approach is sound/in-line with the vision of the codebase and if there's anything else I should bear in mind.