### PR TITLE
Update default k8s version to 1.29

### DIFF
--- a/cmd/tk/init.go
+++ b/cmd/tk/init.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/tanka/pkg/spec/v1alpha1"
 )
 
-const defaultK8sVersion = "1.20"
+const defaultK8sVersion = "1.29"
 
 // initCmd creates a new application
 func initCmd() *cli.Command {


### PR DESCRIPTION
Hello 👋

It seems that support for Kubernetes versions 1.20 through 1.25 were recently removed from [k8s-libsonnet](https://github.com/jsonnet-libs/k8s-libsonnet) by this commit: jsonnet-libs/k8s-libsonnet@90d0fae415cff9d0c089d60e9a478efee092c42e. Since then, `tk init` (without the `--k8s` flag set) fails by default since the files for 1.20 are no longer available. See example below.

```bash
$ tk init

GET https://github.com/jsonnet-libs/k8s-libsonnet/archive/bf9a62cfd32a58c071b8410bfcdec058475dd25e.tar.gz 200
panic: rename /Users/root/project/vendor/.tmp/28d5d0cf4e0847d16afe3035627683a62705765237/1.20 /Users/root/project/vendor/github.com/jsonnet-libs/k8s-libsonnet/1.20: no such file or directory
[...]
Installing k.libsonnet: exit status 2
```
I've proposed updating the `defaultK8sVersion` flag for the init command to instead use the latest stable version, 1.29.

Cheers!