### PR TITLE
Add repository config option for private repositories

### DIFF
--- a/cmd/tk/toolCharts.go
+++ b/cmd/tk/toolCharts.go
@@ -35,6 +35,7 @@ func chartsVendorCmd() *cli.Command {
 		Short: "Download Charts to a local folder",
 	}
 	prune := cmd.Flags().Bool("prune", false, "also remove non-vendored files from the destination directory")
+	repoConfigPath := cmd.Flags().String("repository-config", "", "specify a local helm repository config file to use instead of the repositories in the chartfile.yaml. For use with private repositories")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		c, err := loadChartfile()
@@ -42,7 +43,7 @@ func chartsVendorCmd() *cli.Command {
 			return err
 		}
 
-		return c.Vendor(*prune)
+		return c.Vendor(*prune, *repoConfigPath)
 	}
 
 	return cmd
@@ -53,6 +54,7 @@ func chartsAddCmd() *cli.Command {
 		Use:   "add [chart@version] [...]",
 		Short: "Adds Charts to the chartfile",
 	}
+	repoConfigPath := cmd.Flags().String("repository-config", "", "specify a local helm repository config file to use instead of the repositories in the chartfile.yaml. For use with private repositories")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		c, err := loadChartfile()
@@ -60,7 +62,7 @@ func chartsAddCmd() *cli.Command {
 			return err
 		}
 
-		return c.Add(args)
+		return c.Add(args, *repoConfigPath)
 	}
 
 	return cmd

--- a/pkg/helm/spec.go
+++ b/pkg/helm/spec.go
@@ -33,6 +33,19 @@ type Chartfile struct {
 	Directory string `json:"directory,omitempty"`
 }
 
+// ConfigFile represents the default Helm config structure to be used in place of the chartfile
+// Repositories if supplied.
+type ConfigFile struct {
+	// Version of the Helm repo config schema
+	APIVersion string `json:"apiVersion"`
+
+	// The datetime of when this repo config was generated
+	Generated string `json:"generated"`
+
+	// Repositories to source from
+	Repositories Repos `json:"repositories"`
+}
+
 // Repo describes a single Helm repository
 type Repo struct {
 	Name     string `json:"name,omitempty"`


### PR DESCRIPTION
Closes https://github.com/grafana/tanka/issues/922

## What we are trying to do
Usage of private Helm repositories right now requires the credentials to be stored in the `chartfile.yaml`. This leads to issues described in the linked issue where different users usually have different credentials, and those credentials you probably don't want to commit to version control. Helm has a `repositories.yaml` file that is updated when you run `helm repo add` where it stores your user-supplied credentials to any private repository. This file has a similar layout to the repositories section in the `chartfile.yaml`
```yaml
# repositories.yaml
apiVersion: ""
generated: "0001-01-01T00:00:00Z"
repositories:
- caFile: ""
  certFile: ""
  insecure_skip_tls_verify: false
  keyFile: ""
  name: simkev2
  pass_credentials_all: false
  password: <generated token>
  url: https://raw.githubusercontent.com/SimKev2/charts/main/stable/
  username: <generated token>
```

It would be good to provide users an option to use this existing helm config file with their tanka commands to manage helm charts.

## Testing
Currently you can add the chart but it has errors vendoring:
```bash
$ tk tool charts add simkev2/nginx-ingress@1.2.0:1.2.0
{"level":"info","time":"2024-04-19T10:01:20-05:00","message":"Adding 1 Charts ..."}
{"level":"info","time":"2024-04-19T10:01:20-05:00","message":"OK: simkev2/nginx-ingress@1.2.0:1.2.0"}
{"level":"info","time":"2024-04-19T10:01:20-05:00","message":"Added 1 Charts to helmfile.yaml. Vendoring ..."}
{"level":"info","time":"2024-04-19T10:01:20-05:00","message":"Vendoring..."}
{"level":"info","time":"2024-04-19T10:01:20-05:00","message":"Syncing Repositories ..."}
{"level":"info","time":"2024-04-19T10:01:20-05:00","message":"Pulling Charts ..."}
Error: repository "simkev2" not found for chart "simkev2/nginx-ingress"

$ tk tool charts vendor
{"level":"info","time":"2024-04-19T10:01:45-05:00","message":"Vendoring..."}
{"level":"info","time":"2024-04-19T10:01:45-05:00","message":"Syncing Repositories ..."}
{"level":"info","time":"2024-04-19T10:01:46-05:00","message":"Pulling Charts ..."}
Error: repository "simkev2" not found for chart "simkev2/nginx-ingress"
```

After these changes I can specify my helm config file and it works:
```bash
$ ../../../../../go/src/github.com/grafana/tanka/tk tool charts add --repository-config $HOME/Library/Preferences/helm/repositories.yaml simkev2/nginx-ingress@1.2.0:1.2.0
{"level":"info","time":"2024-04-19T10:02:51-05:00","message":"Adding 1 Charts ..."}
{"level":"info","time":"2024-04-19T10:02:51-05:00","message":"OK: simkev2/nginx-ingress@1.2.0:1.2.0"}
{"level":"info","time":"2024-04-19T10:02:51-05:00","message":"Added 1 Charts to helmfile.yaml. Vendoring ..."}
{"level":"info","time":"2024-04-19T10:02:51-05:00","message":"Vendoring..."}
{"level":"info","time":"2024-04-19T10:02:51-05:00","message":"Syncing Repositories ..."}
{"level":"info","time":"2024-04-19T10:02:51-05:00","message":"Pulling Charts ..."}
{"level":"info","time":"2024-04-19T10:02:51-05:00","message":"simkev2/nginx-ingress@1.2.0 downloaded"}

$ rm -rf charts/1.2.0/
$ ../../../../../go/src/github.com/grafana/tanka/tk tool charts vendor --repository-config $HOME/Library/Preferences/helm/repositories.yaml
{"level":"info","time":"2024-04-19T10:03:27-05:00","message":"Vendoring..."}
{"level":"info","time":"2024-04-19T10:03:27-05:00","message":"fluxcd-community/flux2@2.12.4 (dir: 2.12.4) exists"}
{"level":"info","time":"2024-04-19T10:03:27-05:00","message":"Syncing Repositories ..."}
{"level":"info","time":"2024-04-19T10:03:27-05:00","message":"Pulling Charts ..."}
{"level":"info","time":"2024-04-19T10:03:28-05:00","message":"simkev2/nginx-ingress@1.2.0 downloaded"}
```

## Questions for Discussion
2 questions I have for these changes

1. Is there a better way to share `repository-config` flag between the `Add` and `Vendor` commands? I see the log-level option uses the `addCommandsWithLogLevelOption` function, but I don't believe I can run the function through a helper function like that twice? And having a helper function that adds the repo config option and then calls that seemed weird to me.

2. Should we try and merge the `repositories.yaml` repositories with the `chartfile.yaml` repositories instead of overwriting them? I went for the simple option of just replacing the existing config with the helm config, but this does mean that if you had a mix of public and private repositories you would need to ensure that `helm repo add ...` was run on your local machine for each of the public repos. I don't think that is a huge ask for the simplicity it brings the code, but I am open to opinions if we should try to merge-with-overwrite the helm config file to our chartfile.yaml.