### PR TITLE
Add version-check command for vendored helm charts

### DIFF
--- a/cmd/tk/toolCharts.go
+++ b/cmd/tk/toolCharts.go
@@ -153,6 +153,7 @@ func chartsVersionCheckCmd() *cli.Command {
 		Short: "Check required charts for updated versions",
 	}
 	repoConfigPath := cmd.Flags().String("repository-config", "", repoConfigFlagUsage)
+	prettyPrint := cmd.Flags().Bool("pretty-print", false, "pretty print json output with indents")
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		c, err := loadChartfile()
@@ -165,13 +166,11 @@ func chartsVersionCheckCmd() *cli.Command {
 			return err
 		}
 
-		returnData, err := json.Marshal(data)
-		if err != nil {
-			return err
+		enc := json.NewEncoder(os.Stdout)
+		if *prettyPrint {
+			enc.SetIndent("", "  ")
 		}
-
-		fmt.Printf("%s", returnData)
-		return nil
+		return enc.Encode(data)
 	}
 
 	return cmd

--- a/cmd/tk/toolCharts.go
+++ b/cmd/tk/toolCharts.go
@@ -11,6 +11,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const repoConfigFlagUsage = "specify a local helm repository config file to use instead of the repositories in the chartfile.yaml. For use with private repositories"
+
 func chartsCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "charts",
@@ -37,7 +39,7 @@ func chartsVendorCmd() *cli.Command {
 		Short: "Download Charts to a local folder",
 	}
 	prune := cmd.Flags().Bool("prune", false, "also remove non-vendored files from the destination directory")
-	repoConfigPath := cmd.Flags().String("repository-config", "", "specify a local helm repository config file to use instead of the repositories in the chartfile.yaml. For use with private repositories")
+	repoConfigPath := cmd.Flags().String("repository-config", "", repoConfigFlagUsage)
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		c, err := loadChartfile()
@@ -56,7 +58,7 @@ func chartsAddCmd() *cli.Command {
 		Use:   "add [chart@version] [...]",
 		Short: "Adds Charts to the chartfile",
 	}
-	repoConfigPath := cmd.Flags().String("repository-config", "", "specify a local helm repository config file to use instead of the repositories in the chartfile.yaml. For use with private repositories")
+	repoConfigPath := cmd.Flags().String("repository-config", "", repoConfigFlagUsage)
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		c, err := loadChartfile()
@@ -150,7 +152,7 @@ func chartsVersionCheckCmd() *cli.Command {
 		Use:   "version-check",
 		Short: "Check required charts for updated versions",
 	}
-	repoConfigPath := cmd.Flags().String("repository-config", "", "specify a local helm repository config file to use instead of the repositories in the chartfile.yaml. For use with private repositories")
+	repoConfigPath := cmd.Flags().String("repository-config", "", repoConfigFlagUsage)
 
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		c, err := loadChartfile()

--- a/cmd/tk/toolCharts.go
+++ b/cmd/tk/toolCharts.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,6 +25,7 @@ func chartsCmd() *cli.Command {
 		chartsAddRepoCmd(),
 		chartsVendorCmd(),
 		chartsConfigCmd(),
+		chartsVersionCheckCmd(),
 	)
 
 	return cmd
@@ -137,6 +139,36 @@ func chartsInitCmd() *cli.Command {
 		}
 
 		fmt.Fprintf(os.Stderr, "Success! New Chartfile created at '%s'", path)
+		return nil
+	}
+
+	return cmd
+}
+
+func chartsVersionCheckCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "version-check",
+		Short: "Check required charts for updated versions",
+	}
+	repoConfigPath := cmd.Flags().String("repository-config", "", "specify a local helm repository config file to use instead of the repositories in the chartfile.yaml. For use with private repositories")
+
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		c, err := loadChartfile()
+		if err != nil {
+			return err
+		}
+
+		data, err := c.VersionCheck(*repoConfigPath)
+		if err != nil {
+			return err
+		}
+
+		returnData, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s", returnData)
 		return nil
 	}
 

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -305,9 +305,6 @@ func TestVersionCheckWithConfig(t *testing.T) {
 	c, err := InitChartfile(filepath.Join(tempDir, Filename))
 	require.NoError(t, err)
 
-	err = c.Add([]string{"private/prometheus@11.12.0"}, "")
-	assert.NoError(t, err)
-
 	// Don't want to commit credentials so we just verify the "private" repo reference will make
 	// use of this helm config since the InitChartfile does not have a reference to it.
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "helmConfig.yaml"), []byte(`

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -59,6 +59,31 @@ type ChartSearchVersion struct {
 
 type ChartSearchVersions []ChartSearchVersion
 
+// RequiresVersionInfo represents a specific required chart and the information around the current
+// version and any upgrade information.
+type RequiresVersionInfo struct {
+	// Name of the required chart in the form of repo/chartName
+	Name string `json:"name,omitempty"`
+
+	// Directory information for the chart.
+	Directory string `json:"directory,omitempty"`
+
+	// The current version information of the required helm chart.
+	CurrentVersion string `json:"current_version,omitempty"`
+
+	// Boolean representing if the required chart is already up to date.
+	UsingLatestVersion bool `json:"using_latest_version"`
+
+	// The most up-to-date version information of the required helm chart.
+	LatestVersion ChartSearchVersion `json:"latest_version,omitempty"`
+
+	// The latest version information of the required helm chart that matches the current major version.
+	LatestMatchingMajorVersion ChartSearchVersion `json:"latest_matching_major_version,omitempty"`
+
+	// The latest version information of the required helm chart that matches the current minor version.
+	LatestMatchingMinorVersion ChartSearchVersion `json:"latest_matching_minor_version,omitempty"`
+}
+
 // Opts are additional, non-required options that all Helm operations accept
 type Opts struct {
 	Repositories []Repo
@@ -148,35 +173,58 @@ func (e ExecHelm) ChartExists(chart string, opts *JsonnetOpts) (string, error) {
 	return chart, nil
 }
 
+// Searches the helm repositories for the latest, the latest matching major, and the latest
+// matching minor versions for the given chart.
 func (e ExecHelm) SearchRepo(chart, currVersion string, opts Opts) (ChartSearchVersions, error) {
+	searchVersions := []string{
+		fmt.Sprintf(">=%s", currVersion), // Latest version X.X.X
+		fmt.Sprintf("^%s", currVersion),  // Latest matching major version 1.X.X
+		fmt.Sprintf("~%s", currVersion),  // Latest matching minor version 1.1.X
+	}
+
 	repoFile, err := writeRepoTmpFile(opts.Repositories)
 	if err != nil {
 		return nil, err
 	}
 	defer os.Remove(repoFile)
 
-	// Vertical tabs are used as deliminators in table so \v is used to match exactly the chart.
-	// By default the helm search repo command only returns the latest version for the chart.
-	cmd := e.cmd("search", "repo",
-		"--repository-config", repoFile,
-		"--regexp",
-		fmt.Sprintf("\v%s\v", chart),
-		"--version", fmt.Sprintf(">%s", currVersion),
-		"-o", "json",
-	)
-	var errBuf bytes.Buffer
-	var outBuf bytes.Buffer
-	cmd.Stderr = &errBuf
-	cmd.Stdout = &outBuf
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("%s\n%s", errBuf.String(), err)
-	}
-
 	var chartVersions ChartSearchVersions
-	err = json.Unmarshal(outBuf.Bytes(), &chartVersions)
-	if err != nil {
-		return nil, err
+	for _, versionRegex := range searchVersions {
+		var chartVersion ChartSearchVersions
+
+		// Vertical tabs are used as deliminators in table so \v is used to match exactly the chart.
+		// Helm search by default only returns the latest version matching the given version regex.
+		cmd := e.cmd("search", "repo",
+			"--repository-config", repoFile,
+			"--regexp", fmt.Sprintf("\v%s\v", chart),
+			"--version", versionRegex,
+			"-o", "json",
+		)
+		var errBuf bytes.Buffer
+		var outBuf bytes.Buffer
+		cmd.Stderr = &errBuf
+		cmd.Stdout = &outBuf
+
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("%s\n%s", errBuf.String(), err)
+		}
+
+		err = json.Unmarshal(outBuf.Bytes(), &chartVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(chartVersion) != 1 {
+			log.Debug().Msgf("helm search repo for %s did not return 1 version : %+v", chart, chartVersion)
+			chartVersions = append(chartVersions, ChartSearchVersion{
+				Name:        chart,
+				Version:     currVersion,
+				AppVersion:  "",
+				Description: "search did not return 1 version",
+			})
+		} else {
+			chartVersions = append(chartVersions, chartVersion...)
+		}
 	}
 
 	return chartVersions, nil

--- a/pkg/helm/jsonnet_test.go
+++ b/pkg/helm/jsonnet_test.go
@@ -44,6 +44,11 @@ func (m *MockHelm) ChartExists(chart string, opts *JsonnetOpts) (string, error) 
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockHelm) SearchRepo(chart, currVersion string, opts Opts) (ChartSearchVersions, error) {
+	args := m.Called(chart, currVersion, opts)
+	return args.Get(0).(ChartSearchVersions), args.Error(1)
+}
+
 func callNativeFunction(t *testing.T, expectedHelmTemplateOptions TemplateOpts, inputOptionsFromJsonnet map[string]interface{}) []string {
 	t.Helper()
 


### PR DESCRIPTION
## What are we doing
This change is  a part of a larger effort to enable more automatic helm chart version management. First step is to get a command that can search the repositories within a `chartfile.yaml` for newer versions of the required charts. This output should be easy to parse for another script in order to kick off an automation to add the chart, vendor it, and make a PR.

## Testing
Adding 2 different flux2 requires returns only 1 chart update :
```bash
$ ../../../../../go/src/github.com/grafana/tanka/tk tool charts version-check | jq
[
  {
    "name": "fluxcd-community/flux2",
    "version": "2.12.4",
    "app_version": "2.2.3",
    "description": "A Helm chart for flux2"
  }
]
```
**Potential question here, should we be searching the existing requires for this version and exclude it if so? Right now if you have versions 2.12.4 and 2.12.3 of flux2 it would still return this even though you have the most up to date version.**

Private repositories, I modified the `chartfile.yaml` to be a lower version to test it can search private repos:
```bash
$ ../../../../../go/src/github.com/grafana/tanka/tk tool charts version-check --repository-config $HOME/Library/Preferences/helm/repositories.yaml | jq
[
  {
    "name": "simkev2/nginx-ingress",
    "version": "1.2.0",
    "app_version": "3.5.0",
    "description": "NGINX Ingress Controller"
  }
]
``` 