### PR TITLE
Run helm repo update before searching repos

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -188,6 +188,18 @@ func (e ExecHelm) SearchRepo(chart, currVersion string, opts Opts) (ChartSearchV
 	}
 	defer os.Remove(repoFile)
 
+	// Helm repo update in order to let "helm search repo" function
+	updateCmd := e.cmd("repo", "update",
+		"--repository-config", repoFile,
+	)
+	var updateErrBuf bytes.Buffer
+	var updateOutBuf bytes.Buffer
+	updateCmd.Stderr = &updateErrBuf
+	updateCmd.Stdout = &updateOutBuf
+	if err := updateCmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s\n%s", updateErrBuf.String(), err)
+	}
+
 	var chartVersions ChartSearchVersions
 	for _, versionRegex := range searchVersions {
 		var chartVersion ChartSearchVersions


### PR DESCRIPTION
If you are using a registry within your `chartfile.yaml` that you do not have a cached version of it seems that `helm search repo` will not function as expected. To fix this we can run a `helm repo update` on the repository file that will be used while searching in order to ensure we get up-to-date information.