### PR TITLE
docs: fix helm example

### DIFF
--- a/docs/src/content/docs/helm.mdx
+++ b/docs/src/content/docs/helm.mdx
@@ -305,7 +305,7 @@ To handle this, pass a custom name format, e.g. to also include the namespace:
 
 ```jsonnet
 custom: helm.template('foo', './charts/foo', {
-  nameFormat: '{{ print .namespace "_" .kind "_" .metadata.name | snakecase }}'
+  nameFormat: '{{ print .metadata.namespace "_" .kind "_" .metadata.name | snakecase }}'
 })
 ```
 


### PR DESCRIPTION
Fixes example in https://tanka.dev/helm/#two-resources-share-the-same-name

Fixes #894