### PR TITLE
feat(cli): TANKA_PAGER environment variable

### DIFF
--- a/cmd/tk/util.go
+++ b/cmd/tk/util.go
@@ -19,7 +19,10 @@ func pageln(i ...interface{}) error {
 // If the PAGER environment variable is empty, no pager is used.
 // If the PAGER environment variable is unset, use GNU less with convenience flags.
 func fPageln(r io.Reader) error {
-	pager, ok := os.LookupEnv("PAGER")
+	pager, ok := os.LookupEnv("TANKA_PAGER")
+	if !ok {
+		pager, ok = os.LookupEnv("PAGER")
+	}
 	if !ok {
 		// --RAW-CONTROL-CHARS  Honors colors from diff. Must be in all caps, otherwise display issues occur.
 		// --quit-if-one-screen Closer to the git experience.

--- a/docs/src/content/docs/env-vars.md
+++ b/docs/src/content/docs/env-vars.md
@@ -29,7 +29,12 @@ sidebar:
 **Description**: Path to the `kustomize` executable  
 **Default**: `$PATH/kustomize`
 
-## PAGER
+## TANKA_PAGER
 
 **Description**: Pager to use when displaying output. Set to an empty string to disable paging.
+**Default**: `$PAGER`
+
+## PAGER
+
+**Description**: Pager to use when displaying output. Only used if TANKA_PAGER is not set. Set to an empty string to disable paging.
 **Default**: `less --RAW-CONTROL-CHARS --quit-if-one-screen --no-init`


### PR DESCRIPTION
Adds TANKA_PAGER environment variable. Takes precedence over PAGER. If unset, PAGER works as it did before.

Resolves #1028