### PR TITLE
don't print debug logs by default in `complete`, `env list`

### DIFF
--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -21,6 +21,9 @@ func main() {
 		Version: tanka.CurrentVersion,
 	}
 
+	// set default logging level early; not all commands parse --log-level
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
 	// workflow commands
 	addCommandsWithLogLevelOption(
 		rootCmd,

--- a/pkg/tanka/find.go
+++ b/pkg/tanka/find.go
@@ -56,7 +56,7 @@ func findEnvsFromPaths(paths []string, opts FindOpts) ([]*v1alpha1.Environment, 
 
 	findEnvsEndTime := time.Now()
 
-	log.Info().
+	log.Debug().
 		Int("environments", len(envs)).
 		Dur("ms_to_find_jsonnet_files", findJsonnetFilesEndTime.Sub(startTime)).
 		Dur("ms_to_find_environments", findEnvsEndTime.Sub(findJsonnetFilesEndTime)).


### PR DESCRIPTION
Suppress logs that I suspect we don't want to be printing by default:

Before:
_default `info` logging prints unimportant information on basic commands_
```
$ tk env list
{"level":"info","environments":5,"ms_to_find_jsonnet_files":20.682708,"ms_to_find_environments":1.767584,"time":"2024-06-05T16:01:40-04:00","message":"Found Tanka environments"}
NAME                                           NAMESPACE    SERVER
...
```

_logs cannot be suppressed in completer because there is no way to send it --log-level flag_
```
$ tk show <TAB>{"level":"debug","parallelism":12,"paths":1,"time":"2024-06-05T16:05:37-04:00","message":"Finding Tanka environments"}
{"level":"info","environments":5,"ms_to_find_jsonnet_files":20.73575,"ms_to_find_environments":2.033417,"time":"2024-06-05T16:05:37-04:00","message":"Found Tanka environments"}
 environments/
```

After:
_the above examples work as they did on `v0.26.0`_
```
$ tk env list
NAME                                           NAMESPACE    SERVER
```

```
$ tk show <TAB>environments/
```

_setting a chattier log level still works as expected_
```
$ tk env list --log-level=debug
{"level":"debug","parallelism":12,"paths":1,"time":"2024-06-07T10:08:29-04:00","message":"Finding Tanka environments"}
{"level":"debug","environments":5,"ms_to_find_jsonnet_files":21.046125,"ms_to_find_environments":2.08725,"time":"2024-06-07T10:08:29-04:00","message":"Found Tanka environments"}
NAME                                           NAMESPACE    SERVER
...
```

resolves #1048