### PR TITLE
fix: replace godirwalk with filepath.WalkDir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-jsonnet v0.20.0
-	github.com/karrick/godirwalk v1.17.0
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=
-github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
This removes an external dependency and hopefully also fixes #1055.

Performance-wise the two implementations look comparable:

Old:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tanka/pkg/jsonnet
BenchmarkFindImporters-8               	      85	  12308651 ns/op
BenchmarkFindImporters_StaticCases/no_files-8         	  530050	      2272 ns/op
BenchmarkFindImporters_StaticCases/invalid_file-8     	   86710	     13794 ns/op
BenchmarkFindImporters_StaticCases/project_with_no_imports-8         	    3116	    386994 ns/op
BenchmarkFindImporters_StaticCases/local_import-8                    	    3112	    384138 ns/op
BenchmarkFindImporters_StaticCases/local_import_with_relative_path-8 	    3141	    382911 ns/op
BenchmarkFindImporters_StaticCases/lib_imported_through_chain-8      	    3099	    387749 ns/op
BenchmarkFindImporters_StaticCases/vendored_lib_imported_through_chain_+_directly-8         	    3039	    383107 ns/op
BenchmarkFindImporters_StaticCases/vendored_lib_found_through_symlink-8                     	    3115	    384220 ns/op
BenchmarkFindImporters_StaticCases/text_file-8                                              	    3121	    385579 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_environment-8                          	    3109	    383340 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_environment_with_doubled_'..'-8        	    3148	    382611 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_text_file-8                            	    3152	    382753 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_text_file_with_doubled_'..'-8          	    3123	    390173 ns/op
BenchmarkFindImporters_StaticCases/vendor_override_in_env:_override_vendor_used-8           	    3093	    382785 ns/op
BenchmarkFindImporters_StaticCases/vendor_override_in_env:_global_vendor_unused-8           	    3134	    382218 ns/op
BenchmarkFindImporters_StaticCases/imported_file_in_lib_relative_to_env-8                   	    3136	    382655 ns/op
BenchmarkFindImporters_StaticCases/unused_deleted_file-8                                    	  256819	      4691 ns/op
BenchmarkFindImporters_StaticCases/deleted_local_path_that_is_still_potentially_imported-8  	  233666	      5029 ns/op
BenchmarkFindImporters_StaticCases/deleted_lib_that_is_still_potentially_imported-8         	  246162	      4877 ns/op
BenchmarkFindImporters_StaticCases/deleted_vendor_that_is_still_potentially_imported-8      	  246010	      4889 ns/op
BenchmarkFindImporters_StaticCases/deleted_lib_that_is_still_potentially_imported,_relative_path_from_root-8         	  251054	      4800 ns/op
BenchmarkFindImporters_StaticCases/deleted_dir_in_environment-8                                                      	  243165	      4966 ns/op
BenchmarkFindImporters_StaticCases/imports_through_a_main_file_are_followed-8                                        	    3120	    382977 ns/op
BenchmarkGetSnippetHash/all-imported-from-main-8                                                                     	      69	  16845759 ns/op
BenchmarkGetSnippetHash/deeply-nested-8                                                                              	      69	  16665107 ns/op
PASS
ok  	github.com/grafana/tanka/pkg/jsonnet	34.298s

```

New:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/tanka/pkg/jsonnet
BenchmarkFindImporters-8               	     102	  11829940 ns/op
BenchmarkFindImporters_StaticCases/no_files-8         	  529087	      2282 ns/op
BenchmarkFindImporters_StaticCases/invalid_file-8     	   86583	     13791 ns/op
BenchmarkFindImporters_StaticCases/project_with_no_imports-8         	    3076	    384882 ns/op
BenchmarkFindImporters_StaticCases/local_import-8                    	    3126	    428205 ns/op
BenchmarkFindImporters_StaticCases/local_import_with_relative_path-8 	    3118	    384546 ns/op
BenchmarkFindImporters_StaticCases/lib_imported_through_chain-8      	    3039	    385703 ns/op
BenchmarkFindImporters_StaticCases/vendored_lib_imported_through_chain_+_directly-8         	    3118	    386329 ns/op
BenchmarkFindImporters_StaticCases/vendored_lib_found_through_symlink-8                     	    3043	    384431 ns/op
BenchmarkFindImporters_StaticCases/text_file-8                                              	    3096	    387576 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_environment-8                          	    3094	    385090 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_environment_with_doubled_'..'-8        	    3106	    384936 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_text_file-8                            	    3135	    384335 ns/op
BenchmarkFindImporters_StaticCases/relative_imported_text_file_with_doubled_'..'-8          	    3120	    384643 ns/op
BenchmarkFindImporters_StaticCases/vendor_override_in_env:_override_vendor_used-8           	    3136	    385253 ns/op
BenchmarkFindImporters_StaticCases/vendor_override_in_env:_global_vendor_unused-8           	    3140	    387898 ns/op
BenchmarkFindImporters_StaticCases/imported_file_in_lib_relative_to_env-8                   	    3121	    385021 ns/op
BenchmarkFindImporters_StaticCases/unused_deleted_file-8                                    	  255633	      4729 ns/op
BenchmarkFindImporters_StaticCases/deleted_local_path_that_is_still_potentially_imported-8  	  238418	      5022 ns/op
BenchmarkFindImporters_StaticCases/deleted_lib_that_is_still_potentially_imported-8         	  246826	      4930 ns/op
BenchmarkFindImporters_StaticCases/deleted_vendor_that_is_still_potentially_imported-8      	  245030	      4912 ns/op
BenchmarkFindImporters_StaticCases/deleted_lib_that_is_still_potentially_imported,_relative_path_from_root-8         	  250392	      4834 ns/op
BenchmarkFindImporters_StaticCases/deleted_dir_in_environment-8                                                      	  233756	      4973 ns/op
BenchmarkFindImporters_StaticCases/imports_through_a_main_file_are_followed-8                                        	    3100	    386400 ns/op
BenchmarkGetSnippetHash/all-imported-from-main-8                                                                     	      69	  16851776 ns/op
BenchmarkGetSnippetHash/deeply-nested-8                                                                              	      70	  16859413 ns/op
PASS
ok  	github.com/grafana/tanka/pkg/jsonnet	35.749s
```