### PR TITLE
Add new line at the end of "Formatted %v files" output

### DIFF
--- a/cmd/tk/fmt.go
+++ b/cmd/tk/fmt.go
@@ -81,7 +81,7 @@ func fmtCmd() *cli.Command {
 		case len(changed) == 0:
 			fmt.Fprintln(os.Stderr, "All discovered files are already formatted. No changes were made")
 		case len(changed) > 0:
-			fmt.Fprintf(os.Stderr, "Formatted %v files", len(changed))
+			fmt.Fprintf(os.Stderr, "Formatted %v files\n", len(changed))
 		}
 
 		return nil


### PR DESCRIPTION
Fix #942 

The issue is caused because the no changes output uses `Fprintln`, since the output when files are formatted wants to include the file number it uses `Fprintf` which requires a `\n` at the end to include the new line.