### PR TITLE
chore: Add dependabot updates to dagger & acceptance-tests folders

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
     schedule:
       interval: weekly
 
+  - directory: /dagger
+    open-pull-requests-limit: 5
+    package-ecosystem: gomod
+    schedule:
+      interval: weekly
+
+  - directory: /acceptance-tests
+    open-pull-requests-limit: 5
+    package-ecosystem: gomod
+    schedule:
+      interval: weekly
+
   - directory: /docs
     open-pull-requests-limit: 5
     package-ecosystem: npm


### PR DESCRIPTION
This should also finally discover outdated dependencies in these two folders.