### PR TITLE
CI: Run publish-page workflow only on non-forks and docs changes

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -27,7 +27,7 @@ concurrency: ci-${{ github.ref }}
 jobs:
   publish:
     # Do not run this on forks:
-    if: github.repository == 'grafana/tanka'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'grafana/tanka'
 
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -5,12 +5,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/publish-page.yml"
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
       - closed
+    paths:
+      - "docs/**"
+      - ".github/workflows/publish-page.yml"
 
 permissions:
   contents: write
@@ -20,6 +26,9 @@ concurrency: ci-${{ github.ref }}
 
 jobs:
   publish:
+    # Do not run this on forks:
+    if: github.repository == 'grafana/tanka'
+
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Resolves https://github.com/grafana/tanka/issues/1054