### PR TITLE
CI: Run publish-page workflow only on non-forks and docs changes

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -31,6 +31,8 @@ jobs:
 
     runs-on: ubuntu-22.04
     steps:
+      - name: Print github context
+        run: echo "${{ toJson(github) }}" | jq .
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install pnpm
@@ -40,8 +42,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
-          cache-dependency-path: 'docs'
+          cache: "pnpm"
+          cache-dependency-path: "docs"
 
       - name: Install and Build
         working-directory: docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,5 +39,7 @@ Markdown files with relative links.
 Check out [Starlight’s docs](https://starlight.astro.build/) and the
 [the Astro documentation](https://docs.astro.build)
 
+test
+
 [astro]: https://astro.build
 [starlight]: https://starlight.astro.build


### PR DESCRIPTION
Resolves #1054- **CI: Run publish-page workflow only on non-forks and docs changes**
- **test**
