### PR TITLE
feat: allow using external variables in export and env list  

### DIFF
--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -241,6 +241,8 @@ func envListCmd() *cli.Command {
 
 	useNames := cmd.Flags().Bool("names", false, "plain names output")
 
+	getJsonnetOpts := jsonnetFlags(cmd.Flags())
+
 	cmd.Run = func(cmd *cli.Command, args []string) error {
 		var path string
 		var err error
@@ -253,7 +255,7 @@ func envListCmd() *cli.Command {
 			}
 		}
 
-		envs, err := tanka.FindEnvs(path, tanka.FindOpts{Selector: getLabelSelector()})
+		envs, err := tanka.FindEnvs(path, tanka.FindOpts{Selector: getLabelSelector(), JsonnetOpts: getJsonnetOpts()})
 		if err != nil {
 			return err
 		}

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -88,7 +88,6 @@ func exportCmd() *cli.Command {
 		var exportEnvs []*v1alpha1.Environment
 		// find possible environments
 		if *recursive {
-
 			// get absolute path to Environment
 			envs, err := tanka.FindEnvsFromPaths(args[1:], tanka.FindOpts{Selector: opts.Selector, Parallelism: opts.Parallelism, JsonnetOpts: opts.Opts.JsonnetOpts})
 			if err != nil {

--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -88,8 +88,9 @@ func exportCmd() *cli.Command {
 		var exportEnvs []*v1alpha1.Environment
 		// find possible environments
 		if *recursive {
+
 			// get absolute path to Environment
-			envs, err := tanka.FindEnvsFromPaths(args[1:], tanka.FindOpts{Selector: opts.Selector, Parallelism: opts.Parallelism})
+			envs, err := tanka.FindEnvsFromPaths(args[1:], tanka.FindOpts{Selector: opts.Selector, Parallelism: opts.Parallelism, JsonnetOpts: opts.Opts.JsonnetOpts})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Using `std.extVar` in an inline environment's definition will cause `tk env list` and `tk export ... --recursive` to fail.

An example use case (what I'm writing this to support), is when you have inline environments whose namespace needs to be set at runtime, such as a review environment whos namespace is dynamic eg:
```jsonnet
{
    prod: {
        apiVersion: 'tanka.dev/v1alpha1',
        kind: 'Environment',
        metadata: {
            name: 'prod',
        },
        spec: {
            namespace: 'prod',
            applyStrategy: 'server',
        },
    },
    review: {
        apiVersion: 'tanka.dev/v1alpha1',
        kind: 'Environment',
        metadata: {
            name: 'review',
        },
        spec: {
            namespace: std.extVar('reviewNamespace'),
            applyStrategy: 'server',
        },
    }
}
```
Tanka has a bunch of different ways one could work around this, but its very convenient to be able to specify the default namespace so succinctly.

 - For `tk export ... --recursive` the `JsonnetOpts` were already parsed and just needed to be plumbed through to where environments are discovered.
 - For `tk env list`, the `ext-str` and `tla-str` arguments needed to be added to the command.