### PR TITLE
ci: fix missing tag name in release draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,14 @@ jobs:
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           body: |
-            This is release `${{ env.GITHUB_REF_NAME }}` of Tanka (`tk`).
+            This is release `${{ github.ref_name }}` of Tanka (`tk`).
 
             ## Install instructions
 
             #### Binary:
             ```bash
             # download the binary (adapt os and arch as needed)
-            $ curl -fSL -o "/usr/local/bin/tk" "https://github.com/grafana/tanka/releases/download/${{ env.GITHUB_REF_NAME }}/tk-linux-amd64"
+            $ curl -fSL -o "/usr/local/bin/tk" "https://github.com/grafana/tanka/releases/download/${{ github.ref_name }}/tk-linux-amd64"
 
             # make it executable
             $ chmod a+x "/usr/local/bin/tk"


### PR DESCRIPTION
The `env` context does not contain all environment variables but just those that were explicitly set by writing to `$GITHUB_ENV` or through the `env` property of the step/job. Since that is not the case here, the variable is empty.

This switches over to using `${{ github.ref_name }}`.