### PR TITLE
fix: prevent concurrent writes in `env list` command

### DIFF
--- a/pkg/tanka/find.go
+++ b/pkg/tanka/find.go
@@ -127,9 +127,13 @@ func findEnvsFromJsonnetFiles(jsonnetFiles []string, opts FindOpts) ([]*v1alpha1
 
 	for i := 0; i < opts.Parallelism; i++ {
 		go func() {
+			// We need to create a copy of the opts for each goroutine because
+			// the content may be modified down the line:
+			jsonnetOpts := opts.JsonnetOpts.Clone()
+
 			for jsonnetFile := range jsonnetFilesChan {
 				// try if this has envs
-				list, err := List(jsonnetFile, Opts{JsonnetOpts: opts.JsonnetOpts})
+				list, err := List(jsonnetFile, Opts{JsonnetOpts: jsonnetOpts})
 				if err != nil &&
 					// expected when looking for environments
 					!errors.As(err, &jpath.ErrorNoBase{}) &&


### PR DESCRIPTION
Fixes https://github.com/grafana/tanka/issues/1175

Unfortunately, this issue wasn't even visible with the `BenchmarkFindEnvsFromPaths` test running at more than 500 iterations. With running the env-list command with a new process every iteration, the error appeared after 30-120 runs. After applying this change, the error did not re-appear even after around 10K runs.