### PR TITLE
feat(ci): run required checks on merge groups

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/check-dagger-drift.yml
+++ b/.github/workflows/check-dagger-drift.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   check-dagger-drift:
@@ -26,13 +27,13 @@ jobs:
         with:
           path: bin
           key: daggercli-download-${{ steps.dagger_version.outputs.version }}
-  
+
       - name: Install Dagger CLI
         if: steps.cache_daggercli.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ steps.dagger_version.outputs.version }} sh
-        
+
       - name: Check drift
         run: |
           set -e

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,10 +9,11 @@ on:
       - v*
   pull_request:
     branches:
-      - '*'
+      - "*"
     paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/publish-page.yml'
+      - "docs/**"
+      - ".github/workflows/publish-page.yml"
+  merge_group:
 
 permissions:
   contents: read
@@ -35,7 +36,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -53,9 +54,9 @@ jobs:
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: grafana/shared-workflows/actions/dockerhub-login@main
-  
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.0
@@ -63,30 +64,30 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'push' }}
 
       - name: Export digest
         id: digest
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"          
+          touch "/tmp/digests/${digest#sha256:}"
           echo "artifact_name=digests-${{ matrix.platform }}" | sed -e 's/\//-/g' >> "$GITHUB_OUTPUT"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: ${{ steps.digest.outputs.artifact_name }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-  
+
   merge:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    needs: 
+    if: github.event_name == 'push'
+    needs:
       - build
     steps:
       - name: Download digests (linux/amd64)
@@ -109,7 +110,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
-    
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
@@ -124,7 +125,7 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}          
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -9,12 +9,12 @@ on:
       - reopened
     branches:
       - main
+  merge_group:
 
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/shared-workflows/actions/lint-pr-title@main
+      - uses: grafana/shared-workflows/actions/lint-pr-title@90e72fd7b35f5d30696313aeb736a13a15eb82ad # lint-pr-title-v1.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,8 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
+  merge_group:
 
 jobs:
   lint:
@@ -15,7 +16,7 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - uses: ./.github/actions/setup-goversion
       - run: make lint
-  
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +24,7 @@ jobs:
       - uses: ./.github/actions/setup-goversion
       - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
-          version: '3.13.1' 
+          version: "3.13.1"
       - name: Install jsonnet
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
       - run: make test


### PR DESCRIPTION
We often get several Dependabot pull requests in a short period. Our current repository settings - we require a successful build in CI, build for arm64, and require branches to be up to date - means it can be slow to manually merge them.

I'd like to switch to using merge queues, then we can disable the requirement for branches to be up to date before merging, since this will be handled by the queue. Developers will then be able to review and enqueue all the PRs, and they will be tested properly against the main branch.

To be able to do that we need to run the required tests for enqueued pull requests. That's what we're doing here.
