### PR TITLE
feat(ci): run on real arm64 builders

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,13 +29,14 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - linux/amd64
-          - linux/arm64
+          - ubuntu-latest
+          - github-hosted-ubuntu-arm64
+
+    runs-on: ${{ matrix.platform }}
 
     steps:
       - name: Checkout
@@ -47,9 +48,6 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: ${{ env.TAGS_CONFIG }}
 
-      # Setup buildx
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
@@ -62,7 +60,6 @@ jobs:
         uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.0
         with:
           context: .
-          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'push' }}
 
@@ -93,13 +90,13 @@ jobs:
       - name: Download digests (linux/amd64)
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: digests-linux-amd64
+          name: digests-github-hosted-ubuntu-arm64
           path: /tmp/digests-linux-amd64
 
       - name: Download digests (linux/arm64)
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: digests-linux-arm64
+          name: digests-ubuntu-latest
           path: /tmp/digests-linux-arm64
 
       - name: Merge digests


### PR DESCRIPTION
Emulated arm64 builds are slow. Fortunately, GitHub has real Linux ARM64 hardware these days, so let's switch to it.
