### PR TITLE
fix(docs): Starlight 0.28.3 introduced some changes to the i18n config

### DIFF
--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -1,6 +1,7 @@
 import { defineCollection } from 'astro:content';
-import { docsSchema } from '@astrojs/starlight/schema';
+import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
   docs: defineCollection({ schema: docsSchema() }),
+  i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
 };


### PR DESCRIPTION
Turns out that you now have to explicitly configure the i18n collection if you want to use translation strings. This is the error that we got before the change:

```
> astro check && astro build

17:20:01 [types] Generated 400ms
17:20:01 [check] Getting diagnostics for Astro files in /home/runner/work/tanka/tanka/docs...
src/components/MobileTableOfContents.astro:17:24 - error ts(23[45](https://github.com/grafana/tanka/actions/runs/11559221997/job/32173402020?pr=1212#step:5:46)): Argument of type '["tableOfContents.onThisPage"]' is not assignable to parameter of type '[key: TemplateStringsArray | TemplateStringsArray[], options?: TOptionsBase & $Dictionary] | [key: string | string[], options: TOptionsBase & ... 1 more ... & { ...; }] | [key: ...]'.
  Type '["tableOfContents.onThisPage"]' is not assignable to type '[key: TemplateStringsArray | TemplateStringsArray[], options?: TOptionsBase & $Dictionary]'.

17        {Astro.locals.t('tableOfContents.onThisPage')}
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/components/TableOfContents.astro:12:54 - error ts(2345): Argument of type '["tableOfContents.onThisPage"]' is not assignable to parameter of type '[key: TemplateStringsArray | TemplateStringsArray[], options?: TOptionsBase & $Dictionary] | [key: string | string[], options: TOptionsBase & ... 1 more ... & { ...; }] | [key: ...]'.
  Type '["tableOfContents.onThisPage"]' is not assignable to type '[key: TemplateStringsArray | TemplateStringsArray[], options?: TOptionsBase & $Dictionary]'.

12     <h2 id="starlight__on-this-page">{Astro.locals.t('tableOfContents.onThisPage')}</h2>
                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Result (9 files): 
- 2 errors
- 0 warnings
- 0 hints
```

The setup worked in 0.28.2 and broke with 0.28.3.