### PR TITLE
ci: prevent breaking change from creating major release < 1.0.0

### DIFF
--- a/.release-please.json
+++ b/.release-please.json
@@ -52,6 +52,7 @@
   ],
   "draft-pull-request": true,
   "include-v-in-tag": true,
+  "bump-minor-pre-major": true,
   "packages": {
     ".": {
     }


### PR DESCRIPTION
We want to avoid reaching 1.0.0 by accident 😄 