### PR TITLE
feat: support --{tla,ext}-{code,str}-file flag in "tk eval"

### DIFF
--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -74,12 +75,16 @@ func cliCodeParser(fs *pflag.FlagSet) (func() map[string]string, func() map[stri
 	// need to use StringArray instead of StringSlice, because pflag attempts to
 	// parse StringSlice using the csv parser, which breaks when passing objects
 	extCode := fs.StringArray("ext-code", nil, "Set code value of extVar (Format: key=<code>)")
+	extCodeFile := fs.StringArray("ext-code-file", nil, "Set code value of extVar from file (Format: key=filename)")
 	extStr := fs.StringArrayP("ext-str", "V", nil, "Set string value of extVar (Format: key=value)")
+	extStrFile := fs.StringArray("ext-str-file", nil, "Set string value of extVar from file (Format: key=filename)")
 
 	tlaCode := fs.StringArray("tla-code", nil, "Set code value of top level function (Format: key=<code>)")
+	tlaCodeFile := fs.StringArray("tla-code-file", nil, "Set code value of top level function from file (Format: key=filename)")
 	tlaStr := fs.StringArrayP("tla-str", "A", nil, "Set string value of top level function (Format: key=value)")
+	tlaStrFile := fs.StringArray("tla-str-file", nil, "Set string value of top level function from file (Format: key=filename)")
 
-	newParser := func(kind string, code, str *[]string) func() map[string]string {
+	newParser := func(kind string, code, str, codeFile, strFile *[]string) func() map[string]string {
 		return func() map[string]string {
 			m := make(map[string]string)
 			for _, s := range *code {
@@ -103,12 +108,28 @@ func cliCodeParser(fs *pflag.FlagSet) (func() map[string]string, func() map[stri
 				}
 				m[split[0]] = string(js)
 			}
+
+			for _, x := range []struct {
+				arg        *[]string
+				kind2, imp string
+			}{
+				{arg: codeFile, kind2: "code", imp: "import"},
+				{arg: strFile, kind2: "str", imp: "importstr"},
+			} {
+				for _, s := range *x.arg {
+					split := strings.SplitN(s, "=", 2)
+					if len(split) != 2 {
+						log.Fatal().Msgf("%s-%s-file argument has wrong format: `%s`. Expected `key=filename`", kind, x.kind2, s)
+					}
+					m[split[0]] = fmt.Sprintf(`%s @"%s"`, x.imp, strings.ReplaceAll(split[1], `"`, `""`))
+				}
+			}
 			return m
 		}
 	}
 
-	return newParser("ext", extCode, extStr),
-		newParser("tla", tlaCode, tlaStr)
+	return newParser("ext", extCode, extStr, extCodeFile, extStrFile),
+		newParser("tla", tlaCode, tlaStr, tlaCodeFile, tlaStrFile)
 }
 
 func envSettingsFlags(env *v1alpha1.Environment, fs *pflag.FlagSet) {

--- a/cmd/tk/flags_test.go
+++ b/cmd/tk/flags_test.go
@@ -17,6 +17,10 @@ func TestCliCodeParser(t *testing.T) {
 		"--tla-code", "tc=2+3",
 		"-A", "ts2=ts2", // tla-str
 		"-V", "es2=es2", // ext-str
+		"--ext-str-file", `esf=e"sf.txt`,
+		"--tla-str-file", `tsf=t"s"f.txt`,
+		"--ext-code-file", `ecf=e"cf.json`,
+		"--tla-code-file", `tcf=t"c"f.json`,
 	})
 	assert.NoError(t, err)
 	ext := parseExt()
@@ -24,11 +28,15 @@ func TestCliCodeParser(t *testing.T) {
 		"es":  `"1a \" ` + "\U0001f605" + ` ' b\nc` + "\u010f" + `"`,
 		"ec":  "1+2",
 		"es2": `"es2"`,
+		"esf": `importstr @"e""sf.txt"`,
+		"ecf": `import @"e""cf.json"`,
 	}, ext)
 	tla := parseTLA()
 	assert.Equal(t, map[string]string{
 		"ts":  `"2a \" ` + "\U0001f605" + ` ' b\nc` + "\u010f" + `"`,
 		"tc":  "2+3",
 		"ts2": `"ts2"`,
+		"tsf": `importstr @"t""s""f.txt"`,
+		"tcf": `import @"t""c""f.json"`,
 	}, tla)
 }


### PR DESCRIPTION
Convert the flag values to `import/importstr @"verbatim ""quoted"" string"`,
pretty much like go-jsonnet does it.

Implements https://github.com/grafana/tanka/issues/848