### PR TITLE
ci: create release docker image through workflow-call

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,15 +5,18 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
   pull_request:
     branches:
       - "*"
     paths-ignore:
       - "docs/**"
       - ".github/workflows/publish-page.yml"
-  merge_group:
+  merge_group: {}
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -23,9 +26,9 @@ env:
   REGISTRY_IMAGE: grafana/tanka
   # Docker image tags. See https://github.com/docker/metadata-action for format
   TAGS_CONFIG: |
-    type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
     type=sha,prefix={{branch}}-,format=short,enable=${{ github.ref == 'refs/heads/main' }}
-    type=semver,pattern={{version}}
+    type=raw,value=latest,enable=${{ inputs.tag != '' }}
+    type=semver,pattern={{version}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
 
 jobs:
   build:
@@ -41,6 +44,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,18 @@ jobs:
           manifest-file: .release-please-manifest.json
           github-token: ${{ github.secret }}
 
+  release-docker-image:
+    needs:
+      - release-please
+    if: needs.release-please.outputs.release_created
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/docker.yml
+    with:
+      tag: ${{ needs.release-please.outputs.release_tag }}
+
   # If a release was created, also create the binaries and attach them
   release-binaries:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The docker workflow was not properly triggered by release-please and so we didn't get a 0.30.0 docker image. With this PR we will now call the docker workflow explicitly from release please.