### PR TITLE
fix: mimic --tla-code behavior from jsonnet for functions in main.jsonnet in env discovery

### DIFF
--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -20,6 +20,11 @@ func evalJsonnet(path string, impl types.JsonnetImplementation, opts jsonnet.Opt
 
 	// evaluate Jsonnet
 	if opts.EvalScript != "" {
+		// Determine if the entrypoint is a function.
+		isFunction, err := jsonnet.Evaluate(path, impl, fmt.Sprintf("std.isFunction(import '%s')", entrypoint), opts)
+		if err != nil {
+			return "", fmt.Errorf("evaluating jsonnet in path '%s': %w", path, err)
+		}
 		var tla []string
 		for k := range opts.TLACode {
 			tla = append(tla, k+"="+k)
@@ -29,7 +34,7 @@ func evalJsonnet(path string, impl types.JsonnetImplementation, opts jsonnet.Opt
   %s
 `, entrypoint, opts.EvalScript)
 
-		if len(tla) != 0 {
+		if isFunction == "true\n" {
 			tlaJoin := strings.Join(tla, ", ")
 			evalScript = fmt.Sprintf(`
 function(%s)

--- a/pkg/tanka/testdata/cases/function-with-zero-params/main.jsonnet
+++ b/pkg/tanka/testdata/cases/function-with-zero-params/main.jsonnet
@@ -1,0 +1,16 @@
+function() {
+  apiVersion: 'tanka.dev/v1alpha1',
+  kind: 'Environment',
+  metadata: {
+    name: 'inline',
+  },
+  spec: {
+    apiServer: 'https://localhost',
+    namespace: 'inline',
+  },
+  data: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: { name: 'config' },
+  },
+}

--- a/pkg/tanka/testdata/cases/with-optional-tlas/main.jsonnet
+++ b/pkg/tanka/testdata/cases/with-optional-tlas/main.jsonnet
@@ -1,0 +1,16 @@
+function(bar='bar', baz='baz') {
+  apiVersion: 'tanka.dev/v1alpha1',
+  kind: 'Environment',
+  metadata: {
+    name: bar + '-' + baz,
+  },
+  spec: {
+    apiServer: 'https://localhost',
+    namespace: 'inline',
+  },
+  data: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: { name: 'config' },
+  },
+}


### PR DESCRIPTION
## Problem
Some parts of tanka behave inconsistently with standard jsonnet when using inline environments with top level arguments.  The differences can be illustrated by this inline environment:
#### main.jsonnet
```jsonnet
function(foo="bar", fizz='buzz') {
  apiVersion: 'tanka.dev/v1alpha1',
  kind: 'Environment',
  // Other env stuff
}
```
And then running:
```bash
$ tk env list main.jsonnet
NAME    NAMESPACE    SERVER    
```
which finds no environments.  Similarly running:
```bash
$ tk export export-dir main.jsonnet --recursive
{"level":"info","parallelism":8,"envs":0,"time":"2024-11-29T13:28:23-07:00","message":"Reducing parallelism to match number of environments"}
```
will export no manifests.  For both commands, appending `--tla-code foo=1` will resolve the issue, listing the environment and exporting manifests.

If instead main.jsonnet is a function taking no arguments, eg:
#### main.jsonnet
```jsonnet
function() {
  apiVersion: 'tanka.dev/v1alpha1',
  kind: 'Environment',
  // Other env stuff
}
```
Then there is no combination of arguments that will cause `tk env list` or `tk export --recursive` to succeed.  It will either do nothing or fail when a `--tla-code` argument is provided.

## Expectation
These `tk env list` and `tk export` should permit the same flexibility as underlying jsonnet, namely that:
 - A main.jsonnet whose TLA's are all optional should be usable without specifying any `--tla-code` arguments.
 - A main.jsonnet with a function that takes no arguments should be useable.
 - Calling `tk env list main.jsonnet --tla-code badargument=0` on a mainfaile that isn't a function ignores the tla-code argument.
This is the behavior I'd expect to see from `tk`, because its also how calling `jsonnet` works. 

My current workaround for this is to always add a dummy  `unused` TLA to my main.jsonnet and ensure that all my tk commands are run with `--tla-code unused=0`, which is cumbersome.

## Cause
The root cause of this appears to be in how the [EvalScript for finding environments is constructed](https://github.com/grafana/tanka/blob/main/pkg/tanka/evaluators.go#L32-L38).  The presence of any `--tla-code` argument is used to determine if main.jsonnet should be used called as a function or not.  This decision logic behaves incorrectly if a `--tla-code` is provided with a non-function main.jsonnet or if no `--tla-code` argument is provided to a main.jsonnet that has no required arguments.

## Solution in this PR
Before running an EvalScript,  `jsonnet.Evaulate` is called with `std.isFunction` on the imported mainfile to determine if it needs to be called as a function.  This adds an extra evaluation every time an EvalScript is used, but since thats typically only done once per `tk` call and the `std.isFunction` doesn't manifest anything except a boolean, I'd expect it to have a minimal impact on performance.  