### PR TITLE
chore: update location from where kubectl is downloaded from

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # download kubectl
 FROM golang:1.23.3-alpine AS kubectl
 RUN apk add --no-cache curl
-RUN export VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) &&\
+RUN export VERSION=$(curl -s https://cdn.dl.k8s.io/release/stable.txt) &&\
     export OS=$(go env GOOS) && \
     export ARCH=$(go env GOARCH) &&\
-    curl -o /usr/local/bin/kubectl -L https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/${OS}/${ARCH}/kubectl &&\
+    curl -o /usr/local/bin/kubectl -L  https://cdn.dl.k8s.io/release/${VERSION}/bin/${OS}/${ARCH}/kubectl &&\
     chmod +x /usr/local/bin/kubectl
 
 # build jsonnet-bundler


### PR DESCRIPTION
Seems like the location changed around 1.31.0. The new location also includes the current patch release and thereby updating kubectl to 1.31.3.