### PR TITLE
refactor: define jsonnet-implementation flag in a single place

### DIFF
--- a/acceptance-tests/flag_test.go
+++ b/acceptance-tests/flag_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonnetImplementationFlag(t *testing.T) {
+	// The jsonnet implementation flag should be present for the following sub-commands
+	supportedSubCommands := []string{
+		"eval",
+		"export",
+		"status",
+		"apply",
+		"diff",
+		"delete",
+		"show",
+		// https://github.com/grafana/tanka/pull/1208
+		"env list",
+	}
+	tmpDir := t.TempDir()
+	for _, subcommand := range supportedSubCommands {
+		t.Run(subcommand, func(t *testing.T) {
+			args := []string{}
+			command := strings.Split(subcommand, " ")
+			args = append(args, command...)
+			args = append(args, "--help")
+			helpOutput := getCmdOutput(t, tmpDir, "tk", args...)
+			require.Contains(t, helpOutput, "jsonnet-implementation")
+		})
+	}
+}

--- a/cmd/tk/env.go
+++ b/cmd/tk/env.go
@@ -236,7 +236,8 @@ func envListCmd() *cli.Command {
 		Args:    args,
 	}
 
-	jsonnetImplementation := cmd.Flags().String("jsonnet-implementation", "go", "Use `go` to use native go-jsonnet implementation and `binary:<path>` to delegate evaluation to a binary (with the same API as the regular `jsonnet` binary, see the BinaryImplementation docstrings for more details)")
+	var jsonnetImplementation string
+	jsonnetImplementationFlag(cmd.Flags(), &jsonnetImplementation)
 	useJSON := cmd.Flags().Bool("json", false, "json output")
 	getLabelSelector := labelSelectorFlag(cmd.Flags())
 
@@ -256,7 +257,7 @@ func envListCmd() *cli.Command {
 			}
 		}
 
-		envs, err := tanka.FindEnvs(path, tanka.FindOpts{JsonnetImplementation: *jsonnetImplementation, Selector: getLabelSelector(), JsonnetOpts: getJsonnetOpts()})
+		envs, err := tanka.FindEnvs(path, tanka.FindOpts{JsonnetImplementation: jsonnetImplementation, Selector: getLabelSelector(), JsonnetOpts: getJsonnetOpts()})
 		if err != nil {
 			return err
 		}

--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -18,11 +18,15 @@ type workflowFlagVars struct {
 	jsonnetImplementation string
 }
 
+func jsonnetImplementationFlag(fs *pflag.FlagSet, output *string) {
+	fs.StringVar(output, "jsonnet-implementation", "go", "Use `go` to use native go-jsonnet implementation and `binary:<path>` to delegate evaluation to a binary (with the same API as the regular `jsonnet` binary, see the BinaryImplementation docstrings for more details)")
+}
+
 func workflowFlags(fs *pflag.FlagSet) *workflowFlagVars {
 	v := workflowFlagVars{}
 	fs.StringVar(&v.name, "name", "", "string that only a single inline environment contains in its name")
 	fs.StringSliceVarP(&v.targets, "target", "t", nil, "Regex filter on '<kind>/<name>'. See https://tanka.dev/output-filtering")
-	fs.StringVar(&v.jsonnetImplementation, "jsonnet-implementation", "go", "Use `go` to use native go-jsonnet implementation and `binary:<path>` to delegate evaluation to a binary (with the same API as the regular `jsonnet` binary, see the BinaryImplementation docstrings for more details)")
+	jsonnetImplementationFlag(fs, &v.jsonnetImplementation)
 	return &v
 }
 

--- a/cmd/tk/jsonnet.go
+++ b/cmd/tk/jsonnet.go
@@ -15,14 +15,15 @@ func evalCmd() *cli.Command {
 		Args:  workflowArgs,
 	}
 
+	var jsonnetImplementation string
 	evalPattern := cmd.Flags().StringP("eval", "e", "", "Evaluate expression on output of jsonnet")
-	jsonnetImplementation := cmd.Flags().String("jsonnet-implementation", "go", "Use `go` to use native go-jsonnet implementation and `binary:<path>` to delegate evaluation to a binary (with the same API as the regular `jsonnet` binary, see the BinaryImplementation docstrings for more details)")
+	jsonnetImplementationFlag(cmd.Flags(), &jsonnetImplementation)
 
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(_ *cli.Command, args []string) error {
 		jsonnetOpts := tanka.Opts{
-			JsonnetImplementation: *jsonnetImplementation,
+			JsonnetImplementation: jsonnetImplementation,
 			JsonnetOpts:           getJsonnetOpts(),
 		}
 		if *evalPattern != "" {


### PR DESCRIPTION
Right now this flag is defined in 3 places, with this change there should only be a single place for it.