### PR TITLE
ci: ignore Astro 5 for now as Starlight does not support it yet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
     package-ecosystem: npm
     schedule:
       interval: weekly
+    ignore:
+      # Starlight is not yet compatible with Astro 5
+      - dependency-name: "astro"
+        versions: [">=5.0.0"]
     groups:
       docs-dependencies:
         patterns:


### PR DESCRIPTION
See https://github.com/grafana/tanka/pull/1272