### PR TITLE
Revert "ci: ignore Astro 5 for now as Starlight does not support it yet"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,10 +31,6 @@ updates:
     package-ecosystem: npm
     schedule:
       interval: weekly
-    ignore:
-      # Starlight is not yet compatible with Astro 5
-      - dependency-name: "astro"
-        versions: [">=5.0.0"]
     groups:
       docs-dependencies:
         patterns:


### PR DESCRIPTION
Reverts grafana/tanka#1274

A new version of Starlight is now available which no does not support Astro 4 anymore and so we can update both.