### PR TITLE
fix(helm): allow special char in chart repo name

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	// https://regex101.com/r/7xFFtU/3
-	chartExp = regexp.MustCompile(`^(?P<chart>\w+\/.+)@(?P<version>[^:\n\s]+)(?:\:(?P<path>[\w-. ]+))?$`)
-	repoExp  = regexp.MustCompile(`^\w+$`)
+	// https://regex101.com/r/9m42pQ/1
+	chartExp = regexp.MustCompile(`^(?P<chart>[\w+-\/.]+)@(?P<version>[^:\n\s]+)(?:\:(?P<path>[\w-. ]+))?$`)
+	// https://regex101.com/r/xoAx8c/1
+	repoExp = regexp.MustCompile(`^[\w-]+$`)
 )
 
 // LoadChartfile opens a Chartfile tree

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -50,6 +50,15 @@ func TestParseReq(t *testing.T) {
 			input: "https://helm.releases.hashicorp.com/vault@0.19.0",
 			err:   errors.New("not of form 'repo/chart@version(:path)' where repo contains no special characters"),
 		},
+		{
+			name:  "repo-with-special-chars",
+			input: "with-dashes/package@1.0.0",
+			expected: &Requirement{
+				Chart:     "with-dashes/package",
+				Version:   "1.0.0",
+				Directory: "",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -68,12 +77,13 @@ func TestAddRepos(t *testing.T) {
 	err = c.AddRepos(
 		Repo{Name: "foo", URL: "https://foo.com"},
 		Repo{Name: "foo2", URL: "https://foo2.com"},
+		Repo{Name: "with-dashes", URL: "https://foo.com"},
 	)
 	assert.NoError(t, err)
 
-	// Only \w characters are allowed in repo names
+	// Only \w- characters are allowed in repo names
 	err = c.AddRepos(
-		Repo{Name: "with-dashes", URL: "https://foo.com"},
+		Repo{Name: "re:po", URL: "https://foo.com"},
 	)
 	assert.EqualError(t, err, "1 Repo(s) were skipped. Please check above logs for details")
 


### PR DESCRIPTION
# Description

Currently, when I trying to add a repository and a chart with containing the special char `-` in the repo name, it fails:

```
tk tool charts add-repo cert-manager https://charts.jetstack.io
{"level":"info","time":"2025-02-28T08:51:19+01:00","message":"Skipping cert-manager: invalid name. cannot contain any special characters."}
Error: 1 Repo(s) were skipped. Please check above logs for details
```

```
tk tool charts add cert-manager/cert-manager@1.17.1
{"level":"info","time":"2025-02-28T08:52:03+01:00","message":"Adding 1 Charts ..."}
{"level":"info","time":"2025-02-28T08:52:03+01:00","message":"Skipping cert-manager/cert-manager@1.17.1: not of form 'repo/chart@version(:path)' where repo contains no special characters."}
Error: 1 Chart(s) were skipped. Please check above logs for details
```

We should be able to use the special char `-` in chart repository names, a lot of charts installation instruction includes the special char `-` as default:
- [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager)
- [metrics-server](https://artifacthub.io/packages/helm/metrics-server/metrics-server)
- [kubernetes-dashboard](https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard)

Helm only checks for the special char `/` as it would break the `repo/chart@version` url pattern. It might be a preferable to provide the same behavior but I did not want to completely change the current logic.
See <https://github.com/helm/helm/blob/main/pkg/cmd/repo_add.go#L182>.