### PR TITLE
feat(jsonnet): add support for importing all files in a directory

### DIFF
--- a/pkg/jsonnet/implementations/goimpl/vm.go
+++ b/pkg/jsonnet/implementations/goimpl/vm.go
@@ -25,6 +25,10 @@ func MakeRawVM(importPaths []string, extCode map[string]string, tlaCode map[stri
 		vm.NativeFunction(nf)
 	}
 
+	for _, nvf := range native.VMFuncs(vm) {
+		vm.NativeFunction(nvf)
+	}
+
 	if maxStack > 0 {
 		vm.MaxStack = maxStack
 	}

--- a/pkg/jsonnet/native/funcs.go
+++ b/pkg/jsonnet/native/funcs.go
@@ -213,6 +213,18 @@ func parseImportOpts(data interface{}) (*importFilesOpts, error) {
 	if opts.CalledFrom == "" {
 		return nil, fmt.Errorf("importFiles: `opts.calledFrom` is unset or empty\nTanka needs this to find your directory.")
 	}
+	// Make sure calledFrom is inside the current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("importFiles: failed to get current working directory: %s", err)
+	}
+	calledFromAbs, err := filepath.Abs(opts.CalledFrom)
+	if err != nil {
+		return nil, fmt.Errorf("importFiles: failed to get absolute path to `opts.calledFrom`: %s", err)
+	}
+	if !strings.HasPrefix(calledFromAbs, cwd) {
+		return nil, fmt.Errorf("importFiles: `opts.calledFrom` must be a subdirectory of the current working directory: %s", cwd)
+	}
 	return &opts, nil
 }
 

--- a/pkg/jsonnet/native/funcs.go
+++ b/pkg/jsonnet/native/funcs.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	jsonnet "github.com/google/go-jsonnet"
@@ -14,6 +17,7 @@ import (
 	"github.com/grafana/tanka/pkg/helm"
 	"github.com/grafana/tanka/pkg/kustomize"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -39,6 +43,14 @@ func Funcs() []*jsonnet.NativeFunction {
 
 		helm.NativeFunc(helm.ExecHelm{}),
 		kustomize.NativeFunc(kustomize.ExecKustomize{}),
+	}
+}
+
+// VMFuncs returns a slice of functions similar to Funcs but are passed the jsonnet VM
+// for in-line evaluation
+func VMFuncs(vm *jsonnet.VM) []*jsonnet.NativeFunction {
+	return []*jsonnet.NativeFunction{
+		importFiles(vm),
 	}
 }
 
@@ -175,6 +187,78 @@ func regexSubst() *jsonnet.NativeFunction {
 				return "", err
 			}
 			return r.ReplaceAllString(src, repl), nil
+		},
+	}
+}
+
+type importFilesOpts struct {
+	CalledFrom string   `json:"calledFrom"`
+	Exclude    []string `json:"exclude"`
+	Extension  string   `json:"extension"`
+}
+
+func parseImportOpts(data interface{}) (*importFilesOpts, error) {
+	c, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// default extension to `.libsonnet`
+	opts := importFilesOpts{
+		Extension: ".libsonnet",
+	}
+	if err := json.Unmarshal(c, &opts); err != nil {
+		return nil, err
+	}
+	if opts.CalledFrom == "" {
+		return nil, fmt.Errorf("importFiles: `opts.calledFrom` is unset or empty\nTanka needs this to find your directory.")
+	}
+	return &opts, nil
+}
+
+// importFiles imports and evaluates all matching jsonnet files in the given relative directory
+func importFiles(vm *jsonnet.VM) *jsonnet.NativeFunction {
+	return &jsonnet.NativeFunction{
+		Name:   "importFiles",
+		Params: ast.Identifiers{"directory", "opts"},
+		Func: func(data []interface{}) (interface{}, error) {
+			dir, ok := data[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("first argument 'directory' must be of 'string' type, got '%T' instead", data[0])
+			}
+			opts, err := parseImportOpts(data[1])
+			if err != nil {
+				return nil, err
+			}
+			dirPath := filepath.Join(filepath.Dir(opts.CalledFrom), dir)
+			imports := make(map[string]interface{})
+			err = filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() || !strings.HasSuffix(info.Name(), opts.Extension) {
+					return nil
+				}
+				if slices.Contains(opts.Exclude, info.Name()) {
+					return nil
+				}
+				log.Debug().Msgf("importFiles: parsing file %s", info.Name())
+				resultStr, err := vm.EvaluateFile(path)
+				if err != nil {
+					return fmt.Errorf("importFiles: failed to evaluate %s: %s", path, err)
+				}
+				var result interface{}
+				err = json.Unmarshal([]byte(resultStr), &result)
+				if err != nil {
+					return err
+				}
+				imports[info.Name()] = result
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			return imports, nil
 		},
 	}
 }

--- a/pkg/jsonnet/native/funcs_test.go
+++ b/pkg/jsonnet/native/funcs_test.go
@@ -227,26 +227,35 @@ func TestRegexSubstInvalid(t *testing.T) {
 }
 
 func TestImportFiles(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
 	tempDir, err := os.MkdirTemp("", "importFilesTest")
-	assert.Nil(t, err)
-	defer os.RemoveAll(tempDir)
+	assert.NoError(t, err)
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			panic(err)
+		}
+		os.RemoveAll(tempDir)
+	}()
+	err = os.Chdir(tempDir)
+	assert.NoError(t, err)
 	importDirName := "imports"
 	importDir := filepath.Join(tempDir, importDirName)
 	err = os.Mkdir(importDir, 0750)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	importFiles := []string{"test1.libsonnet", "test2.libsonnet"}
 	excludeFiles := []string{"skip1.libsonnet", "skip2.libsonnet"}
 	for i, fName := range append(importFiles, excludeFiles...) {
 		fPath := filepath.Join(importDir, fName)
 		content := fmt.Sprintf("{ test: %d }", i)
 		err = os.WriteFile(fPath, []byte(content), 0644)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}
 	opts := make(map[string]interface{})
 	opts["calledFrom"] = filepath.Join(tempDir, "main.jsonnet")
 	opts["exclude"] = excludeFiles
 	ret, err, callerr := callVMNative("importFiles", []interface{}{importDirName, opts})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, callerr)
 	importMap, ok := ret.(map[string]interface{})
 	assert.True(t, ok)


### PR DESCRIPTION
Add native function `importFiles` which reads and evaluates all jsonnet files in a directory.

Returns an object of with key/value pairs of `<file name>: <evaluated object>`

Directory path is found using a `calledFrom` option, similar to `helmTemplate`.

Includes support for:
 - Choosing files by extension using the `extension` option (default is `.libsonnet`)
 - Excluding files using the `exclude` option, which takes an array of file names to skip

Fixes #1375