### PR TITLE
fix(tanka/inline): ensure Peek only grabs metadata

### DIFF
--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -105,7 +105,7 @@ local singleEnv(object) =
          && std.objectHas(object, 'kind')
       then
         if object.kind == 'Environment'
-        && object.metadata.name == '%s'
+        && std.member(object.metadata.name, '%s')
         then object { data:: super.data }
         else {}
       else

--- a/pkg/tanka/inline.go
+++ b/pkg/tanka/inline.go
@@ -25,7 +25,20 @@ func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment
 	if opts.Name != "" {
 		opts.JsonnetOpts.EvalScript = fmt.Sprintf(SingleEnvEvalScript, opts.Name)
 	}
+	return i.load(path, opts)
+}
 
+func (i *InlineLoader) Peek(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
+	opts.JsonnetOpts.EvalScript = MetadataEvalScript
+	if opts.Name != "" {
+		opts.JsonnetOpts.EvalScript = fmt.Sprintf(MetadataSingleEnvEvalScript, opts.Name)
+	}
+	env, err := i.load(path, opts)
+	return env, err
+}
+
+// abstracted out as Peek and Load need different JsonnetOpts
+func (i *InlineLoader) load(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
 	data, err := i.Eval(path, opts)
 	if err != nil {
 		return nil, err
@@ -69,14 +82,6 @@ func (i *InlineLoader) Load(path string, opts LoaderOpts) (*v1alpha1.Environment
 	}
 
 	return env, nil
-}
-
-func (i *InlineLoader) Peek(path string, opts LoaderOpts) (*v1alpha1.Environment, error) {
-	opts.JsonnetOpts.EvalScript = MetadataEvalScript
-	if opts.Name != "" {
-		opts.JsonnetOpts.EvalScript = fmt.Sprintf(MetadataSingleEnvEvalScript, opts.Name)
-	}
-	return i.Load(path, opts)
 }
 
 func (i *InlineLoader) List(path string, opts LoaderOpts) ([]*v1alpha1.Environment, error) {


### PR DESCRIPTION
Peek sets `JsonnetOpts.EvalScript` however Load always overrides that, because of this the performance improvement gets lost completely. This is very visible when using a different jsonnet implementation (jrsonnet) as the Peek loads the environment completely (in go), the performance gain from generating the env with jrsonnet gets lost.

This PR abstracts the comment load logic into a separate method, which in turn gets called by Peek and Load. This PR also fixes the `MetadataSingleEnvEvalScript` as it was only filtering on full names, not partial matches.
