### PR TITLE
chore(tests): drop use of testify/mock.Mock.TestData

### DIFF
--- a/pkg/helm/jsonnet_test.go
+++ b/pkg/helm/jsonnet_test.go
@@ -14,6 +14,7 @@ const kubeVersion = "1.18.0"
 
 type MockHelm struct {
 	mock.Mock
+	templateCommandArgs []string
 }
 
 // fulfill the Helm interface
@@ -34,7 +35,7 @@ func (m *MockHelm) Template(name, chart string, opts TemplateOpts) (manifest.Lis
 	// them
 	execHelm := &ExecHelm{}
 	cmdArgs := execHelm.templateCommandArgs(name, chart, opts)
-	m.TestData().Set("templateCommandArgs", cmdArgs)
+	m.templateCommandArgs = cmdArgs
 
 	return args.Get(0).(manifest.List), args.Error(1)
 }
@@ -88,7 +89,7 @@ func callNativeFunction(t *testing.T, expectedHelmTemplateOptions TemplateOpts, 
 
 	helmMock.AssertExpectations(t)
 
-	return helmMock.TestData().Get("templateCommandArgs").StringSlice()
+	return helmMock.templateCommandArgs
 }
 
 // TestDefaultCommandineFlagsIncludeCrds tests that the includeCrds flag is set


### PR DESCRIPTION
Simplify tests in `pkg/helm` by replacing a use of [`github.com/stretchr/testify/mock.Mock.TestData`](https://pkg.go.dev/github.com/stretchr/testify/mock#Mock.TestData) with just direct storage in the MockHelm object.

## Why?

I'm a maintainer of [`github.com/stretchr/testify`](https://github.com/stretchr/testify) and we are considering deprecating (and ultimately removing) the `TestData` method because it brings the single requirement of dependency `github.com/stretchr/objx.Map`.
See https://github.com/stretchr/testify/issues/1752
I'm surveying the use of that method and the use in this project clearly shows us a case where `TestData` is not necessary and its replacement is simple.