### PR TITLE
fix(setup-goversion): fix string manipulation to exclude unwanted strings and chars

### DIFF
--- a/.github/actions/setup-goversion/action.yml
+++ b/.github/actions/setup-goversion/action.yml
@@ -4,7 +4,7 @@ runs:
   steps:
     - id: goversion
       run: |
-        cat Dockerfile | awk '/^FROM golang:.* AS build$/ {v=$2;split(v,a,":")}; END {printf("version=%s", a[2])}' >> $GITHUB_OUTPUT
+        cat Dockerfile | awk '/^FROM golang:.* AS build$/ {v=$2;split(v,a,":"); split(a[2],b,"@")}; END {printf("version=%s", b[1])}' >> $GITHUB_OUTPUT
       shell: bash
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:


### PR DESCRIPTION
[This PR](https://github.com/grafana/tanka/pull/1549) is failing due to the action that parses a wrong version of golang - 

```text
Run actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
  with:
    go-version: 1.25.0@sha256
    check-latest: false
    token: ***
    cache: true
```

The current PR fixes that issue by further splitting the produced string to ignore `@` and whatever comes after it.