### PR TITLE
feat: support `TANKA_DANGEROUS_ALLOW_REDIRECT` env variable

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -275,16 +275,23 @@ func showCmd() *cli.Command {
 		Args:  workflowArgs,
 	}
 
-	allowRedirect := cmd.Flags().Bool("dangerous-allow-redirect", false, "allow redirecting output to a file or a pipe.")
+	allowRedirectFlag := cmd.Flags().Bool("dangerous-allow-redirect", false, "allow redirecting output to a file or a pipe.")
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(_ *cli.Command, args []string) error {
-		if !interactive && !*allowRedirect {
+		allowRedirectEnv := os.Getenv("TANKA_DANGEROUS_ALLOW_REDIRECT") == "true"
+		allowRedirect := allowRedirectEnv || *allowRedirectFlag
+
+		if !interactive && !allowRedirect {
 			fmt.Fprintln(os.Stderr, `Redirection of the output of tk show is discouraged and disabled by default.
 If you want to export .yaml files for use with other tools, try 'tk export'.
-Otherwise run tk show --dangerous-allow-redirect to bypass this check.`)
+Otherwise run:
+  tk show --dangerous-allow-redirect 
+or set the environment variable 
+  TANKA_DANGEROUS_ALLOW_REDIRECT=true 
+to bypass this check.`)
 			return nil
 		}
 

--- a/docs/src/content/docs/env-vars.md
+++ b/docs/src/content/docs/env-vars.md
@@ -38,3 +38,8 @@ sidebar:
 
 **Description**: Pager to use when displaying output. Only used if TANKA_PAGER is not set. Set to an empty string to disable paging.
 **Default**: `less --RAW-CONTROL-CHARS --quit-if-one-screen --no-init`
+
+## TANKA_DANGEROUS_ALLOW_REDIRECT
+
+**Description**: Allow redirection of the output of `tk show` to other commands when set to `true`, same as the `--dangerous-allow-redirect ` flag. Redirection of the output of `tk show` is discouraged and disabled by default. If you want to export `.yaml` files for use with other tools, try `tk export`.
+**Default**: `false`


### PR DESCRIPTION
I use 'tk show' quite frequently from the cli, I (think I) know what I'm doing, I'd like to permanently allow the dangerous redirects.