### PR TITLE
feat(tk-tool-importers): find importers when libraries import from environments

### DIFF
--- a/pkg/jsonnet/find_importers.go
+++ b/pkg/jsonnet/find_importers.go
@@ -295,7 +295,6 @@ func findImporters(root string, searchForFile string, chain map[string]struct{})
 
 	// If the file is not a vendored or a lib file, we assume:
 	// - it is used in a Tanka environment
-	// - it will not be imported by any lib or vendor files
 	// - the environment base (closest main file in parent dirs) will be considered an importer
 	// - if no base is found, all main files in child dirs will be considered importers
 	rootVendor := filepath.Join(root, "vendor")
@@ -325,12 +324,6 @@ func findImporters(root string, searchForFile string, chain map[string]struct{})
 
 	for jsonnetFilePath, jsonnetFileContent := range jsonnetFiles {
 		if len(jsonnetFileContent.Imports) == 0 {
-			continue
-		}
-
-		if !searchedFileIsLibOrVendored && isFileLibOrVendored(jsonnetFilePath) {
-			// Skip the file if it's a vendored or lib file and the searched file is an environment file
-			// Libs and vendored files cannot import environment files
 			continue
 		}
 

--- a/pkg/jsonnet/find_importers_test.go
+++ b/pkg/jsonnet/find_importers_test.go
@@ -227,6 +227,27 @@ func findImportersTestCases(t testing.TB) []findImportersTestCase {
 				absPath(t, "testdata/findImporters/environments/import-other-main-file/env2/main.jsonnet"),
 			},
 		},
+		{
+			name: "lib file imports environment file",
+			files: []string{
+				"testdata/findImporters/environments/lib-imports-environment/config.jsonnet",
+			},
+			expectedImporters: []string{
+				absPath(t, "testdata/findImporters/environments/lib-imports-environment/main.jsonnet"),
+				absPath(t, "testdata/findImporters/environments/uses-lib-that-imports-env/main.jsonnet"),
+			},
+		},
+		{
+			name: "complex transitive chain: env1 -> lib1 -> env2 -> lib3 -> env3",
+			files: []string{
+				"testdata/findImporters/environments/chain-env1/config.jsonnet",
+			},
+			expectedImporters: []string{
+				absPath(t, "testdata/findImporters/environments/chain-env1/main.jsonnet"), // direct env importer
+				absPath(t, "testdata/findImporters/environments/chain-env2/main.jsonnet"), // via lib1
+				absPath(t, "testdata/findImporters/environments/chain-env3/main.jsonnet"), // via lib1->env2->lib3
+			},
+		},
 	}
 }
 

--- a/pkg/jsonnet/testdata/findImporters/environments/chain-env1/config.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/chain-env1/config.jsonnet
@@ -1,0 +1,4 @@
+{
+  database: "postgres://env1-db/data",
+  feature_flag: "enabled"
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/chain-env1/main.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/chain-env1/main.jsonnet
@@ -1,0 +1,4 @@
+{
+  name: "env1",
+  config: "original-config"
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/chain-env2/main.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/chain-env2/main.jsonnet
@@ -1,0 +1,9 @@
+local lib1 = import 'chain-lib1/main.libsonnet';
+
+{
+  // env2 imports lib1
+  name: "env2",
+  inherited_config: lib1.processedConfig + {
+    enhanced_by: "env2"
+  }
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/chain-env3/main.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/chain-env3/main.jsonnet
@@ -1,0 +1,9 @@
+local lib3 = import 'chain-lib3/main.libsonnet';
+
+{
+  // env3 imports lib3
+  name: "env3",
+  final_result: lib3.importedFromEnv2 + {
+    finalized_by: "env3"
+  }
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/lib-imports-environment/config.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/lib-imports-environment/config.jsonnet
@@ -1,0 +1,4 @@
+{
+  shared_config: "environment-specific-value",
+  database_url: "postgres://localhost/test"
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/lib-imports-environment/main.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/lib-imports-environment/main.jsonnet
@@ -1,0 +1,6 @@
+{
+  environment: "test-environment",
+  config: {
+    value: 42
+  }
+}

--- a/pkg/jsonnet/testdata/findImporters/environments/uses-lib-that-imports-env/main.jsonnet
+++ b/pkg/jsonnet/testdata/findImporters/environments/uses-lib-that-imports-env/main.jsonnet
@@ -1,0 +1,6 @@
+local lib = import 'lib-imports-environment/main.libsonnet';
+
+{
+  // This environment uses a lib that imports from another environment
+  result: lib.environment_config
+}

--- a/pkg/jsonnet/testdata/findImporters/lib/chain-lib1/main.libsonnet
+++ b/pkg/jsonnet/testdata/findImporters/lib/chain-lib1/main.libsonnet
@@ -1,0 +1,6 @@
+{
+  // lib1 imports env1
+  processedConfig: (import '../../environments/chain-env1/config.jsonnet') + {
+    processed_by: "lib1"
+  }
+}

--- a/pkg/jsonnet/testdata/findImporters/lib/chain-lib3/main.libsonnet
+++ b/pkg/jsonnet/testdata/findImporters/lib/chain-lib3/main.libsonnet
@@ -1,0 +1,6 @@
+{
+  // lib3 imports env2
+  importedFromEnv2: (import '../../environments/chain-env2/main.jsonnet') + {
+    processed_by: "lib3"
+  }
+}

--- a/pkg/jsonnet/testdata/findImporters/lib/lib-imports-environment/main.libsonnet
+++ b/pkg/jsonnet/testdata/findImporters/lib/lib-imports-environment/main.libsonnet
@@ -1,0 +1,8 @@
+{
+  // This lib file imports from an environment directory. So when we look for
+  // the importers of `config.jsonnet` we should find environments that import
+  // this file - those are the ones that need to be re-exported.
+  environment_config: (import '../../environments/lib-imports-environment/config.jsonnet') + {
+    lib_enhancement: 'added by lib',
+  },
+}


### PR DESCRIPTION
This is not a good practice, but nevertheless Tanka does allow it. We're seeing in our environment that we have situations like:

```jsonnet
{
    foo: 'bar',
}
```

```jsonnet
import ('../../env1/main.jsonnet');
```

```jsonnet
import('lib1/main.libsonnet');
```

Now, in this situation, when `env1` is modified, we also need to ensure that `env2` is exported. If we don't, then we have drift and there are changes which aren't applied until some time later.

As far as I can tell, this restriction was a performance optimisation to avoid searching too many files. I've tested this a fair bit and it doesn't seem to cause a noticeable performance degradation. One reason might be that we have all Jsonnet files in memory already, in the `jsonnetFiles` cache object. So it may not really be very costly to perform more lookups.
