### PR TITLE
chore: prevent yaml.v2 update to v3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -133,6 +133,12 @@
         'helm',
       ],
       allowedVersions: '<4.0.0',
-    }
+    },
+    {
+      matchPackageNames: [
+        'gopkg.in/yaml.v2',
+      ],
+      allowedVersions: '<3.0.0',
+    },
   ],
 }


### PR DESCRIPTION
Part of https://github.com/grafana/tanka/issues/1749