### PR TITLE
chore: pin alpine container to patch level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY . .
 RUN make static
 
 # assemble final container
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --no-cache coreutils diffutils less git openssh-client && \
     apk upgrade --quiet
 COPY --from=build /app/tk /usr/local/bin/tk


### PR DESCRIPTION
This should make updates by renovate more readable as most updates will affect at least the patch level alongside the sha.