### PR TITLE
fix(tanka): normalise entrypoint path for jsonnet import on Windows

### DIFF
--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -3,6 +3,7 @@ package tanka
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -11,6 +12,32 @@ import (
 	"github.com/grafana/tanka/pkg/jsonnet/implementations/types"
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 )
+
+// buildEvalScript constructs the jsonnet snippet that wraps the user's
+// EvalScript around an `import` of the entrypoint. The entrypoint is
+// normalised to forward slashes so Windows paths (e.g. `C:\proj\main.jsonnet`)
+// do not produce invalid jsonnet escape sequences when embedded in a
+// single-quoted string literal. See grafana/tanka#551.
+func buildEvalScript(entrypoint, evalScript string, tlas []string, isFunction bool) string {
+	entrypoint = filepath.ToSlash(entrypoint)
+	if isFunction {
+		tlaParams := strings.Join(tlas, ", ")
+		tlaArgs := make([]string, len(tlas))
+		for i, k := range tlas {
+			tlaArgs[i] = k + "=" + k
+		}
+		tlaArgsJoin := strings.Join(tlaArgs, ", ")
+		return fmt.Sprintf(`
+function(%s)
+  local main = (import '%s')(%s);
+  %s
+`, tlaParams, entrypoint, tlaArgsJoin, evalScript)
+	}
+	return fmt.Sprintf(`
+  local main = (import '%s');
+  %s
+`, entrypoint, evalScript)
+}
 
 // EvalJsonnet evaluates the jsonnet environment at the given file system path
 func evalJsonnet(ctx context.Context, path string, impl types.JsonnetImplementation, opts jsonnet.Opts) (raw string, err error) {
@@ -22,27 +49,16 @@ func evalJsonnet(ctx context.Context, path string, impl types.JsonnetImplementat
 	// evaluate Jsonnet
 	if opts.EvalScript != "" {
 		// Determine if the entrypoint is a function.
-		isFunction, err := jsonnet.Evaluate(ctx, path, impl, fmt.Sprintf("std.isFunction(import '%s')", entrypoint), opts)
+		isFunctionProbe := fmt.Sprintf("std.isFunction(import '%s')", filepath.ToSlash(entrypoint))
+		isFunction, err := jsonnet.Evaluate(ctx, path, impl, isFunctionProbe, opts)
 		if err != nil {
 			return "", fmt.Errorf("evaluating jsonnet in path '%s': %w", path, err)
 		}
-		var tla []string
+		var tlas []string
 		for k := range opts.TLACode {
-			tla = append(tla, k+"="+k)
+			tlas = append(tlas, k)
 		}
-		evalScript := fmt.Sprintf(`
-  local main = (import '%s');
-  %s
-`, entrypoint, opts.EvalScript)
-
-		if isFunction == "true\n" {
-			tlaJoin := strings.Join(tla, ", ")
-			evalScript = fmt.Sprintf(`
-function(%s)
-  local main = (import '%s')(%s);
-  %s
-`, tlaJoin, entrypoint, tlaJoin, opts.EvalScript)
-		}
+		evalScript := buildEvalScript(entrypoint, opts.EvalScript, tlas, isFunction == "true\n")
 
 		raw, err = jsonnet.Evaluate(ctx, path, impl, evalScript, opts)
 		if err != nil {

--- a/pkg/tanka/evaluators.go
+++ b/pkg/tanka/evaluators.go
@@ -3,7 +3,6 @@ package tanka
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -13,13 +12,19 @@ import (
 	"github.com/grafana/tanka/pkg/jsonnet/jpath"
 )
 
+// normaliseImportPath replaces backslashes with forward slashes so Windows
+// paths (e.g. `C:\proj\main.jsonnet`) do not produce invalid escape sequences
+// when embedded in a jsonnet string literal. This is done unconditionally
+// rather than via filepath.ToSlash because the latter is host-OS dependent
+// and would be a no-op on non-Windows CI. See grafana/tanka#551.
+func normaliseImportPath(p string) string {
+	return strings.ReplaceAll(p, `\`, `/`)
+}
+
 // buildEvalScript constructs the jsonnet snippet that wraps the user's
-// EvalScript around an `import` of the entrypoint. The entrypoint is
-// normalised to forward slashes so Windows paths (e.g. `C:\proj\main.jsonnet`)
-// do not produce invalid jsonnet escape sequences when embedded in a
-// single-quoted string literal. See grafana/tanka#551.
+// EvalScript around an `import` of the entrypoint.
 func buildEvalScript(entrypoint, evalScript string, tlas []string, isFunction bool) string {
-	entrypoint = filepath.ToSlash(entrypoint)
+	entrypoint = normaliseImportPath(entrypoint)
 	if isFunction {
 		tlaParams := strings.Join(tlas, ", ")
 		tlaArgs := make([]string, len(tlas))
@@ -49,7 +54,7 @@ func evalJsonnet(ctx context.Context, path string, impl types.JsonnetImplementat
 	// evaluate Jsonnet
 	if opts.EvalScript != "" {
 		// Determine if the entrypoint is a function.
-		isFunctionProbe := fmt.Sprintf("std.isFunction(import '%s')", filepath.ToSlash(entrypoint))
+		isFunctionProbe := fmt.Sprintf("std.isFunction(import '%s')", normaliseImportPath(entrypoint))
 		isFunction, err := jsonnet.Evaluate(ctx, path, impl, isFunctionProbe, opts)
 		if err != nil {
 			return "", fmt.Errorf("evaluating jsonnet in path '%s': %w", path, err)

--- a/pkg/tanka/evaluators_test.go
+++ b/pkg/tanka/evaluators_test.go
@@ -110,3 +110,24 @@ func TestTlaWithNonFunction(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, json)
 }
+
+func TestBuildEvalScript_WindowsPath(t *testing.T) {
+	got := buildEvalScript(`C:\Users\foo\bar\main.jsonnet`, "main", nil, false)
+
+	assert.Contains(t, got, `import 'C:/Users/foo/bar/main.jsonnet'`,
+		"entrypoint backslashes must be converted to forward slashes")
+}
+
+func TestBuildEvalScript_Function(t *testing.T) {
+	tlas := []string{"foo", "bar"}
+	got := buildEvalScript(`C:\proj\main.jsonnet`, "main", tlas, true)
+
+	assert.Contains(t, got, `function(foo, bar)`)
+	assert.Contains(t, got, `import 'C:/proj/main.jsonnet'`)
+	assert.Contains(t, got, `(foo=foo, bar=bar)`)
+}
+
+func TestBuildEvalScript_UnixPathUnchanged(t *testing.T) {
+	got := buildEvalScript(`/home/user/proj/main.jsonnet`, "main", nil, false)
+	assert.Contains(t, got, `import '/home/user/proj/main.jsonnet'`)
+}


### PR DESCRIPTION
## Summary

Fixes #551.

On Windows, `tk` commands that build an `EvalScript` (`tk diff`, `tk export`, `tk show` with `--name` or `--tla-str`) embed an absolute Windows path into a single-quoted jsonnet `import '...'` string. Backslash sequences like `\d`, `\g`, `\p`, `\U` are then parsed as jsonnet string escapes and fail with:

```
Unknown escape sequence: \d
```

## Fix

Extract a small `buildEvalScript` helper in `pkg/tanka/evaluators.go` and run the entrypoint path through `filepath.ToSlash` before embedding it. The `std.isFunction(import '...')` probe used to decide whether the entrypoint is a top-level function is normalised the same way.

`filepath.ToSlash` is OS-aware: on Windows it converts `\` to `/`, on POSIX it's a no-op, so the behaviour on Linux/macOS is unchanged. go-jsonnet's `FileImporter` accepts forward-slash paths on Windows.

## Testing

- New unit tests in `evaluators_test.go` cover the Windows path case, the function-entrypoint TLA wrapping, and the POSIX no-op case. They run on Linux CI because `buildEvalScript` is a pure function.
- Full `go test ./...` is green locally on Windows; before the fix, the existing `TestEval*` tests already reproduced #551 because `testdata/` paths resolve to `C:\dev\tanka\pkg\tanka\testdata\...`.
- End-to-end: ran `tk export` against a real tanka config on Windows. Baseline (`upstream/main`) reproduces `Unknown escape sequence: \d`; the fix branch exports 28 manifests successfully.

## Compatibility

No behaviour change on Linux/macOS. No new flags. No dependency changes.

## Test plan

- [x] `go test ./pkg/tanka/...` passes on Windows
- [x] `go build ./...` passes
- [x] `tk export` succeeds against a real env on Windows (baseline fails, fix passes)
- [ ] CI checks green on the PR