### PR TITLE
feat(prune): add --target flag support to tk prune

### DIFF
--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -135,7 +135,6 @@ func pruneCmd(ctx context.Context) *cli.Command {
 	}
 
 	var opts tanka.PruneOpts
-	cmd.Flags().StringVar(&opts.Name, "name", "", "string that only a single inline environment contains in its name")
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", "", "limit pruning to a single namespace")
 	var (
 		autoApproveDeprecated bool
@@ -143,6 +142,7 @@ func pruneCmd(ctx context.Context) *cli.Command {
 	)
 	addApplyFlags(cmd.Flags(), &opts.ApplyBaseOpts, &autoApproveDeprecated, &autoApproveString)
 	addDiffFlags(cmd.Flags(), &opts.DiffBaseOpts)
+	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 
 	cmd.Run = func(_ *cli.Command, args []string) error {
@@ -159,7 +159,14 @@ func pruneCmd(ctx context.Context) *cli.Command {
 			return err
 		}
 
+		filters, err := process.StrExps(vars.targets...)
+		if err != nil {
+			return err
+		}
+		opts.Filters = filters
 		opts.JsonnetOpts = getJsonnetOpts()
+		opts.Name = vars.name
+		opts.JsonnetImplementation = vars.jsonnetImplementation
 
 		return tanka.Prune(ctx, args[0], opts)
 	}

--- a/docs/src/content/docs/garbage-collection.md
+++ b/docs/src/content/docs/garbage-collection.md
@@ -35,3 +35,30 @@ Once added, run a `tk apply`, make sure the label is actually added and confirm
 by typing `yes`.
 
 From now on, you can use `tk prune` to remove old resources from your cluster. You can also limit pruning to a single namespace, with `tk prune --namespace <my-namespace>`.
+
+## Filtering pruned resources
+
+By default `tk prune` considers every resource kind labeled with the
+environment. In large environments this can be expensive because it must list
+every resource type from the Kubernetes API.
+
+You can restrict pruning to a specific subset of resources using the `--target`
+(`-t`) flag, which accepts the same `kind/name` regex syntax as the other
+workflow commands:
+
+```bash
+# prune only orphaned StatefulSets
+tk prune -t 'statefulset/.*' .
+
+# prune only StatefulSets whose names start with "live-store"
+tk prune -t 'statefulset/live-store.*' .
+
+# prune everything except Deployments
+tk prune -t '!deployment/.*' .
+```
+
+When a literal kind name is given (no regex metacharacters in the kind
+position), Tanka restricts the Kubernetes API query to only that resource type,
+avoiding the cost of listing every other kind.
+
+See [Output filtering](/output-filtering) for the full filter syntax.

--- a/pkg/kubernetes/apply.go
+++ b/pkg/kubernetes/apply.go
@@ -22,14 +22,24 @@ func (k *Kubernetes) Apply(state manifest.List, opts ApplyOpts) error {
 // AnnoationLastApplied is the last-applied-configuration annotation used by kubectl
 const AnnotationLastApplied = "kubectl.kubernetes.io/last-applied-configuration"
 
-// OrphanedOpts allow to specify additional parameters for finding orphaned resources
+// OrphanedOpts configures the behaviour of Orphaned.
 type OrphanedOpts struct {
 	// Namespace limits the search to a single namespace. Empty string searches all namespaces.
 	Namespace string
+
+	// Filters restricts both the resource kinds queried from the cluster and
+	// the resources returned. Uses the same kind/name regex syntax as the
+	// --target flag on tk apply. When empty, all resource kinds labeled with
+	// the environment are considered.
+	Filters process.Matchers
 }
 
 // Orphaned returns previously created resources that are missing from the
 // local state. It uses UIDs to safely identify objects.
+//
+// When opts.Filters is non-empty, only resource kinds targeted by the filters
+// are queried from the cluster. This makes large-environment prune operations
+// cheaper when only a subset of kinds needs to be inspected.
 func (k *Kubernetes) Orphaned(state manifest.List, opts OrphanedOpts) (manifest.List, error) {
 	log.Info().Msg("Finding orphaned resources to prune")
 
@@ -54,9 +64,21 @@ See https://tanka.dev/garbage-collection for more details`)
 
 	var orphaned manifest.List
 
-	// Find all kinds into a comma separated string that should be checked for pruning:
+	// Determine which kinds to query. When filters are set and we can extract
+	// literal kind names from them, restrict the cluster query to only those
+	// kinds. This avoids listing every resource type in environments where only
+	// a specific kind (e.g. StatefulSet) needs pruning.
+	kindHints, hasKindHints := opts.Filters.KindsFor()
+	kindHintSet := make(map[string]bool, len(kindHints))
+	for _, hint := range kindHints {
+		kindHintSet[strings.ToLower(hint)] = true
+	}
+
+	// Find all kinds into a comma-separated string that should be checked for
+	// pruning:
 	// * support LIST operation
 	// * when namespace is set, only consider namespaced resources
+	// * when filters are set, only consider hinted kinds
 	kinds := ""
 	for _, r := range apiResources {
 		if !strings.Contains(r.Verbs, "list") {
@@ -65,7 +87,9 @@ See https://tanka.dev/garbage-collection for more details`)
 		if opts.Namespace != "" && !r.Namespaced {
 			continue
 		}
-
+		if hasKindHints && !kindHintSet[strings.ToLower(r.Kind)] {
+			continue
+		}
 		kinds += "," + r.FQN()
 	}
 	kinds = strings.TrimPrefix(kinds, ",")
@@ -106,6 +130,13 @@ See https://tanka.dev/garbage-collection for more details`)
 		resourceLog.Msg("orphaned resource")
 		orphaned = append(orphaned, m)
 		uids[m.Metadata().UID()] = true
+	}
+
+	// Apply filters to the final result so that negative filters and any
+	// name-level restrictions are enforced even when kind pre-filtering was
+	// not possible.
+	if len(opts.Filters) > 0 {
+		orphaned = process.Filter(orphaned, opts.Filters)
 	}
 
 	return orphaned, nil

--- a/pkg/kubernetes/apply_test.go
+++ b/pkg/kubernetes/apply_test.go
@@ -1,0 +1,204 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tanka/pkg/kubernetes/client"
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/grafana/tanka/pkg/process"
+	"github.com/grafana/tanka/pkg/spec/v1alpha1"
+)
+
+// fakeClient is a minimal client.Client for testing Orphaned.
+type fakeClient struct {
+	resources    client.Resources
+	byLabels     manifest.List
+	byState      manifest.List
+	byStateErr   error
+	byLabelsKind string // records the kind string passed to GetByLabels
+}
+
+func (f *fakeClient) Get(namespace, kind, name string) (manifest.Manifest, error) {
+	return nil, nil
+}
+func (f *fakeClient) Resources() (client.Resources, error) { return f.resources, nil }
+
+func (f *fakeClient) GetByLabels(namespace, kind string, labels map[string]string) (manifest.List, error) {
+	f.byLabelsKind = kind
+	return f.byLabels, nil
+}
+
+func (f *fakeClient) GetByState(data manifest.List, opts client.GetByStateOpts) (manifest.List, error) {
+	return f.byState, f.byStateErr
+}
+
+func (f *fakeClient) Apply(data manifest.List, opts client.ApplyOpts) error { return nil }
+func (f *fakeClient) DiffServerSide(data manifest.List) (*string, error)    { return nil, nil }
+func (f *fakeClient) DiffExitCode(data manifest.List) (bool, error)         { return false, nil }
+func (f *fakeClient) Delete(namespace, apiVersion, kind, name string, opts client.DeleteOpts) error {
+	return nil
+}
+func (f *fakeClient) Namespaces() (map[string]bool, error)           { return nil, nil }
+func (f *fakeClient) Namespace(ns string) (manifest.Manifest, error) { return nil, nil }
+func (f *fakeClient) Info() client.Info {
+	return client.Info{ClientVersion: semver.MustParse("1.22.0")}
+}
+func (f *fakeClient) Close() error { return nil }
+
+// testEnv returns a minimal environment suitable for Orphaned tests.
+func testEnv() v1alpha1.Environment {
+	return v1alpha1.Environment{
+		Metadata: v1alpha1.Metadata{Name: "default/test"},
+		Spec: v1alpha1.Spec{
+			InjectLabels: true,
+		},
+	}
+}
+
+// orphanedManifest builds a manifest that looks as though it was directly
+// applied by Tanka: it carries the last-applied annotation.
+func orphanedManifest(kind, name, uid string) manifest.Manifest {
+	return manifest.Manifest{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+			"uid":       uid,
+			"annotations": map[string]any{
+				AnnotationLastApplied: "{}",
+			},
+		},
+	}
+}
+
+// appsResources returns a standard set of apps/v1 API resources for tests.
+// Name is the plural resource name used to build the FQN (e.g. "statefulsets.apps").
+func appsResources() client.Resources {
+	return client.Resources{
+		{APIVersion: "apps/v1", Kind: "StatefulSet", Name: "statefulsets", Namespaced: true, Verbs: "list,get"},
+		{APIVersion: "apps/v1", Kind: "Deployment", Name: "deployments", Namespaced: true, Verbs: "list,get"},
+	}
+}
+
+func TestOrphaned_NoFilters(t *testing.T) {
+	sts := orphanedManifest("StatefulSet", "old-store", "uid-1")
+	dep := orphanedManifest("Deployment", "old-app", "uid-2")
+
+	fc := &fakeClient{
+		resources: appsResources(),
+		byState:   manifest.List{},
+		byLabels:  manifest.List{sts, dep},
+	}
+
+	k := &Kubernetes{Env: testEnv(), ctl: fc}
+	orphaned, err := k.Orphaned(manifest.List{}, OrphanedOpts{})
+	require.NoError(t, err)
+
+	assert.Len(t, orphaned, 2)
+	// With no filters both FQNs are included in the cluster query.
+	assert.Contains(t, fc.byLabelsKind, "statefulsets.apps")
+	assert.Contains(t, fc.byLabelsKind, "deployments.apps")
+}
+
+func TestOrphaned_FilterByKind(t *testing.T) {
+	sts := orphanedManifest("StatefulSet", "old-store", "uid-1")
+	dep := orphanedManifest("Deployment", "old-app", "uid-2")
+
+	fc := &fakeClient{
+		resources: appsResources(),
+		byState:   manifest.List{},
+		// The fake always returns byLabels regardless of the kind argument; the
+		// final process.Filter call in Orphaned ensures only StatefulSets are
+		// returned to the caller.
+		byLabels: manifest.List{sts, dep},
+	}
+
+	filters, err := process.StrExps("statefulset/.*")
+	require.NoError(t, err)
+
+	k := &Kubernetes{Env: testEnv(), ctl: fc}
+	orphaned, err := k.Orphaned(manifest.List{}, OrphanedOpts{Filters: filters})
+	require.NoError(t, err)
+
+	// Only the StatefulSet passes the final filter.
+	require.Len(t, orphaned, 1)
+	assert.Equal(t, "StatefulSet", orphaned[0].Kind())
+
+	// Kind pre-filtering: only the StatefulSet FQN was passed to GetByLabels.
+	assert.Contains(t, fc.byLabelsKind, "statefulsets.apps")
+	assert.NotContains(t, fc.byLabelsKind, "deployments.apps")
+}
+
+func TestOrphaned_FilterByKindAndName(t *testing.T) {
+	live := orphanedManifest("StatefulSet", "live-store-0", "uid-1")
+	old := orphanedManifest("StatefulSet", "old-store", "uid-2")
+
+	fc := &fakeClient{
+		resources: appsResources(),
+		byState:   manifest.List{},
+		byLabels:  manifest.List{live, old},
+	}
+
+	filters, err := process.StrExps("statefulset/old-.*")
+	require.NoError(t, err)
+
+	k := &Kubernetes{Env: testEnv(), ctl: fc}
+	orphaned, err := k.Orphaned(manifest.List{}, OrphanedOpts{Filters: filters})
+	require.NoError(t, err)
+
+	// Only old-store matches the name pattern.
+	require.Len(t, orphaned, 1)
+	assert.Equal(t, "old-store", orphaned[0].Metadata().Name())
+}
+
+func TestOrphaned_KnownResourcesNotReturned(t *testing.T) {
+	// known is still present in desired state; orphaned is not.
+	known := orphanedManifest("StatefulSet", "live-store", "uid-keep")
+	orphan := orphanedManifest("StatefulSet", "dead-store", "uid-drop")
+
+	fc := &fakeClient{
+		resources: client.Resources{
+			{APIVersion: "apps/v1", Kind: "StatefulSet", Name: "statefulsets", Namespaced: true, Verbs: "list,get"},
+		},
+		byState:  manifest.List{known},
+		byLabels: manifest.List{known, orphan},
+	}
+
+	k := &Kubernetes{Env: testEnv(), ctl: fc}
+	orphaned, err := k.Orphaned(manifest.List{known}, OrphanedOpts{})
+	require.NoError(t, err)
+
+	require.Len(t, orphaned, 1)
+	assert.Equal(t, "dead-store", orphaned[0].Metadata().Name())
+}
+
+func TestOrphaned_NegativeFilter(t *testing.T) {
+	sts := orphanedManifest("StatefulSet", "old-store", "uid-1")
+	dep := orphanedManifest("Deployment", "old-app", "uid-2")
+
+	fc := &fakeClient{
+		resources: appsResources(),
+		byState:   manifest.List{},
+		byLabels:  manifest.List{sts, dep},
+	}
+
+	// Negative filter: exclude StatefulSets from prune candidates.
+	filters, err := process.StrExps("!statefulset/.*")
+	require.NoError(t, err)
+
+	k := &Kubernetes{Env: testEnv(), ctl: fc}
+	orphaned, err := k.Orphaned(manifest.List{}, OrphanedOpts{Filters: filters})
+	require.NoError(t, err)
+
+	// Deployment survives; StatefulSet is excluded by the negative filter.
+	require.Len(t, orphaned, 1)
+	assert.Equal(t, "Deployment", orphaned[0].Kind())
+	// No positive matcher → all kinds were queried.
+	assert.Contains(t, fc.byLabelsKind, "statefulsets.apps")
+	assert.Contains(t, fc.byLabelsKind, "deployments.apps")
+}

--- a/pkg/process/filter.go
+++ b/pkg/process/filter.go
@@ -10,6 +10,10 @@ import (
 	"golang.org/x/text/language"
 )
 
+// regexMetaRe matches any regex metacharacter that would make a kind pattern
+// non-literal (i.e. not a plain alphanumeric kind name like "StatefulSet").
+var regexMetaRe = regexp.MustCompile(`[.+*?()\[\]{}|\\^$]`)
+
 // Filter returns all elements of the list that match at least one expression
 // and are not ignored
 func Filter(list manifest.List, exprs Matchers) manifest.List {
@@ -60,6 +64,74 @@ func (e Matchers) IgnoreString(s string) bool {
 		b = b || i.IgnoreString(s)
 	}
 	return b
+}
+
+// KindsFor returns the set of resource kinds that positive matchers in the
+// collection target. It is used to restrict cluster API queries to only the
+// resource types relevant to the filter set, avoiding the cost of listing
+// every resource type when only a few are needed.
+//
+// Returns (kinds, true) when all positive matchers specify a single literal
+// kind (e.g. "statefulset/.*" → "StatefulSet"). Returns (nil, false) when
+// kind restriction cannot be determined — either because no positive matchers
+// exist, a matcher uses regex metacharacters in the kind position, or the
+// matcher type is not a compiled regexp. Callers should query all resource
+// kinds when ok is false.
+func (e Matchers) KindsFor() ([]string, bool) {
+	if len(e) == 0 {
+		return nil, false
+	}
+	var kinds []string
+	hasPositive := false
+	for _, exp := range e {
+		// Negative matchers (NegMatcher) implement Ignorer; skip them here
+		// because they restrict results, not which kinds to query.
+		if _, isIgnorer := exp.(Ignorer); isIgnorer {
+			continue
+		}
+		hasPositive = true
+		r, ok := exp.(*regexp.Regexp)
+		if !ok {
+			// Unknown matcher type — be conservative and query all kinds.
+			return nil, false
+		}
+		kind, ok := kindFromFilterPattern(r.String())
+		if !ok {
+			return nil, false
+		}
+		kinds = append(kinds, kind)
+	}
+	if !hasPositive {
+		// Only negative matchers present — no kind restriction.
+		return nil, false
+	}
+	return kinds, true
+}
+
+// kindFromFilterPattern extracts the literal kind name from a regex pattern
+// produced by StrExps (format: "(?i)^<user-input>$"). Returns ("", false)
+// when the kind portion contains regex metacharacters or cannot be determined.
+func kindFromFilterPattern(pattern string) (string, bool) {
+	// Strip the anchors added by StrExps.
+	s := strings.TrimPrefix(pattern, `(?i)^`)
+	s = strings.TrimSuffix(s, `$`)
+
+	kindPart, _, hasSlash := strings.Cut(s, "/")
+	if !hasSlash {
+		// No kind/name separator: pattern like "(?i)^statefulset$".
+		// KindName() always contains a slash, so this would never match a
+		// resource anyway. Return the pattern as-is so callers can include
+		// the kind if it happens to be a literal, but it won't do harm.
+		if regexMetaRe.MatchString(s) {
+			return "", false
+		}
+		return s, true
+	}
+
+	if regexMetaRe.MatchString(kindPart) {
+		return "", false
+	}
+	return kindPart, true
 }
 
 // RegExps is a helper to construct Matchers from regular expressions

--- a/pkg/process/filter_test.go
+++ b/pkg/process/filter_test.go
@@ -1,0 +1,175 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKindsFor(t *testing.T) {
+	cases := []struct {
+		name      string
+		exprs     []string
+		wantKinds []string
+		wantOK    bool
+	}{
+		{
+			name:      "no filters",
+			exprs:     nil,
+			wantKinds: nil,
+			wantOK:    false,
+		},
+		{
+			name:      "empty filters",
+			exprs:     []string{},
+			wantKinds: nil,
+			wantOK:    false,
+		},
+		{
+			name:      "single kind with wildcard name",
+			exprs:     []string{"statefulset/.*"},
+			wantKinds: []string{"statefulset"},
+			wantOK:    true,
+		},
+		{
+			name:      "single kind with literal name",
+			exprs:     []string{"statefulset/live-store"},
+			wantKinds: []string{"statefulset"},
+			wantOK:    true,
+		},
+		{
+			name:      "single kind with name regex",
+			exprs:     []string{"statefulset/live-store.*"},
+			wantKinds: []string{"statefulset"},
+			wantOK:    true,
+		},
+		{
+			name:      "multiple kinds",
+			exprs:     []string{"statefulset/.*", "deployment/.*"},
+			wantKinds: []string{"statefulset", "deployment"},
+			wantOK:    true,
+		},
+		{
+			name:      "only negative matcher",
+			exprs:     []string{"!statefulset/.*"},
+			wantKinds: nil,
+			wantOK:    false,
+		},
+		{
+			name:      "positive and negative matcher",
+			exprs:     []string{"statefulset/.*", "!deployment/.*"},
+			wantKinds: []string{"statefulset"},
+			wantOK:    true,
+		},
+		{
+			name:      "kind with regex metachar — falls back to all",
+			exprs:     []string{"(statefulset|deployment)/.*"},
+			wantKinds: nil,
+			wantOK:    false,
+		},
+		{
+			name:      "wildcard kind — falls back to all",
+			exprs:     []string{".*/.*"},
+			wantKinds: nil,
+			wantOK:    false,
+		},
+		{
+			name:      "kind without slash",
+			exprs:     []string{"statefulset"},
+			wantKinds: []string{"statefulset"},
+			wantOK:    true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			matchers, err := StrExps(c.exprs...)
+			require.NoError(t, err)
+
+			kinds, ok := matchers.KindsFor()
+			assert.Equal(t, c.wantOK, ok)
+			assert.Equal(t, c.wantKinds, kinds)
+		})
+	}
+}
+
+// TestFilterNegationOnly protects the "prune everything except <kind>" use
+// case. A negation-only filter (e.g. "!certificate/.*") must keep every
+// resource whose kind does not match and drop the ones that do. This is the
+// behaviour tk prune relies on when Orphaned() queries all kinds (because
+// KindsFor returns ok=false for negation-only filters) and then applies the
+// filter to the results.
+func TestFilterNegationOnly(t *testing.T) {
+	list := manifest.List{
+		mkobj("Certificate", "cert-a", "default"),
+		mkobj("Deployment", "deploy-a", "default"),
+		mkobj("StatefulSet", "sts-a", "default"),
+		mkobj("Certificate", "cert-b", "default"),
+	}
+
+	filtered := Filter(list, MustStrExps("!certificate/.*"))
+
+	var gotKinds []string
+	for _, m := range filtered {
+		gotKinds = append(gotKinds, m.Kind())
+	}
+
+	// Everything except Certificate resources survives the filter.
+	assert.ElementsMatch(t, []string{"Deployment", "StatefulSet"}, gotKinds)
+}
+
+func TestKindFromFilterPattern(t *testing.T) {
+	cases := []struct {
+		name     string
+		pattern  string
+		wantKind string
+		wantOK   bool
+	}{
+		{
+			name:     "statefulset with wildcard",
+			pattern:  `(?i)^statefulset/.*$`,
+			wantKind: "statefulset",
+			wantOK:   true,
+		},
+		{
+			name:     "statefulset with name regex",
+			pattern:  `(?i)^statefulset/live-store.*$`,
+			wantKind: "statefulset",
+			wantOK:   true,
+		},
+		{
+			name:     "kind with no slash",
+			pattern:  `(?i)^statefulset$`,
+			wantKind: "statefulset",
+			wantOK:   true,
+		},
+		{
+			name:     "kind alternation falls back",
+			pattern:  `(?i)^(statefulset|deployment)/.*$`,
+			wantKind: "",
+			wantOK:   false,
+		},
+		{
+			name:     "wildcard kind falls back",
+			pattern:  `(?i)^.*/.*$`,
+			wantKind: "",
+			wantOK:   false,
+		},
+		{
+			name:     "mixed case kind",
+			pattern:  `(?i)^StatefulSet/.*$`,
+			wantKind: "StatefulSet",
+			wantOK:   true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			kind, ok := kindFromFilterPattern(c.pattern)
+			assert.Equal(t, c.wantOK, ok)
+			assert.Equal(t, c.wantKind, kind)
+		})
+	}
+}

--- a/pkg/tanka/prune.go
+++ b/pkg/tanka/prune.go
@@ -33,9 +33,10 @@ func Prune(ctx context.Context, baseDir string, opts PruneOpts) error {
 	}
 	defer kube.Close()
 
-	// find orphaned resources
+	// find orphaned resources, restricting to filtered kinds when --target is set
 	orphaned, err := kube.Orphaned(p.Resources, kubernetes.OrphanedOpts{
 		Namespace: opts.Namespace,
+		Filters:   opts.Filters,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds `--target` / `-t` to `tk prune`, bringing it in line with `tk apply`, `tk delete`, and `tk show`. See the updated `docs/garbage-collection.md` for usage and examples.

## Efficiency note

Without `--target`, `tk prune` lists every resource type that supports LIST before reconciling UIDs — expensive in environments with many CRDs. When the filter specifies a literal kind name (no regex metacharacters in the kind position), `Orphaned()` restricts the cluster query to only that resource type, avoiding the cost of listing everything else.