### PR TITLE
fix(helm): skip OCI repos in RepoUpdate

### DIFF
--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -162,12 +162,12 @@ func TestAddOCI(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = c.Add([]string{"karpenter/karpenter@v0.27.1"}, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check file contents
 	listResult, err := os.ReadDir(filepath.Join(tempDir, "charts"))
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(listResult))
+	require.NoError(t, err)
+	require.Len(t, listResult, 1)
 	assert.Equal(t, "karpenter", listResult[0].Name())
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -143,7 +143,19 @@ func (e ExecHelm) Pull(chart, version string, opts PullOpts) error {
 
 // RepoUpdate implements Helm.RepoUpdate
 func (e ExecHelm) RepoUpdate(opts Opts) error {
-	repoFile, err := writeRepoTmpFile(opts.Repositories)
+	// OCI registries do not use the traditional `helm repo update` mechanism;
+	// they are pulled directly by URL, so skip them here.
+	var repos []Repo
+	for _, r := range opts.Repositories {
+		if !strings.HasPrefix(r.URL, "oci://") {
+			repos = append(repos, r)
+		}
+	}
+	if len(repos) == 0 {
+		return nil
+	}
+
+	repoFile, err := writeRepoTmpFile(repos)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`RepoUpdate` passes all repos to `helm repo update` including OCI ones - that straight up fails since OCI registries dont use the index-based update flow. `Pull` already handles this correctly by special-casing `oci://` URLs, `RepoUpdate` was just missing the same treatment. Filter them out, return early if nothing's left.

Also `TestAddOCI` was panicking (`index out of range [0] with length 0`) because `assert` is non-fatal and continued into `listResult[0]` after a failed check. Switched to `require` to fail fast.

Reproduce (panics before this fix):
```
go test ./pkg/helm/... -run TestAddOCI
```