### PR TITLE
fix(security): update helm version to 3.21.2 to pull vulnerability patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache git make bash &&\
 
 FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS helm
 WORKDIR /tmp/helm
-ARG HELM_VERSION=3.19.2
+ARG HELM_VERSION=3.21.2
 RUN apk add --no-cache jq curl
 RUN export OS=$(go env GOOS) && \
     export ARCH=$(go env GOARCH) &&\


### PR DESCRIPTION
Action for Platform Productivity owned CVES: https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/16

This PR targets critical/high vulns found patched in 3.21.2

| Dependency | Before (helm 3.19.2) | After (helm 3.21.2) | Result |
  |---|---|---|---|
  | golang.org/x/crypto | 0.43.0 | **0.53.0** | ✓ all 13 (incl. 4× CRIT 9.1) |
  | golang.org/x/net | 0.45.0 | **0.55.0** | ✓ all 7 |
  | stdlib | go1.24.9 | **go1.26.4** | ✓ all 29 (incl. CRIT 10.0 CVE-2025-68121, CRIT 9.8 CVE-2026-27143) |
  | google.golang.org/grpc | 1.72.1 | **1.80.0** | ✓ CVE-2026-33186 (CRIT 9.1) |
  | github.com/moby/spdystream | 0.5.0 | **removed** | ✓ CVE-2026-35469 (HIGH 8.7) |
  | golang.org/x/sys | 0.37.0 | **0.46.0** | ✓ CVE-2026-39824 (LOW) |
  | github.com/containerd/containerd | 1.7.29 | **1.7.32** | Partial |


containerd 1.7.32 fixes CVE-2026-46680 (HIGH) but not `CVE-2026-53488` (HIGH 8.7) or `CVE-2026-47262` (MED) — those need 1.7.33 which no helm 3.x release ships yet.