### PR TITLE
fix(kubernetes): clarify missing kubeconfig errors

### DIFF
--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -191,6 +191,10 @@ func tryMSISlice(v *objx.Value, what string) ([]map[string]interface{}, error) {
 		return s, nil
 	}
 
+	if v.Data() == nil {
+		return nil, ErrorMissingKubeconfigSection(what)
+	}
+
 	data, ok := v.Data().([]map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("expected %s to be of type `[]map[string]interface{}`, but got `%T` instead", what, v.Data())

--- a/pkg/kubernetes/client/context_test.go
+++ b/pkg/kubernetes/client/context_test.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/objx"
+)
+
+func TestTryMSISliceMissingKubeconfigSection(t *testing.T) {
+	_, err := tryMSISlice(objx.New(map[string]interface{}{}).Get("clusters"), "clusters")
+	if err == nil {
+		t.Fatal("expected missing kubeconfig section error")
+	}
+
+	var missing ErrorMissingKubeconfigSection
+	if !errors.As(err, &missing) {
+		t.Fatalf("expected ErrorMissingKubeconfigSection, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "$KUBECONFIG") {
+		t.Fatalf("expected KUBECONFIG hint, got %q", err.Error())
+	}
+}

--- a/pkg/kubernetes/client/errors.go
+++ b/pkg/kubernetes/client/errors.go
@@ -35,6 +35,14 @@ func (e ErrorNoCluster) Error() string {
 	return fmt.Sprintf("no cluster that matches the apiServer `%s` was found. Please check your $KUBECONFIG", string(e))
 }
 
+// ErrorMissingKubeconfigSection means that kubectl returned an empty or
+// incomplete kubeconfig, usually because no kubeconfig file could be found.
+type ErrorMissingKubeconfigSection string
+
+func (e ErrorMissingKubeconfigSection) Error() string {
+	return fmt.Sprintf("no %s found in Kubernetes config. Please set $KUBECONFIG or create a kubeconfig at $HOME/.kube/config", string(e))
+}
+
 // ErrorNothingReturned means that there was no output returned
 type ErrorNothingReturned struct{}
 


### PR DESCRIPTION
## Summary

Improve the error message shown when kubeconfig sections are missing, which commonly happens when neither `$KUBECONFIG` nor the default kubeconfig file exists.

## Related Issue

Fixes #500

## Changes

- Add a specific missing-kubeconfig-section error with a `$KUBECONFIG` hint.
- Return that error when kubeconfig sections such as `clusters` are absent.
- Add a focused unit test for the missing section case.

## Testing

- [x] `docker run --rm -v "$PWD":/src -w /src golang:1.26.4 go test ./pkg/kubernetes/client`
- [x] `git diff --check`

## Notes

The host environment did not have Go installed, so I ran the targeted package test in the official Go 1.26.4 Docker image.