### PR TITLE
feat: add --inject-label flag to apply, diff, show and export

### DIFF
--- a/cmd/tk/export.go
+++ b/cmd/tk/export.go
@@ -47,6 +47,7 @@ func exportCmd(ctx context.Context) *cli.Command {
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
 	getLabelSelector := labelSelectorFlag(cmd.Flags())
+	getInjectLabels := injectLabelFlag(cmd.Flags())
 
 	recursive := cmd.Flags().BoolP("recursive", "r", false, "Look recursively for Tanka environments")
 
@@ -71,6 +72,7 @@ func exportCmd(ctx context.Context) *cli.Command {
 				JsonnetOpts:           getJsonnetOpts(),
 				Filters:               filters,
 				Name:                  vars.name,
+				InjectLabels:          getInjectLabels(),
 			},
 			Selector:         getLabelSelector(),
 			Parallelism:      *parallel,

--- a/cmd/tk/flags.go
+++ b/cmd/tk/flags.go
@@ -75,6 +75,24 @@ func jsonnetFlags(fs *pflag.FlagSet) func() tanka.JsonnetOpts {
 	}
 }
 
+func injectLabelFlag(fs *pflag.FlagSet) func() map[string]string {
+	// need to use StringArray instead of StringSlice, because pflag attempts to
+	// parse StringSlice using the csv parser, which breaks when values contain commas
+	injectLabels := fs.StringArray("inject-label", nil, "Inject a label into all rendered resources (Format: key=value). Can be repeated. Overrides existing values.")
+
+	return func() map[string]string {
+		m := make(map[string]string)
+		for _, s := range *injectLabels {
+			split := strings.SplitN(s, "=", 2)
+			if len(split) != 2 {
+				log.Fatal().Msgf("--inject-label argument has wrong format: `%s`. Expected `key=value`", s)
+			}
+			m[split[0]] = split[1]
+		}
+		return m
+	}
+}
+
 func cliCodeParser(fs *pflag.FlagSet) (func() map[string]string, func() map[string]string) {
 	// need to use StringArray instead of StringSlice, because pflag attempts to
 	// parse StringSlice using the csv parser, which breaks when passing objects

--- a/cmd/tk/workflow.go
+++ b/cmd/tk/workflow.go
@@ -95,6 +95,7 @@ func applyCmd(ctx context.Context) *cli.Command {
 	addDiffFlags(cmd.Flags(), &opts.DiffBaseOpts)
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
+	getInjectLabels := injectLabelFlag(cmd.Flags())
 
 	cmd.Run = func(_ *cli.Command, args []string) error {
 		ctx, span := tracer.Start(ctx, "applyCmd")
@@ -118,6 +119,7 @@ func applyCmd(ctx context.Context) *cli.Command {
 		opts.JsonnetOpts = getJsonnetOpts()
 		opts.Name = vars.name
 		opts.JsonnetImplementation = vars.jsonnetImplementation
+		opts.InjectLabels = getInjectLabels()
 
 		return tanka.Apply(ctx, args[0], opts)
 	}
@@ -236,6 +238,7 @@ func diffCmd(ctx context.Context) *cli.Command {
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
+	getInjectLabels := injectLabelFlag(cmd.Flags())
 
 	cmd.Run = func(_ *cli.Command, args []string) error {
 		ctx, span := tracer.Start(ctx, "diffCmd")
@@ -251,6 +254,7 @@ func diffCmd(ctx context.Context) *cli.Command {
 		opts.JsonnetOpts = getJsonnetOpts()
 		opts.Name = vars.name
 		opts.JsonnetImplementation = vars.jsonnetImplementation
+		opts.InjectLabels = getInjectLabels()
 
 		changes, err := tanka.Diff(ctx, args[0], opts)
 		if err != nil {
@@ -304,6 +308,7 @@ func showCmd(ctx context.Context) *cli.Command {
 
 	vars := workflowFlags(cmd.Flags())
 	getJsonnetOpts := jsonnetFlags(cmd.Flags())
+	getInjectLabels := injectLabelFlag(cmd.Flags())
 
 	cmd.Run = func(_ *cli.Command, args []string) error {
 		ctx, span := tracer.Start(ctx, "showCmd")
@@ -332,6 +337,7 @@ to bypass this check.`)
 			Filters:               filters,
 			Name:                  vars.name,
 			JsonnetImplementation: vars.jsonnetImplementation,
+			InjectLabels:          getInjectLabels(),
 		})
 
 		if err != nil {

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -66,3 +66,20 @@ local tk = import "tk";
   labels: tk.env.metadata.labels,
 }
 ```
+
+## Injecting labels from the command line
+
+`tk apply`, `tk diff`, `tk show` and `tk export` accept a `--inject-label
+key=value` flag that sets a label on **every** rendered resource. Unlike
+`spec.resourceDefaults.labels` (which only fills in missing keys), an injected
+label always overrides any pre-existing value. The flag can be repeated to set
+multiple labels:
+
+```console
+$ tk apply environments/default --inject-label created-by=alice --inject-label team=infra
+```
+
+This is handy for ad-hoc identification of the resources a given run touched,
+without changing the Environment's `spec.json`. Note this is unrelated to the
+`spec.injectLabels` boolean, which only toggles the `tanka.dev/environment`
+label used by garbage collection.

--- a/pkg/process/inject_test.go
+++ b/pkg/process/inject_test.go
@@ -1,0 +1,82 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/grafana/tanka/pkg/kubernetes/manifest"
+)
+
+func TestInjectLabels(t *testing.T) {
+	cases := []struct {
+		name           string
+		beforeLabels   map[string]string
+		injectLabels   map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name: "No labels is a no-op",
+		},
+		{
+			name:           "Add label",
+			injectLabels:   map[string]string{"a": "b"},
+			expectedLabels: map[string]string{"a": "b"},
+		},
+		{
+			name:           "Add multiple labels",
+			injectLabels:   map[string]string{"a": "b", "c": "d"},
+			expectedLabels: map[string]string{"a": "b", "c": "d"},
+		},
+		{
+			name:           "Add leaves unrelated labels",
+			beforeLabels:   map[string]string{"1": "2"},
+			injectLabels:   map[string]string{"a": "b"},
+			expectedLabels: map[string]string{"a": "b", "1": "2"},
+		},
+		{
+			// Unlike ResourceDefaults, injected labels override existing values.
+			name:           "Injected labels override existing",
+			beforeLabels:   map[string]string{"a": "c", "1": "2"},
+			injectLabels:   map[string]string{"a": "b"},
+			expectedLabels: map[string]string{"a": "b", "1": "2"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			before := manifest.Manifest{
+				"kind": "Deployment",
+			}
+			for k, v := range c.beforeLabels {
+				before.Metadata().Labels()[k] = v
+			}
+
+			expected := manifest.Metadata{}
+			for k, v := range c.expectedLabels {
+				expected.Labels()[k] = v
+			}
+
+			result := InjectLabels(manifest.List{before}, c.injectLabels)
+			actual := result[0]
+			if diff := cmp.Diff(expected, actual.Metadata()); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestInjectLabelsAllManifests(t *testing.T) {
+	list := manifest.List{
+		{"kind": "Deployment"},
+		{"kind": "Service"},
+	}
+
+	result := InjectLabels(list, map[string]string{"created-by": "tester"})
+
+	for _, m := range result {
+		if got := m.Metadata().Labels()["created-by"]; got != "tester" {
+			t.Errorf("expected label on every manifest, %s has %v", m.Kind(), got)
+		}
+	}
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -103,6 +103,20 @@ func ResourceDefaults(list manifest.List, cfg v1alpha1.Environment) manifest.Lis
 	return list
 }
 
+// InjectLabels sets the given labels on every manifest in the list, overriding
+// any pre-existing values. Unlike ResourceDefaults (which only fills in missing
+// keys from the spec), these labels are explicitly requested (e.g. via
+// --inject-label) and therefore always win.
+func InjectLabels(list manifest.List, labels map[string]string) manifest.List {
+	for i, m := range list {
+		for k, v := range labels {
+			m.Metadata().Labels()[k] = v
+		}
+		list[i] = m
+	}
+	return list
+}
+
 // Unwrap returns all Kubernetes objects in the manifest. If m is not a List
 // type, a one item List is returned
 func Unwrap(manifests map[string]manifest.Manifest) error {

--- a/pkg/tanka/export.go
+++ b/pkg/tanka/export.go
@@ -200,7 +200,7 @@ func manifestSingleEnv(ctx context.Context, work *v1alpha1.Environment, to strin
 
 	fileToEnv := make(map[string]string)
 
-	loaded, err := LoadManifests(ctx, work, opts.Opts.Filters)
+	loaded, err := LoadManifests(ctx, work, opts.Opts.Filters, opts.Opts.InjectLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tanka/load.go
+++ b/pkg/tanka/load.go
@@ -34,7 +34,7 @@ func Load(ctx context.Context, path string, opts Opts) (*LoadResult, error) {
 		return nil, err
 	}
 
-	result, err := LoadManifests(ctx, env, opts.Filters)
+	result, err := LoadManifests(ctx, env, opts.Filters, opts.InjectLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func LoadEnvironment(ctx context.Context, path string, opts Opts) (*v1alpha1.Env
 	return env, nil
 }
 
-func LoadManifests(_ context.Context, env *v1alpha1.Environment, filters process.Matchers) (*LoadResult, error) {
+func LoadManifests(_ context.Context, env *v1alpha1.Environment, filters process.Matchers, injectLabels map[string]string) (*LoadResult, error) {
 	if err := checkVersion(env.Spec.ExpectVersions.Tanka); err != nil {
 		return nil, err
 	}
@@ -84,6 +84,10 @@ func LoadManifests(_ context.Context, env *v1alpha1.Environment, filters process
 	processed, err := process.Process(*env, filters)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(injectLabels) > 0 {
+		processed = process.InjectLabels(processed, injectLabels)
 	}
 
 	return &LoadResult{Env: env, Resources: processed}, nil

--- a/pkg/tanka/tanka.go
+++ b/pkg/tanka/tanka.go
@@ -26,6 +26,11 @@ type Opts struct {
 
 	// Name is used to extract a single environment from multiple environments
 	Name string
+
+	// InjectLabels are labels to set on every rendered resource (e.g. via
+	// --inject-label). They override any pre-existing values. This is distinct
+	// from Spec.InjectLabels (a bool toggling the tanka.dev/environment label).
+	InjectLabels map[string]string
 }
 
 // defaultDevVersion is the placeholder version used when no actual semver is


### PR DESCRIPTION
Adds a repeatable `--inject-label key=value` flag to `tk apply`, `diff`, `show` and `export`.

The flag sets the given label on every rendered resource, overriding any pre-existing value. This makes it easy to identify, in a cluster, which resources a given run touched (e.g. `--inject-label created-by=alice`) without having to edit the Environment's `spec.json`.

It is intentionally distinct from `spec.injectLabels` (the boolean toggling the `tanka.dev/environment` label) and from `spec.resourceDefaults.labels` (which only fills in missing keys). Labels are injected at the single `LoadManifests` chokepoint, so all four commands behave consistently.