### PR TITLE
Improve error messages for missing or empty kubeconfig

### DIFF
--- a/pkg/kubernetes/client/context.go
+++ b/pkg/kubernetes/client/context.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -191,11 +192,43 @@ func tryMSISlice(v *objx.Value, what string) ([]map[string]interface{}, error) {
 		return s, nil
 	}
 
+	if v.Data() == nil {
+		return nil, makeKubeconfigError(what)
+	}
+
 	data, ok := v.Data().([]map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("expected %s to be of type `[]map[string]interface{}`, but got `%T` instead", what, v.Data())
 	}
 	return data, nil
+}
+
+func makeKubeconfigError(what string) error {
+	kubeconfigEnv := os.Getenv("KUBECONFIG")
+	if kubeconfigEnv != "" {
+		paths := filepath.SplitList(kubeconfigEnv)
+		var missing []string
+		for _, p := range paths {
+			if _, err := os.Stat(p); os.IsNotExist(err) {
+				missing = append(missing, p)
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("expected %s to be of type `[]map[string]interface{}`, but got `<nil>` instead. The following files in your KUBECONFIG environment variable do not exist: %s", what, strings.Join(missing, ", "))
+		}
+		return fmt.Errorf("expected %s to be of type `[]map[string]interface{}`, but got `<nil>` instead. Your KUBECONFIG is set to '%s', but contains no %s", what, kubeconfigEnv, what)
+	}
+
+	// KUBECONFIG is unset, check default ~/.kube/config
+	home, err := os.UserHomeDir()
+	if err == nil {
+		defaultPath := filepath.Join(home, ".kube", "config")
+		if _, err := os.Stat(defaultPath); os.IsNotExist(err) {
+			return fmt.Errorf("expected %s to be of type `[]map[string]interface{}`, but got `<nil>` instead. KUBECONFIG is unset and the default kubeconfig file at %s does not exist", what, defaultPath)
+		}
+	}
+
+	return fmt.Errorf("expected %s to be of type `[]map[string]interface{}`, but got `<nil>` instead. KUBECONFIG is unset and default ~/.kube/config contains no %s", what, what)
 }
 
 // ErrorNoMatch occurs when no item matched had the expected value

--- a/pkg/kubernetes/client/context_test.go
+++ b/pkg/kubernetes/client/context_test.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/objx"
+)
+
+func TestTryMSISlice(t *testing.T) {
+	// Test when v is not nil and holds a valid slice
+	validVal := objx.New([]map[string]interface{}{{"name": "test"}})
+	res, err := tryMSISlice(validVal, "contexts")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 1 || res[0]["name"] != "test" {
+		t.Fatalf("unexpected result: %v", res)
+	}
+
+	// Test when v.Data() is nil (triggering makeKubeconfigError)
+	nilVal := objx.New(nil)
+
+	// Case 1: KUBECONFIG is set but file doesn't exist
+	t.Run("KUBECONFIG set with missing file", func(t *testing.T) {
+		tempFile := filepath.Join(t.TempDir(), "nonexistent-kubeconfig")
+		t.Setenv("KUBECONFIG", tempFile)
+
+		_, err := tryMSISlice(nilVal, "clusters")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		expectedMsg := "The following files in your KUBECONFIG environment variable do not exist"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("expected error message to contain '%s', got '%s'", expectedMsg, err.Error())
+		}
+	})
+
+	// Case 2: KUBECONFIG is unset and default config is missing
+	t.Run("KUBECONFIG unset, default config missing", func(t *testing.T) {
+		t.Setenv("KUBECONFIG", "")
+		// Temporarily change user home to a tmp dir where .kube/config doesn't exist
+		tempHome := t.TempDir()
+
+		// Setenv HOME to redirect os.UserHomeDir on Unix systems
+		t.Setenv("HOME", tempHome)
+
+		_, err := tryMSISlice(nilVal, "clusters")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		expectedMsg := "KUBECONFIG is unset and the default kubeconfig file at"
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("expected error to contain '%s', got '%s'", expectedMsg, err.Error())
+		}
+	})
+}


### PR DESCRIPTION
### Problem                                                                                    
    Forgetting to set the `$KUBECONFIG` environment variable (or having an empty/missing default   
  `~/.kube/config`) triggers a cryptic internal JSON mapping error:                                
    `connecting to Kubernetes: finding usable context: expected clusters to be of type             
  []map[string]interface{}, but got <nil> instead`                                                 
                                                                                                   
    This is a common source of confusion for newcomers and developers setting up their environment.
                                                                                                   
    Fixes #500                                                                                     
                                                                                                   
    ### Solution                                                                                   
    - Intercept cases in `tryMSISlice` where the decoded slices are `nil`.                         
    - Added a helper `makeKubeconfigError()` to output a descriptive error identifying:            
      - The specific list of files in `$KUBECONFIG` that do not exist (if set).                    
      - The missing default `~/.kube/config` (if `$KUBECONFIG` is unset).                          
    - Created a new test file `pkg/kubernetes/client/context_test.go` to cover the new logic. 