### PR TITLE
fix(deps): bump Go build image to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN export OS=$(go env GOOS) &&\
     curl -SL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz" > kustomize.tgz && \
     tar -xvf kustomize.tgz
 
-FROM golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b AS build
+FROM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS build
 WORKDIR /app
 COPY . .
 RUN make static


### PR DESCRIPTION
## Summary
Bump the Go build stage from `golang:1.26.3` to `golang:1.26.4` (version tag, not digest-only).

Supersedes #2048 which is stuck on Renovate's `stability-days` check — digest-only updates never get a `releaseTimestamp`, so the check never passes ([context](https://raintank-corp.slack.com/archives/C098XGH30CB/p1782482000789569)).

Go 1.26.4 (released 2026-06-02) includes security fixes for `crypto/x509`, `mime`, and `net/textproto`.