### PR TITLE
ci: update publish-page workflow to publish as artifact

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -1,4 +1,3 @@
-# .github/workflows/preview.yml
 name: Deploy Github Pages
 
 on:
@@ -18,18 +17,19 @@ on:
       - "docs/**"
       - ".github/workflows/publish-page.yml"
 
-concurrency: ci-${{ github.ref }}
+concurrency: 
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  publish:
+  build-pages:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     # Do not run this on forks:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'grafana/tanka'
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -40,6 +40,7 @@ jobs:
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.8.0
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
@@ -48,10 +49,6 @@ jobs:
 
       - name: Install and Build
         working-directory: docs
-        env:
-          # Main: https://tanka.dev/
-          # PRs: https://tanka.dev/pr-preview/pr-{number}/
-          PATH_PREFIX: "${{ github.event_name == 'pull_request' && format('/pr-preview/pr-{0}/', github.event.number) || '' }}"
         run: |
           pnpm install
           pnpm build
@@ -62,16 +59,25 @@ jobs:
             touch ./dist/.nojekyll
           fi
 
-      - name: Deploy main
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          clean-exclude: pr-preview/
-          folder: ./docs/dist/
+          path: ./docs/dist/
 
-      - name: Deploy preview
-        if: github.event_name == 'pull_request'
-        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
-        with:
-          deploy-repository: ${{ github.event.pull_request.head.repo.full_name }}
-          source-dir: ./docs/dist/
+  publish-pages:
+    needs:
+      - build-pages
+    permissions:
+      id-token: write
+      pages: write
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+


### PR DESCRIPTION
This is necessary since we want to enforce signed commits which is not feasible with the branch-based workflow.