### PR TITLE
ci: signed-commits-info workflow

### DIFF
--- a/.github/workflows/signed-commits-info.yml
+++ b/.github/workflows/signed-commits-info.yml
@@ -1,0 +1,18 @@
+name: Signed commits
+
+on:
+  pull_request:
+  pull_request_target:
+
+jobs:
+  signed-commits:
+    permissions:
+      contents: read
+      pull-requests: write
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grafana/shared-workflows/actions/signed-commits-info@f7e20b4de846c5951fba99c43c0340e8d2147468 # signed-commits-info/v0.1.0
+        continue-on-error: true


### PR DESCRIPTION
This workflow should show users details about their commits if they include unsigned commits. This is especially relevant for PRs coming from forks.