### PR TITLE
ci: signed-commits-info workflow

### DIFF
--- a/.github/workflows/signed-commits-info.yml
+++ b/.github/workflows/signed-commits-info.yml
@@ -1,0 +1,18 @@
+name: Signed commits
+
+on:
+  pull_request:
+  pull_request_target:
+
+jobs:
+  signed-commits:
+    permissions:
+      contents: read
+      pull-requests: write
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grafana/shared-workflows/actions/signed-commits-info@f7e20b4de846c5951fba99c43c0340e8d2147468 # signed-commits-info/v0.1.0
+        continue-on-error: true

--- a/.github/workflows/signed-commits-info.yml
+++ b/.github/workflows/signed-commits-info.yml
@@ -2,6 +2,8 @@ name: Signed commits
 
 on:
   pull_request:
+
+  # zizmor: ignore[dangerous-triggers] The underlying action does not interact in any way with the source code of the fork. It requires the scope of the original repository in order to post a comment to the pull request itself.
   pull_request_target:
 
 jobs:


### PR DESCRIPTION
This workflow should show users details about their commits if they include unsigned commits. This is especially relevant for PRs coming from forks.

The underlying action does not interact with the source branch in any way. All it does it call the GitHub API to check the status of every included commit. `pull_request_target` is needed since the primary use-case there involves PRs originating from forks and we need a way to post a comment to the pull request.