### PR TITLE
ci: sign and attest published Docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'github>grafana/grafana-renovate-config//presets/base',
+    'github>grafana/grafana-renovate-config//presets/github-actions',
   ],
   customDatasources: {
     kubectl: {

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,7 +170,7 @@ jobs:
       id-token: write
       attestations: write
     # No `secrets: inherit` needed: auth is pure OIDC/WIF.
-    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@78d2e75bb333ed062cbe2a40fcf79c920cce440f # main
+    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@24c4b83e50e74fce9871480681d123fd3c68f4f4 # main
     with:
       image: ${{ needs.merge.outputs.image }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -141,9 +141,9 @@ jobs:
           registry: us-docker.pkg.dev
 
       - name: Install crane
-        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
-        with:
-          version: v0.21.7
+        run: |
+          go install github.com/google/go-containerregistry/cmd/crane@v0.21.7
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Create manifest list and push
         id: index

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,6 +105,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      image: ${{ steps.digest.outputs.image }}
     needs:
       - build
     steps:
@@ -151,4 +153,29 @@ jobs:
           RELEASE_VERSION: "${{ steps.meta.outputs.version }}"
         run: |
           docker buildx imagetools inspect "${{ env.REGISTRY_IMAGE }}:${RELEASE_VERSION}"
+
+      - name: Resolve digest
+        id: digest
+        env:
+          RELEASE_VERSION: "${{ steps.meta.outputs.version }}"
+        run: |
+          DIGEST="$(docker buildx imagetools inspect "${REGISTRY_IMAGE}:${RELEASE_VERSION}" --format '{{.Manifest.Digest}}')"
+          if [[ "$DIGEST" != sha256:* ]]; then
+            echo "::error::failed to resolve digest for ${REGISTRY_IMAGE}:${RELEASE_VERSION}, got: $DIGEST"
+            exit 1
+          fi
+          echo "image=${REGISTRY_IMAGE}@${DIGEST}" >> "$GITHUB_OUTPUT"
+
+  sign:
+    needs: merge
+    # Mirrors merge's gate: only images that were actually pushed get signed.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    # No `secrets: inherit` needed: auth is pure OIDC/WIF.
+    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@78d2e75bb333ed062cbe2a40fcf79c920cce440f # main
+    with:
+      image: ${{ needs.merge.outputs.image }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,8 @@ on:
         required: true
 env:
   REGISTRY_IMAGE: us-docker.pkg.dev/grafanalabs-global/dockerhub-tanka-prod-mirror/tanka
+  # renovate: datasource=go depName=github.com/google/go-containerregistry
+  CRANE_VERSION: v0.21.7
   # Docker image tags. See https://github.com/docker/metadata-action for format
   TAGS_CONFIG: |
     type=sha,prefix={{branch}}-,format=short,enable=${{ github.ref == 'refs/heads/main' }}
@@ -142,7 +144,7 @@ jobs:
 
       - name: Install crane
         run: |
-          go install github.com/google/go-containerregistry/cmd/crane@v0.21.7
+          go install "github.com/google/go-containerregistry/cmd/crane@${CRANE_VERSION}"
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Create manifest list and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,7 +106,7 @@ jobs:
       contents: read
       id-token: write
     outputs:
-      image: ${{ steps.digest.outputs.image }}
+      image: ${{ steps.index.outputs.image }}
     needs:
       - build
     steps:
@@ -128,9 +128,6 @@ jobs:
           cp /tmp/digests-linux-amd64/* /tmp/digests/
           cp /tmp/digests-linux-arm64/* /tmp/digests/
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -143,28 +140,26 @@ jobs:
         with:
           registry: us-docker.pkg.dev
 
+      - name: Install crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+        with:
+          version: v0.21.7
+
       - name: Create manifest list and push
+        id: index
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      - name: Inspect image
-        env:
-          RELEASE_VERSION: "${{ steps.meta.outputs.version }}"
-        run: |
-          docker buildx imagetools inspect "${{ env.REGISTRY_IMAGE }}:${RELEASE_VERSION}"
-
-      - name: Resolve digest
-        id: digest
-        env:
-          RELEASE_VERSION: "${{ steps.meta.outputs.version }}"
-        run: |
-          DIGEST="$(docker buildx imagetools inspect "${REGISTRY_IMAGE}:${RELEASE_VERSION}" --format '{{.Manifest.Digest}}')"
-          if [[ "$DIGEST" != sha256:* ]]; then
-            echo "::error::failed to resolve digest for ${REGISTRY_IMAGE}:${RELEASE_VERSION}, got: $DIGEST"
-            exit 1
-          fi
-          echo "image=${REGISTRY_IMAGE}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          mapfile -t TAGS < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          MANIFESTS=()
+          for d in *; do MANIFESTS+=(-m "${REGISTRY_IMAGE}@sha256:${d}"); done
+          # crane prints the pushed digest-pinned ref; extra tags then point at
+          # that exact digest, so nothing resolves back through a mutable tag.
+          IMAGE="$(crane index append -t "${TAGS[0]}" "${MANIFESTS[@]}")"
+          for t in "${TAGS[@]:1}"; do
+            crane tag "${IMAGE}" "${t##*:}"
+          done
+          crane manifest "${IMAGE}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
 
   sign:
     needs: merge

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+      attestations: write
     uses: ./.github/workflows/docker.yml
     with:
       tag: ${{ needs.release-please.outputs.release_tag }}


### PR DESCRIPTION
# What changed

Creates tanka's multi-arch manifest list with `crane index append`, rather than buildx, so that the image digest is returned directly. 

The multi-arch manifest digest is passed to grafana/shared-workflows' `sign-and-attest` workflow (grafana/shared-workflows#2144), which cosign-signs the image and attaches SLSA build provenance, and self-verifies both.

# Testing
Tested end to end from a test branch against a dev GAR repo mirrored to a test
Docker Hub account (grafana/deployment_tools#644849):

- Build, manifest creation, and signing all green ([run1](https://github.com/grafana/tanka/actions/runs/29327889528) [run2](https://github.com/grafana/tanka/actions/runs/29330541827)).
- Signature and provenance mirrored to Docker Hub; both documented verify commands pass against the mirrored copy.
- Manifest list structure matches a buildx-built prod image; `docker run` by digest works.

  ```bash
  cosign verify \
    --certificate-identity-regexp '^https://github\.com/grafana/shared-workflows/\.github/workflows/sign-and-attest\.yml@' \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    --certificate-github-workflow-repository grafana/tanka \
    docker.io/dwyliegrafana/tanka@sha256:0ca2d9699016c17b3d921fc17d9e32477cebf15c6c25141c9a2f611952474192

  gh attestation verify \
    oci://docker.io/dwyliegrafana/tanka@sha256:0ca2d9699016c17b3d921fc17d9e32477cebf15c6c25141c9a2f611952474192 \
    --repo grafana/tanka \
    --signer-workflow grafana/shared-workflows/.github/workflows/sign-and-attest.yml